### PR TITLE
feat(calendar): ICS calendar integration + Linux audio fixes

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -148,6 +148,11 @@ ffmpeg-sidecar = { git = "https://github.com/nathanbabcock/ffmpeg-sidecar", bran
 
 sqlx = { version = "0.8", features = [ "runtime-tokio", "sqlite", "chrono"] }
 
+# Calendar / ICS parsing
+ical = "0.11"
+rrule = "0.13"
+chrono-tz = "0.10"
+
 # Common Tauri configuration
 tauri = { version = "2.11.0", features = [ "devtools", "macos-private-api", "protocol-asset", "tray-icon"] }
 tauri-plugin-fs = "2.5.0"

--- a/frontend/src-tauri/migrations/20260506000000_add_calendar_sources_and_events.sql
+++ b/frontend/src-tauri/migrations/20260506000000_add_calendar_sources_and_events.sql
@@ -1,0 +1,49 @@
+-- Calendar sources: each row is one public ICS URL the user has registered.
+-- We support multiple sources (work + personal, etc) up front so we don't
+-- repaint the schema later if a second is added.
+CREATE TABLE IF NOT EXISTS calendar_sources (
+    id              TEXT PRIMARY KEY,
+    url             TEXT NOT NULL,
+    label           TEXT,
+    last_fetched_at TEXT,
+    last_error      TEXT,
+    created_at      TEXT NOT NULL,
+    updated_at      TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_sources_url
+    ON calendar_sources(url);
+
+-- Calendar events parsed from each source. Recurring events are expanded
+-- into one row per occurrence and identified by (source_id, ics_uid,
+-- recurrence_id) so re-fetches upsert cleanly.
+CREATE TABLE IF NOT EXISTS calendar_events (
+    id               TEXT PRIMARY KEY,
+    source_id        TEXT NOT NULL,
+    ics_uid          TEXT NOT NULL,
+    recurrence_id    TEXT,            -- NULL for non-recurring; ISO-8601 of occurrence start otherwise
+    summary          TEXT,
+    description      TEXT,
+    location         TEXT,
+    organizer_name   TEXT,
+    organizer_email  TEXT,
+    start_at         TEXT NOT NULL,   -- ISO-8601 UTC
+    end_at           TEXT NOT NULL,   -- ISO-8601 UTC
+    is_all_day       INTEGER NOT NULL DEFAULT 0,
+    attendees_json   TEXT NOT NULL DEFAULT '[]',
+    raw_ics          TEXT,
+    fetched_at       TEXT NOT NULL,
+    FOREIGN KEY (source_id) REFERENCES calendar_sources(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_events_source_uid_recur
+    ON calendar_events(source_id, ics_uid, COALESCE(recurrence_id, ''));
+
+CREATE INDEX IF NOT EXISTS idx_calendar_events_start
+    ON calendar_events(start_at);
+
+-- Link a meeting to the calendar event it was recorded for.
+ALTER TABLE meetings ADD COLUMN calendar_event_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_meetings_calendar_event
+    ON meetings(calendar_event_id);

--- a/frontend/src-tauri/src/audio/devices/configuration.rs
+++ b/frontend/src-tauri/src/audio/devices/configuration.rs
@@ -68,23 +68,32 @@ impl AudioDevice {
             return Err(anyhow!("Device name cannot be empty"));
         }
 
-        let (name, device_type) = if name.to_lowercase().ends_with("(input)") {
+        let lower = name.to_lowercase();
+        // Output devices on Linux are surfaced as
+        // `<description> (System Audio)` from `configure_linux_audio`,
+        // so accept that as an Output marker too. Keep the device name
+        // intact (suffix included) — capture-side resolution
+        // (`open_linux_system_audio_input`) trims it back to the
+        // description before doing the pactl lookup.
+        let (clean_name, device_type) = if lower.ends_with("(input)") {
             (
                 name.trim_end_matches("(input)").trim().to_string(),
                 DeviceType::Input,
             )
-        } else if name.to_lowercase().ends_with("(output)") {
+        } else if lower.ends_with("(output)") {
             (
                 name.trim_end_matches("(output)").trim().to_string(),
                 DeviceType::Output,
             )
+        } else if lower.ends_with("(system audio)") {
+            (name.to_string(), DeviceType::Output)
         } else {
             return Err(anyhow!(
                 "Device type (input/output) not specified in the name"
             ));
         };
 
-        Ok(AudioDevice::new(name, device_type))
+        Ok(AudioDevice::new(clean_name, device_type))
     }
 }
 
@@ -180,6 +189,77 @@ fn preferred_output_config(device: &cpal::Device) -> Result<cpal::SupportedStrea
         .map_err(|e| anyhow!("Failed to get default output config: {}", e))
 }
 
+/// Open the cpal default input *redirected* to a specific PulseAudio /
+/// PipeWire monitor source. The picker exposes monitor sources by their
+/// `pactl` description (e.g. "Monitor of Arctis Pro Wireless Game (System Audio)");
+/// here we translate that back to the source name (e.g.
+/// `alsa_output.usb-SteelSeries...stereo-game.monitor`) and set
+/// `PIPEWIRE_NODE` so `pipewire-alsa` binds the next opened PCM to that
+/// source. The env var is only read at `snd_pcm_open` time, so streams
+/// already running are unaffected and we restore the previous value
+/// once the open completes.
+#[cfg(target_os = "linux")]
+fn open_linux_system_audio_input(
+    device_name: &str,
+) -> Result<(cpal::Device, cpal::SupportedStreamConfig)> {
+    use cpal::traits::HostTrait;
+    use log::info;
+
+    // The picker labels are `<description> (System Audio)`; trim the
+    // suffix to get the raw description we matched on in pactl.
+    let description = device_name
+        .trim()
+        .trim_end_matches("(System Audio)")
+        .trim()
+        .to_string();
+
+    let source_name = match super::platform::resolve_source_name_by_description(&description) {
+        Ok(Some(n)) => n,
+        Ok(None) => {
+            return Err(anyhow!(
+                "No PulseAudio monitor source matches description '{}'. Refresh device list.",
+                description
+            ));
+        }
+        Err(e) => {
+            return Err(anyhow!(
+                "Failed to enumerate PulseAudio sources for '{}': {}",
+                description,
+                e
+            ));
+        }
+    };
+
+    info!(
+        "🔊 Linux system audio: redirecting cpal default input to PIPEWIRE_NODE={}",
+        source_name
+    );
+
+    let host = cpal::default_host();
+    let prev = std::env::var("PIPEWIRE_NODE").ok();
+    // SAFETY: this process is single-threaded with respect to env at
+    // this exact moment — `start_streams` opens streams sequentially.
+    // The env value is only consumed by snd_pcm_open under us, and we
+    // restore it before returning so subsequent opens (e.g. the level
+    // monitor) see the original setting.
+    std::env::set_var("PIPEWIRE_NODE", &source_name);
+
+    let opened = (|| -> Result<(cpal::Device, cpal::SupportedStreamConfig)> {
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| anyhow!("no default input device available for system-audio redirect"))?;
+        let config = preferred_input_config(&device)?;
+        Ok((device, config))
+    })();
+
+    match prev {
+        Some(v) => std::env::set_var("PIPEWIRE_NODE", v),
+        None => std::env::remove_var("PIPEWIRE_NODE"),
+    }
+
+    opened
+}
+
 /// Get device and config for audio operations
 pub async fn get_device_and_config(
     audio_device: &AudioDevice,
@@ -223,19 +303,7 @@ pub async fn get_device_and_config(
 
                 #[cfg(target_os = "linux")]
                 {
-                    // For Linux, we use PulseAudio monitor sources for system audio.
-                    // Monitor sources are *input* PCMs in ALSA terms, so the same
-                    // 48 kHz preference applies.
-                    if let Ok(pulse_host) = cpal::host_from_id(cpal::HostId::Alsa) {
-                        for device in pulse_host.input_devices()? {
-                            if let Ok(name) = device.name() {
-                                if name == audio_device.name {
-                                    let config = preferred_input_config(&device)?;
-                                    return Ok((device, config));
-                                }
-                            }
-                        }
-                    }
+                    return open_linux_system_audio_input(&audio_device.name);
                 }
             }
         }

--- a/frontend/src-tauri/src/audio/devices/platform/linux.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/linux.rs
@@ -64,7 +64,41 @@ pub fn configure_linux_audio(host: &cpal::Host) -> Result<Vec<AudioDevice>> {
     }
 
     // Monitor sources = system-audio capture (meeting participants).
-    if let Ok(alsa_host) = cpal::host_from_id(cpal::HostId::Alsa) {
+    //
+    // On modern Fedora / Arch / Ubuntu the host is PipeWire (with the
+    // `pipewire-alsa` shim). cpal's ALSA backend only sees ALSA PCMs
+    // (`arecord -L`), and per-sink `*.monitor` sources are PulseAudio
+    // / PipeWire concepts that don't appear in that list — so the
+    // previous `name.contains("monitor")` filter on
+    // `alsa_host.input_devices()` returned nothing on every modern
+    // Linux setup. We now ask `pactl` directly, which is the
+    // authoritative source. The capture path
+    // (`get_device_and_config` for `DeviceType::Output`) translates
+    // the user's pick back to a source name and redirects via
+    // `PIPEWIRE_NODE`.
+    let monitors_via_pactl = match super::pulseaudio::list_pulseaudio_monitors() {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("pactl monitor enumeration failed: {}", e);
+            Vec::new()
+        }
+    };
+    if !monitors_via_pactl.is_empty() {
+        for monitor in monitors_via_pactl {
+            // Use the human description as the device name so the
+            // picker shows "Monitor of Arctis Pro Wireless Game"
+            // rather than the raw alsa_output.usb-... source name.
+            // Resolution back to the source name happens at capture
+            // time.
+            devices.push(AudioDevice::new(
+                format!("{} (System Audio)", monitor.description),
+                DeviceType::Output,
+            ));
+        }
+    } else if let Ok(alsa_host) = cpal::host_from_id(cpal::HostId::Alsa) {
+        // Fallback for hosts where pactl isn't installed but cpal
+        // somehow surfaces monitor sources (rare, mostly legacy
+        // PulseAudio + alsa-plugins-pulseaudio setups).
         for device in alsa_host.input_devices()? {
             if let Ok(name) = device.name() {
                 if name.contains("monitor") && is_user_facing_linux_device(&name) {

--- a/frontend/src-tauri/src/audio/devices/platform/mod.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/mod.rs
@@ -9,6 +9,9 @@ pub mod macos;
 #[cfg(target_os = "linux")]
 pub mod linux;
 
+#[cfg(target_os = "linux")]
+pub mod pulseaudio;
+
 // Re-export platform-specific functions
 #[cfg(target_os = "windows")]
 pub use windows::{configure_windows_audio, get_windows_device};
@@ -18,3 +21,8 @@ pub use macos::configure_macos_audio;
 
 #[cfg(target_os = "linux")]
 pub use linux::{configure_linux_audio, is_user_facing_linux_device};
+
+#[cfg(target_os = "linux")]
+pub use pulseaudio::{
+    list_pulseaudio_monitors, resolve_source_name_by_description, MonitorSource,
+};

--- a/frontend/src-tauri/src/audio/devices/platform/pulseaudio.rs
+++ b/frontend/src-tauri/src/audio/devices/platform/pulseaudio.rs
@@ -1,0 +1,148 @@
+//! Linux-only helpers for enumerating PulseAudio / PipeWire monitor sources
+//! and resolving a user-facing description back to its source name.
+//!
+//! Why this exists: cpal's ALSA backend only sees ALSA PCMs (`arecord -L`),
+//! which on a PipeWire / PulseAudio system does *not* include the
+//! per-sink `*.monitor` sources used to record what's coming out of
+//! speakers. The previous Linux device enumerator filtered cpal's ALSA
+//! input list for `name.contains("monitor")` and consequently found
+//! nothing on every modern Fedora / Arch / Ubuntu install. Shelling out
+//! to `pactl` (always available where PipeWire / PulseAudio is) gives us
+//! the authoritative list.
+//!
+//! The corresponding capture redirect lives in
+//! `audio::devices::configuration::get_device_and_config` and uses the
+//! `PIPEWIRE_NODE` environment variable, which `pipewire-alsa` reads at
+//! `snd_pcm_open` time to bind the default PCM to a specific source.
+
+use std::process::Command;
+
+use anyhow::{anyhow, Result};
+
+#[derive(Debug, Clone)]
+pub struct MonitorSource {
+    /// Internal PA name (e.g.
+    /// `alsa_output.usb-RODE_..._NT-USB-00.pro-output-0.monitor`). Used
+    /// as `PIPEWIRE_NODE` at capture time.
+    pub name: String,
+    /// User-facing description from `pactl` (e.g.
+    /// "Monitor of RODE NT-USB Pro"). Used in the device picker.
+    pub description: String,
+}
+
+/// Run `pactl list sources` and parse out monitor entries. Returns an
+/// empty Vec — not Err — when `pactl` isn't on PATH so the caller can
+/// fall back to the cpal-based enumeration without polluting logs.
+pub fn list_pulseaudio_monitors() -> Result<Vec<MonitorSource>> {
+    let output = match Command::new("pactl").arg("list").arg("sources").output() {
+        Ok(o) => o,
+        Err(e) => {
+            log::debug!(
+                "pactl not available ({}); skipping PulseAudio monitor enumeration",
+                e
+            );
+            return Ok(Vec::new());
+        }
+    };
+    if !output.status.success() {
+        return Err(anyhow!(
+            "pactl exited with status {}",
+            output.status
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_pactl_sources(&stdout))
+}
+
+/// Find the PA source name whose `Description` matches `description`.
+/// Used to translate the user-picked label (which we expose as the
+/// device name) back to the actual source name we set as
+/// `PIPEWIRE_NODE`. Description match is exact and case-insensitive
+/// trimmed; PA descriptions are stable enough that this is safe.
+pub fn resolve_source_name_by_description(description: &str) -> Result<Option<String>> {
+    let monitors = list_pulseaudio_monitors()?;
+    let needle = description.trim().to_lowercase();
+    Ok(monitors
+        .into_iter()
+        .find(|m| m.description.trim().to_lowercase() == needle)
+        .map(|m| m.name))
+}
+
+fn parse_pactl_sources(stdout: &str) -> Vec<MonitorSource> {
+    let mut out = Vec::new();
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut device_class: Option<String> = None;
+
+    let flush = |out: &mut Vec<MonitorSource>,
+                 name: &mut Option<String>,
+                 description: &mut Option<String>,
+                 device_class: &mut Option<String>| {
+        if let (Some(n), Some(d)) = (name.take(), description.take()) {
+            let class_is_monitor = device_class
+                .take()
+                .map(|c| c.eq_ignore_ascii_case("monitor"))
+                .unwrap_or(false);
+            if class_is_monitor || n.ends_with(".monitor") {
+                out.push(MonitorSource {
+                    name: n,
+                    description: d,
+                });
+            }
+        } else {
+            *device_class = None;
+        }
+    };
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if line.starts_with("Source #") {
+            flush(&mut out, &mut name, &mut description, &mut device_class);
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Name: ") {
+            name = Some(rest.to_string());
+        } else if let Some(rest) = trimmed.strip_prefix("Description: ") {
+            description = Some(rest.to_string());
+        } else if let Some(rest) = trimmed.strip_prefix("device.class = ") {
+            device_class = Some(rest.trim_matches('"').to_string());
+        }
+    }
+    // Final block (no trailing "Source #" header).
+    flush(&mut out, &mut name, &mut description, &mut device_class);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = "Source #9301\n\
+\tName: alsa_output.usb-RODE_Microphones_RODE_NT-USB-00.pro-output-0.monitor\n\
+\tDescription: Monitor of RODE NT-USB Pro\n\
+\tProperties:\n\
+\t\tdevice.class = \"monitor\"\n\
+Source #9302\n\
+\tName: alsa_input.usb-RODE_Microphones_RODE_NT-USB-00.pro-input-0\n\
+\tDescription: RODE NT-USB Pro\n\
+\tProperties:\n\
+\t\tdevice.class = \"sound\"\n\
+Source #13141\n\
+\tName: alsa_output.usb-SteelSeries_Arctis_Pro_Wireless-00.stereo-game.monitor\n\
+\tDescription: Monitor of Arctis Pro Wireless Game\n\
+\tProperties:\n\
+\t\tdevice.class = \"monitor\"\n\
+";
+
+    #[test]
+    fn parses_only_monitor_sources() {
+        let monitors = parse_pactl_sources(FIXTURE);
+        assert_eq!(monitors.len(), 2);
+        assert_eq!(monitors[0].description, "Monitor of RODE NT-USB Pro");
+        assert!(monitors[0].name.ends_with(".monitor"));
+        assert_eq!(
+            monitors[1].description,
+            "Monitor of Arctis Pro Wireless Game"
+        );
+    }
+}

--- a/frontend/src-tauri/src/audio/simple_level_monitor.rs
+++ b/frontend/src-tauri/src/audio/simple_level_monitor.rs
@@ -1,16 +1,42 @@
-use anyhow::Result;
-use log::{error, info};
+//! Real-time RMS/peak meter for the recording-page hero.
+//!
+//! Earlier this module was a stub that emitted a sine-wave so the UI
+//! had something to draw. That hid two bugs: the meter never told the
+//! user whether their actual mic / system-audio source was alive, and
+//! the event name didn't match what the frontend hook was listening
+//! for. This implementation opens real cpal input streams for each
+//! requested device, computes RMS + peak per buffer, and emits via
+//! `audio-levels` (the same event name the legacy
+//! `level_monitor.rs` uses, kept for compatibility with
+//! `DeviceSelection.tsx`).
+//!
+//! System-audio entries are surfaced in the picker as
+//! `<description> (System Audio)` (see `audio::devices::platform::linux`).
+//! cpal can't see PulseAudio / PipeWire `*.monitor` sources directly,
+//! so for those entries we resolve the description back to a PA source
+//! name via `pactl` and redirect cpal's default-input PCM through the
+//! `PIPEWIRE_NODE` env var. Same trick as the recording path; see
+//! `audio::devices::configuration::open_linux_system_audio_input`.
+
+use anyhow::{anyhow, Context, Result};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{SampleFormat, StreamConfig};
+use log::{debug, error, info, warn};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use tauri::{AppHandle, Emitter, Runtime};
+
+use super::audio_processing::audio_to_mono;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct AudioLevelData {
     pub device_name: String,
     pub device_type: String, // "input" or "output"
-    pub rms_level: f32,      // RMS level (0.0 to 1.0)
-    pub peak_level: f32,     // Peak level (0.0 to 1.0)
-    pub is_active: bool,     // Whether audio is being detected
+    pub rms_level: f32,
+    pub peak_level: f32,
+    pub is_active: bool,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -19,78 +45,301 @@ pub struct AudioLevelUpdate {
     pub levels: Vec<AudioLevelData>,
 }
 
-// Simple global monitoring state
 static IS_MONITORING: AtomicBool = AtomicBool::new(false);
 
-/// Start audio level monitoring for specified devices
+/// Newtype that lets us park `cpal::Stream` instances in a `static`
+/// without the compiler reasoning about cpal's auto-trait derivations.
+/// Streams only get touched on creation (the thread that calls
+/// `start_monitoring`) and on drop (the thread that calls
+/// `stop_monitoring`); cpal callbacks themselves run on cpal's
+/// internal threads and don't read this Vec. The unsafe `Send + Sync`
+/// claim covers exactly that access pattern — never share a single
+/// stream across threads through this container.
+// Field is read-implicitly via Drop (which stops every stream) — the
+// dead-code lint can't see that.
+#[allow(dead_code)]
+struct StreamHolder(Vec<cpal::Stream>);
+unsafe impl Send for StreamHolder {}
+unsafe impl Sync for StreamHolder {}
+
+static ACTIVE_STREAMS: OnceLock<Mutex<Option<StreamHolder>>> = OnceLock::new();
+
+fn streams_slot() -> &'static Mutex<Option<StreamHolder>> {
+    ACTIVE_STREAMS.get_or_init(|| Mutex::new(None))
+}
+
+/// Begin emitting `audio-levels` events for the requested device names.
+/// Call again with a different list to switch — this drops the prior
+/// streams and replaces them.
 pub async fn start_monitoring<R: Runtime>(
     app_handle: AppHandle<R>,
     device_names: Vec<String>,
 ) -> Result<()> {
-    info!(
-        "Starting simplified audio level monitoring for devices: {:?}",
-        device_names
-    );
+    info!("level monitor: start for {:?}", device_names);
 
-    // Stop any existing monitoring
-    IS_MONITORING.store(false, Ordering::SeqCst);
-
-    // Wait a bit for any existing tasks to stop
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
-    // Start new monitoring
+    // Drop any previous streams + emit task before opening new ones.
+    stop_monitoring().await?;
+    // Tiny breather so the prior emit task notices the flag flip and
+    // exits before we set it back to true.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     IS_MONITORING.store(true, Ordering::SeqCst);
 
-    // For now, create fake level data to test the UI
-    let app_handle_clone = app_handle.clone();
+    let level_data: Arc<Mutex<HashMap<String, AudioLevelData>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
+    let mut streams = Vec::new();
+    for name in &device_names {
+        match build_level_stream(name, level_data.clone()) {
+            Ok(stream) => {
+                debug!("level monitor: opened stream for '{}'", name);
+                streams.push(stream);
+            }
+            Err(e) => {
+                warn!("level monitor: could not open '{}': {}", name, e);
+            }
+        }
+    }
+
+    if streams.is_empty() {
+        warn!("level monitor: no streams opened; UI will receive no events");
+    }
+
+    if let Ok(mut guard) = streams_slot().lock() {
+        *guard = Some(StreamHolder(streams));
+    }
+
+    let app = app_handle.clone();
     tokio::spawn(async move {
-        let mut counter: f32 = 0.0;
-
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
         while IS_MONITORING.load(Ordering::SeqCst) {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            interval.tick().await;
 
-            counter += 0.1;
-            let fake_level = (counter.sin().abs() * 0.8) as f32; // Simulate varying levels
-
-            let levels: Vec<AudioLevelData> = device_names
-                .iter()
-                .map(|name| AudioLevelData {
-                    device_name: name.clone(),
-                    device_type: "input".to_string(),
-                    rms_level: fake_level,
-                    peak_level: fake_level * 1.2,
-                    is_active: fake_level > 0.1,
-                })
-                .collect();
+            let snapshot: Vec<AudioLevelData> = match level_data.lock() {
+                Ok(guard) => guard.values().cloned().collect(),
+                Err(_) => continue,
+            };
+            if snapshot.is_empty() {
+                continue;
+            }
 
             let update = AudioLevelUpdate {
                 timestamp: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis() as u64,
-                levels,
+                levels: snapshot,
             };
 
-            if let Err(e) = app_handle_clone.emit("audio-levels", &update) {
-                error!("Failed to emit audio levels: {}", e);
+            if let Err(e) = app.emit("audio-levels", &update) {
+                error!("level monitor: emit failed: {}", e);
                 break;
             }
         }
-
-        info!("Audio level monitoring task ended");
+        debug!("level monitor: emit task exiting");
     });
 
     Ok(())
 }
 
-/// Stop audio level monitoring
 pub async fn stop_monitoring() -> Result<()> {
-    info!("Stopping simplified audio level monitoring");
     IS_MONITORING.store(false, Ordering::SeqCst);
+    if let Ok(mut guard) = streams_slot().lock() {
+        // Dropping each cpal::Stream stops it.
+        guard.take();
+    }
     Ok(())
 }
 
-/// Check if currently monitoring
 pub fn is_monitoring() -> bool {
     IS_MONITORING.load(Ordering::SeqCst)
+}
+
+fn build_level_stream(
+    device_name: &str,
+    level_data: Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) -> Result<cpal::Stream> {
+    if device_name
+        .to_lowercase()
+        .ends_with("(system audio)")
+    {
+        return build_system_audio_stream(device_name, level_data);
+    }
+    build_input_stream(device_name, level_data)
+}
+
+fn build_input_stream(
+    device_name: &str,
+    level_data: Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) -> Result<cpal::Stream> {
+    let host = cpal::default_host();
+
+    // "default" is the magic name the picker uses for "system default
+    // input" — there's both a real cpal entry called "default" *and* the
+    // `default_input_device()` API. Either is fine; iterate first since
+    // it gives us a name match path that works for any device.
+    let mut device: Option<cpal::Device> = None;
+    if let Ok(inputs) = host.input_devices() {
+        for d in inputs {
+            if d.name().map(|n| n == device_name).unwrap_or(false) {
+                device = Some(d);
+                break;
+            }
+        }
+    }
+
+    let device = match device {
+        Some(d) => d,
+        None if device_name == "default" => host
+            .default_input_device()
+            .ok_or_else(|| anyhow!("no default input device available"))?,
+        None => return Err(anyhow!("input device not found in cpal: {}", device_name)),
+    };
+
+    let config = device
+        .default_input_config()
+        .with_context(|| format!("default_input_config({})", device_name))?;
+    open_input_stream(&device, config, device_name, "input", level_data)
+}
+
+#[cfg(target_os = "linux")]
+fn build_system_audio_stream(
+    device_name: &str,
+    level_data: Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) -> Result<cpal::Stream> {
+    use crate::audio::devices::platform::resolve_source_name_by_description;
+
+    let description = device_name
+        .trim()
+        .trim_end_matches("(System Audio)")
+        .trim()
+        .to_string();
+    let source_name = resolve_source_name_by_description(&description)?
+        .ok_or_else(|| anyhow!("no PulseAudio source matches '{}'", description))?;
+
+    let prev = std::env::var("PIPEWIRE_NODE").ok();
+    std::env::set_var("PIPEWIRE_NODE", &source_name);
+
+    let result = (|| -> Result<cpal::Stream> {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| anyhow!("no default input device for system-audio meter"))?;
+        let config = device.default_input_config()?;
+        open_input_stream(&device, config, device_name, "output", level_data)
+    })();
+
+    match prev {
+        Some(v) => std::env::set_var("PIPEWIRE_NODE", v),
+        None => std::env::remove_var("PIPEWIRE_NODE"),
+    }
+    result
+}
+
+#[cfg(not(target_os = "linux"))]
+fn build_system_audio_stream(
+    _device_name: &str,
+    _level_data: Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) -> Result<cpal::Stream> {
+    Err(anyhow!(
+        "system-audio level monitoring not implemented for this platform yet"
+    ))
+}
+
+fn open_input_stream(
+    device: &cpal::Device,
+    config: cpal::SupportedStreamConfig,
+    label: &str,
+    device_type: &str,
+    level_data: Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) -> Result<cpal::Stream> {
+    let channels = config.channels();
+    let sample_format = config.sample_format();
+    let stream_config: StreamConfig = config.into();
+    let label = label.to_string();
+    let device_type = device_type.to_string();
+
+    let stream = match sample_format {
+        SampleFormat::F32 => {
+            let label = label.clone();
+            let device_type = device_type.clone();
+            let level_data = level_data.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    push_levels(data, channels, &label, &device_type, &level_data);
+                },
+                move |e| error!("level monitor stream error: {}", e),
+                None,
+            )?
+        }
+        SampleFormat::I16 => {
+            let label = label.clone();
+            let device_type = device_type.clone();
+            let level_data = level_data.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                    let f: Vec<f32> = data
+                        .iter()
+                        .map(|&s| s as f32 / i16::MAX as f32)
+                        .collect();
+                    push_levels(&f, channels, &label, &device_type, &level_data);
+                },
+                move |e| error!("level monitor stream error: {}", e),
+                None,
+            )?
+        }
+        SampleFormat::I32 => {
+            let label = label.clone();
+            let device_type = device_type.clone();
+            let level_data = level_data.clone();
+            device.build_input_stream(
+                &stream_config,
+                move |data: &[i32], _: &cpal::InputCallbackInfo| {
+                    let f: Vec<f32> = data
+                        .iter()
+                        .map(|&s| s as f32 / i32::MAX as f32)
+                        .collect();
+                    push_levels(&f, channels, &label, &device_type, &level_data);
+                },
+                move |e| error!("level monitor stream error: {}", e),
+                None,
+            )?
+        }
+        f => return Err(anyhow!("unsupported sample format: {:?}", f)),
+    };
+
+    stream.play()?;
+    Ok(stream)
+}
+
+fn push_levels(
+    data: &[f32],
+    channels: u16,
+    label: &str,
+    device_type: &str,
+    level_data: &Arc<Mutex<HashMap<String, AudioLevelData>>>,
+) {
+    if data.is_empty() {
+        return;
+    }
+    let mono = if channels > 1 {
+        audio_to_mono(data, channels)
+    } else {
+        data.to_vec()
+    };
+
+    let rms = (mono.iter().map(|&x| x * x).sum::<f32>() / mono.len() as f32).sqrt();
+    let peak = mono.iter().map(|&x| x.abs()).fold(0.0_f32, f32::max);
+    let entry = AudioLevelData {
+        device_name: label.to_string(),
+        device_type: device_type.to_string(),
+        rms_level: rms.min(1.0),
+        peak_level: peak.min(1.0),
+        is_active: rms > 0.001,
+    };
+
+    if let Ok(mut map) = level_data.lock() {
+        map.insert(label.to_string(), entry);
+    }
 }

--- a/frontend/src-tauri/src/calendar/commands.rs
+++ b/frontend/src-tauri/src/calendar/commands.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Runtime};
@@ -5,6 +7,9 @@ use tauri::{AppHandle, Runtime};
 use super::fetcher;
 use super::models::{CalendarEvent, CalendarSourceRow};
 use super::repository::CalendarRepository;
+use super::snapshot::{
+    self, lookup_meeting_folder, CalendarEventSnapshot, SNAPSHOT_FILENAME,
+};
 use crate::state::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -228,13 +233,70 @@ pub async fn calendar_link_meeting<R: Runtime>(
     meeting_id: String,
     event_id: Option<String>,
 ) -> Result<bool, String> {
-    CalendarRepository::link_meeting(
-        state.db_manager.pool(),
-        &meeting_id,
-        event_id.as_deref(),
-    )
-    .await
-    .map_err(err)
+    let pool = state.db_manager.pool();
+
+    let updated = CalendarRepository::link_meeting(pool, &meeting_id, event_id.as_deref())
+        .await
+        .map_err(err)?;
+
+    if !updated {
+        return Ok(false);
+    }
+
+    // Best-effort sidecar write so a portable copy of the event details
+    // travels with the recording folder (alongside metadata.json /
+    // transcripts.json). Failure here doesn't roll back the DB link —
+    // the link is still valid; the user just won't get the offline
+    // snapshot. We log so it's debuggable.
+    let folder = match lookup_meeting_folder(pool, &meeting_id).await {
+        Ok(Some(p)) => Some(PathBuf::from(p)),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!(
+                "calendar snapshot: meeting folder lookup failed for {}: {}",
+                meeting_id,
+                e
+            );
+            None
+        }
+    };
+
+    if let Some(folder) = folder {
+        if let Some(event_id_ref) = event_id.as_deref() {
+            match CalendarRepository::get_event(pool, event_id_ref).await {
+                Ok(Some(event)) => {
+                    let snapshot_data = CalendarEventSnapshot::from_event(&event);
+                    if let Err(e) = snapshot::write_snapshot(&folder, &snapshot_data) {
+                        log::warn!(
+                            "calendar snapshot: failed to write {} for meeting {}: {}",
+                            SNAPSHOT_FILENAME,
+                            meeting_id,
+                            e
+                        );
+                    }
+                }
+                Ok(None) => log::warn!(
+                    "calendar snapshot: event {} not found when writing snapshot for meeting {}",
+                    event_id_ref,
+                    meeting_id
+                ),
+                Err(e) => log::warn!(
+                    "calendar snapshot: get_event {} failed: {}",
+                    event_id_ref,
+                    e
+                ),
+            }
+        } else if let Err(e) = snapshot::delete_snapshot(&folder) {
+            log::warn!(
+                "calendar snapshot: failed to delete {} for meeting {}: {}",
+                SNAPSHOT_FILENAME,
+                meeting_id,
+                e
+            );
+        }
+    }
+
+    Ok(true)
 }
 
 #[tauri::command]

--- a/frontend/src-tauri/src/calendar/commands.rs
+++ b/frontend/src-tauri/src/calendar/commands.rs
@@ -1,0 +1,255 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Runtime};
+
+use super::fetcher;
+use super::models::{CalendarEvent, CalendarSourceRow};
+use super::repository::CalendarRepository;
+use crate::state::AppState;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CalendarSource {
+    pub id: String,
+    pub url: String,
+    pub label: Option<String>,
+    #[serde(rename = "lastFetchedAt")]
+    pub last_fetched_at: Option<String>,
+    #[serde(rename = "lastError")]
+    pub last_error: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+impl From<CalendarSourceRow> for CalendarSource {
+    fn from(r: CalendarSourceRow) -> Self {
+        Self {
+            id: r.id,
+            url: r.url,
+            label: r.label,
+            last_fetched_at: r.last_fetched_at,
+            last_error: r.last_error,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RefreshResult {
+    #[serde(rename = "sourceId")]
+    pub source_id: String,
+    #[serde(rename = "eventCount")]
+    pub event_count: usize,
+}
+
+fn err<E: std::fmt::Display>(e: E) -> String {
+    e.to_string()
+}
+
+#[tauri::command]
+pub async fn calendar_list_sources<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<CalendarSource>, String> {
+    let rows = CalendarRepository::list_sources(state.db_manager.pool())
+        .await
+        .map_err(err)?;
+    Ok(rows.into_iter().map(CalendarSource::from).collect())
+}
+
+#[tauri::command]
+pub async fn calendar_add_source<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    url: String,
+    label: Option<String>,
+) -> Result<CalendarSource, String> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err("Calendar URL cannot be empty".to_string());
+    }
+    if !(trimmed.starts_with("http://")
+        || trimmed.starts_with("https://")
+        || trimmed.starts_with("webcal://"))
+    {
+        return Err("Calendar URL must start with http(s):// or webcal://".to_string());
+    }
+    let normalized = if let Some(rest) = trimmed.strip_prefix("webcal://") {
+        format!("https://{}", rest)
+    } else {
+        trimmed.to_string()
+    };
+
+    let row = CalendarRepository::add_source(
+        state.db_manager.pool(),
+        &normalized,
+        label.as_deref().filter(|s| !s.trim().is_empty()),
+    )
+    .await
+    .map_err(err)?;
+    Ok(row.into())
+}
+
+#[tauri::command]
+pub async fn calendar_remove_source<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+) -> Result<bool, String> {
+    CalendarRepository::remove_source(state.db_manager.pool(), &source_id)
+        .await
+        .map_err(err)
+}
+
+#[tauri::command]
+pub async fn calendar_update_source_label<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+    label: Option<String>,
+) -> Result<bool, String> {
+    CalendarRepository::update_source_label(
+        state.db_manager.pool(),
+        &source_id,
+        label.as_deref().filter(|s| !s.trim().is_empty()),
+    )
+    .await
+    .map_err(err)
+}
+
+#[tauri::command]
+pub async fn calendar_refresh_source<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    source_id: String,
+) -> Result<RefreshResult, String> {
+    let pool = state.db_manager.pool();
+    let source = CalendarRepository::get_source(pool, &source_id)
+        .await
+        .map_err(err)?
+        .ok_or_else(|| format!("Calendar source {} not found", source_id))?;
+
+    match fetcher::fetch_and_expand(&source.url).await {
+        Ok(occurrences) => {
+            let count = CalendarRepository::replace_events(pool, &source_id, &occurrences)
+                .await
+                .map_err(err)?;
+            CalendarRepository::mark_source_fetched(pool, &source_id, None)
+                .await
+                .map_err(err)?;
+            Ok(RefreshResult {
+                source_id,
+                event_count: count,
+            })
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            CalendarRepository::mark_source_fetched(pool, &source_id, Some(&msg))
+                .await
+                .map_err(err)?;
+            Err(msg)
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn calendar_refresh_all<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<RefreshResult>, String> {
+    let pool = state.db_manager.pool();
+    let sources = CalendarRepository::list_sources(pool).await.map_err(err)?;
+    let mut results = Vec::with_capacity(sources.len());
+    for s in sources {
+        match fetcher::fetch_and_expand(&s.url).await {
+            Ok(occurrences) => match CalendarRepository::replace_events(pool, &s.id, &occurrences)
+                .await
+            {
+                Ok(count) => {
+                    let _ =
+                        CalendarRepository::mark_source_fetched(pool, &s.id, None).await;
+                    results.push(RefreshResult {
+                        source_id: s.id,
+                        event_count: count,
+                    });
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    log::warn!("calendar source {} replace failed: {}", s.id, msg);
+                    let _ =
+                        CalendarRepository::mark_source_fetched(pool, &s.id, Some(&msg)).await;
+                }
+            },
+            Err(e) => {
+                let msg = e.to_string();
+                log::warn!("calendar source {} fetch failed: {}", s.id, msg);
+                let _ = CalendarRepository::mark_source_fetched(pool, &s.id, Some(&msg)).await;
+            }
+        }
+    }
+    Ok(results)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventRangeRequest {
+    pub from: String,
+    pub to: String,
+}
+
+#[tauri::command]
+pub async fn calendar_list_events<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    request: EventRangeRequest,
+) -> Result<Vec<CalendarEvent>, String> {
+    let from = parse_rfc3339(&request.from, "from")?;
+    let to = parse_rfc3339(&request.to, "to")?;
+    CalendarRepository::list_events_in_range(state.db_manager.pool(), from, to)
+        .await
+        .map_err(err)
+}
+
+#[tauri::command]
+pub async fn calendar_find_event_for_now<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<CalendarEvent>, String> {
+    CalendarRepository::find_event_for_now(state.db_manager.pool())
+        .await
+        .map_err(err)
+}
+
+#[tauri::command]
+pub async fn calendar_link_meeting<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    meeting_id: String,
+    event_id: Option<String>,
+) -> Result<bool, String> {
+    CalendarRepository::link_meeting(
+        state.db_manager.pool(),
+        &meeting_id,
+        event_id.as_deref(),
+    )
+    .await
+    .map_err(err)
+}
+
+#[tauri::command]
+pub async fn calendar_get_event_for_meeting<R: Runtime>(
+    _app: AppHandle<R>,
+    state: tauri::State<'_, AppState>,
+    meeting_id: String,
+) -> Result<Option<CalendarEvent>, String> {
+    CalendarRepository::get_event_for_meeting(state.db_manager.pool(), &meeting_id)
+        .await
+        .map_err(err)
+}
+
+fn parse_rfc3339(s: &str, label: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("invalid {} timestamp '{}': {}", label, s, e))
+}

--- a/frontend/src-tauri/src/calendar/fetcher.rs
+++ b/frontend/src-tauri/src/calendar/fetcher.rs
@@ -1,0 +1,83 @@
+use std::time::Duration as StdDuration;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+
+use super::models::ParsedEvent;
+use super::parser;
+
+/// How far back / forward to materialise occurrences of recurring events
+/// when a source is refreshed. The +90d horizon covers typical meeting
+/// scheduling; the -7d window keeps recently-recorded meetings linkable.
+const WINDOW_BACK_DAYS: i64 = 7;
+const WINDOW_FORWARD_DAYS: i64 = 90;
+const MAX_OCCURRENCES_PER_RULE: u16 = 200;
+
+/// One materialised event ready for upsert.
+#[derive(Debug, Clone)]
+pub struct OccurrenceForUpsert {
+    pub master: ParsedEvent,
+    pub start_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+    pub recurrence_id: Option<DateTime<Utc>>,
+}
+
+/// Fetch + parse + expand a single ICS URL. Returns a list of
+/// occurrences within the active window, plus override events
+/// (those carrying RECURRENCE-ID) so the caller can store both and
+/// let the unique constraint resolve override-vs-generated conflicts.
+pub async fn fetch_and_expand(url: &str) -> Result<Vec<OccurrenceForUpsert>> {
+    let client = reqwest::Client::builder()
+        .timeout(StdDuration::from_secs(30))
+        .user_agent("Meetily/0.4 (+https://github.com/Hankanman/Meetily-Local)")
+        .build()
+        .context("building reqwest client")?;
+
+    let resp = client.get(url).send().await.context("fetching ICS URL")?;
+    if !resp.status().is_success() {
+        return Err(anyhow!(
+            "ICS endpoint returned {} ({})",
+            resp.status(),
+            url
+        ));
+    }
+    let body = resp.text().await.context("reading ICS body")?;
+    let masters = parser::parse_ics(&body)?;
+
+    let now = Utc::now();
+    let from = now - Duration::days(WINDOW_BACK_DAYS);
+    let to = now + Duration::days(WINDOW_FORWARD_DAYS);
+
+    // Split into master events (no RECURRENCE-ID) and overrides.
+    let (overrides, masters): (Vec<_>, Vec<_>) = masters
+        .into_iter()
+        .partition(|e| e.recurrence_id.is_some());
+
+    let mut out = Vec::new();
+    for master in masters {
+        let occurrences =
+            parser::expand_event_window(&master, from, to, MAX_OCCURRENCES_PER_RULE);
+        let duration = master.end_at - master.start_at;
+        let is_recurring = master.rrule_block.is_some();
+        for start in occurrences {
+            out.push(OccurrenceForUpsert {
+                master: master.clone(),
+                start_at: start,
+                end_at: start + duration,
+                recurrence_id: if is_recurring { Some(start) } else { None },
+            });
+        }
+    }
+    for ov in overrides {
+        // Override events keep their explicit RECURRENCE-ID so the unique
+        // index (source_id, ics_uid, recurrence_id) replaces the generated
+        // occurrence rather than creating a duplicate row.
+        out.push(OccurrenceForUpsert {
+            start_at: ov.start_at,
+            end_at: ov.end_at,
+            recurrence_id: ov.recurrence_id,
+            master: ov,
+        });
+    }
+    Ok(out)
+}

--- a/frontend/src-tauri/src/calendar/mod.rs
+++ b/frontend/src-tauri/src/calendar/mod.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod fetcher;
+pub mod models;
+pub mod parser;
+pub mod repository;

--- a/frontend/src-tauri/src/calendar/mod.rs
+++ b/frontend/src-tauri/src/calendar/mod.rs
@@ -3,3 +3,4 @@ pub mod fetcher;
 pub mod models;
 pub mod parser;
 pub mod repository;
+pub mod snapshot;

--- a/frontend/src-tauri/src/calendar/models.rs
+++ b/frontend/src-tauri/src/calendar/models.rs
@@ -1,0 +1,120 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct CalendarSourceRow {
+    pub id: String,
+    pub url: String,
+    pub label: Option<String>,
+    pub last_fetched_at: Option<String>,
+    pub last_error: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct CalendarEventRow {
+    pub id: String,
+    pub source_id: String,
+    pub ics_uid: String,
+    pub recurrence_id: Option<String>,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub organizer_name: Option<String>,
+    pub organizer_email: Option<String>,
+    pub start_at: String,
+    pub end_at: String,
+    pub is_all_day: i64,
+    pub attendees_json: String,
+    pub raw_ics: Option<String>,
+    pub fetched_at: String,
+}
+
+/// Parsed attendee entry stored as JSON in `calendar_events.attendees_json`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Attendee {
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub role: Option<String>,
+    pub status: Option<String>,
+    #[serde(rename = "isOrganizer", default)]
+    pub is_organizer: bool,
+}
+
+/// Frontend-facing event shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    #[serde(rename = "sourceId")]
+    pub source_id: String,
+    #[serde(rename = "icsUid")]
+    pub ics_uid: String,
+    #[serde(rename = "recurrenceId")]
+    pub recurrence_id: Option<String>,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    #[serde(rename = "organizerName")]
+    pub organizer_name: Option<String>,
+    #[serde(rename = "organizerEmail")]
+    pub organizer_email: Option<String>,
+    #[serde(rename = "startAt")]
+    pub start_at: DateTime<Utc>,
+    #[serde(rename = "endAt")]
+    pub end_at: DateTime<Utc>,
+    #[serde(rename = "isAllDay")]
+    pub is_all_day: bool,
+    pub attendees: Vec<Attendee>,
+}
+
+impl TryFrom<CalendarEventRow> for CalendarEvent {
+    type Error = String;
+
+    fn try_from(row: CalendarEventRow) -> Result<Self, Self::Error> {
+        let start_at = DateTime::parse_from_rfc3339(&row.start_at)
+            .map_err(|e| format!("invalid start_at {}: {}", row.start_at, e))?
+            .with_timezone(&Utc);
+        let end_at = DateTime::parse_from_rfc3339(&row.end_at)
+            .map_err(|e| format!("invalid end_at {}: {}", row.end_at, e))?
+            .with_timezone(&Utc);
+        let attendees: Vec<Attendee> = serde_json::from_str(&row.attendees_json)
+            .map_err(|e| format!("invalid attendees_json: {}", e))?;
+
+        Ok(CalendarEvent {
+            id: row.id,
+            source_id: row.source_id,
+            ics_uid: row.ics_uid,
+            recurrence_id: row.recurrence_id,
+            summary: row.summary,
+            description: row.description,
+            location: row.location,
+            organizer_name: row.organizer_name,
+            organizer_email: row.organizer_email,
+            start_at,
+            end_at,
+            is_all_day: row.is_all_day != 0,
+            attendees,
+        })
+    }
+}
+
+/// In-memory event used between parser and repository before being assigned a
+/// row id and stored.
+#[derive(Debug, Clone)]
+pub struct ParsedEvent {
+    pub ics_uid: String,
+    pub recurrence_id: Option<DateTime<Utc>>,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub organizer_name: Option<String>,
+    pub organizer_email: Option<String>,
+    pub start_at: DateTime<Utc>,
+    pub end_at: DateTime<Utc>,
+    pub is_all_day: bool,
+    pub attendees: Vec<Attendee>,
+    pub rrule_block: Option<String>,
+    pub raw_ics: String,
+}

--- a/frontend/src-tauri/src/calendar/parser.rs
+++ b/frontend/src-tauri/src/calendar/parser.rs
@@ -1,0 +1,424 @@
+use std::io::BufReader;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use ical::parser::ical::component::IcalEvent;
+use ical::property::Property;
+use rrule::RRuleSet;
+
+use super::models::{Attendee, ParsedEvent};
+
+/// Parse an ICS document string into a list of master events. Recurring
+/// events are returned as a single master entry whose `rrule_block` carries
+/// the DTSTART + RRULE block — expansion happens in `expand_event_window`
+/// at fetch time. Override events (those carrying RECURRENCE-ID) are also
+/// returned as their own ParsedEvent so the repository can use them to
+/// supersede generated occurrences.
+pub fn parse_ics(ics: &str) -> Result<Vec<ParsedEvent>> {
+    let buf = BufReader::new(ics.as_bytes());
+    let parser = ical::IcalParser::new(buf);
+
+    let mut events = Vec::new();
+    for cal in parser {
+        let cal = cal.map_err(|e| anyhow!("ICS parse error: {}", e))?;
+        for ev in cal.events {
+            match parse_event(&ev) {
+                Ok(parsed) => events.push(parsed),
+                Err(e) => {
+                    log::warn!(
+                        "skipping malformed VEVENT (uid={:?}): {}",
+                        prop_value(&ev, "UID"),
+                        e
+                    );
+                }
+            }
+        }
+    }
+    Ok(events)
+}
+
+fn parse_event(ev: &IcalEvent) -> Result<ParsedEvent> {
+    let uid = prop_value(ev, "UID")
+        .context("VEVENT missing UID")?
+        .to_string();
+
+    let (start_at, start_is_all_day) = parse_datetime_property(ev, "DTSTART")?;
+    let end_at = match parse_optional_datetime_property(ev, "DTEND")? {
+        Some((dt, _)) => dt,
+        None => match parse_optional_duration(ev) {
+            Some(dur) => start_at + dur,
+            None => {
+                if start_is_all_day {
+                    start_at + Duration::days(1)
+                } else {
+                    start_at + Duration::minutes(30)
+                }
+            }
+        },
+    };
+
+    let recurrence_id = parse_optional_datetime_property(ev, "RECURRENCE-ID")?
+        .map(|(dt, _)| dt);
+
+    let summary = prop_value(ev, "SUMMARY").map(|s| s.to_string());
+    let description = prop_value(ev, "DESCRIPTION").map(|s| s.to_string());
+    let location = prop_value(ev, "LOCATION").map(|s| s.to_string());
+
+    let (organizer_name, organizer_email) = parse_organizer(ev);
+    let attendees = parse_attendees(ev);
+
+    let rrule_block = build_rrule_block(ev);
+    let raw_ics = serialize_event(ev);
+
+    Ok(ParsedEvent {
+        ics_uid: uid,
+        recurrence_id,
+        summary,
+        description,
+        location,
+        organizer_name,
+        organizer_email,
+        start_at,
+        end_at,
+        is_all_day: start_is_all_day,
+        attendees,
+        rrule_block,
+        raw_ics,
+    })
+}
+
+fn prop<'a>(ev: &'a IcalEvent, name: &str) -> Option<&'a Property> {
+    ev.properties.iter().find(|p| p.name == name)
+}
+
+fn prop_value<'a>(ev: &'a IcalEvent, name: &str) -> Option<&'a str> {
+    prop(ev, name).and_then(|p| p.value.as_deref())
+}
+
+fn parse_datetime_property(
+    ev: &IcalEvent,
+    name: &str,
+) -> Result<(DateTime<Utc>, bool)> {
+    parse_optional_datetime_property(ev, name)?
+        .ok_or_else(|| anyhow!("missing {} property", name))
+}
+
+fn parse_optional_datetime_property(
+    ev: &IcalEvent,
+    name: &str,
+) -> Result<Option<(DateTime<Utc>, bool)>> {
+    let Some(p) = prop(ev, name) else {
+        return Ok(None);
+    };
+    let value = p
+        .value
+        .as_deref()
+        .ok_or_else(|| anyhow!("{} has no value", name))?;
+    let params = p.params.as_ref();
+
+    let value_type = params
+        .and_then(|ps| ps.iter().find(|(k, _)| k.eq_ignore_ascii_case("VALUE")))
+        .and_then(|(_, v)| v.first().cloned())
+        .unwrap_or_default();
+
+    if value_type.eq_ignore_ascii_case("DATE") || value.len() == 8 {
+        let d = NaiveDate::parse_from_str(value, "%Y%m%d")
+            .with_context(|| format!("invalid DATE in {}: {}", name, value))?;
+        let dt = d.and_hms_opt(0, 0, 0).unwrap();
+        return Ok(Some((Utc.from_utc_datetime(&dt), true)));
+    }
+
+    let tzid = params
+        .and_then(|ps| ps.iter().find(|(k, _)| k.eq_ignore_ascii_case("TZID")))
+        .and_then(|(_, v)| v.first().cloned());
+
+    let dt = parse_naive_or_utc(value)
+        .with_context(|| format!("invalid DATE-TIME in {}: {}", name, value))?;
+
+    Ok(Some((apply_tz(dt, value, tzid.as_deref())?, false)))
+}
+
+fn parse_naive_or_utc(value: &str) -> Result<NaiveDateTime> {
+    if let Some(stripped) = value.strip_suffix('Z') {
+        return NaiveDateTime::parse_from_str(stripped, "%Y%m%dT%H%M%S")
+            .map_err(|e| e.into());
+    }
+    NaiveDateTime::parse_from_str(value, "%Y%m%dT%H%M%S").map_err(|e| e.into())
+}
+
+fn apply_tz(naive: NaiveDateTime, raw: &str, tzid: Option<&str>) -> Result<DateTime<Utc>> {
+    if raw.ends_with('Z') {
+        return Ok(Utc.from_utc_datetime(&naive));
+    }
+    if let Some(tzid) = tzid {
+        let tz: Tz = tzid
+            .parse()
+            .map_err(|e| anyhow!("unknown TZID {}: {}", tzid, e))?;
+        return tz
+            .from_local_datetime(&naive)
+            .single()
+            .ok_or_else(|| anyhow!("ambiguous local time {} in {}", naive, tzid))
+            .map(|dt| dt.with_timezone(&Utc));
+    }
+    // Floating local time — interpret as UTC. Acceptable fallback for
+    // public ICS feeds that omit TZID; users can fix on the source side.
+    Ok(Utc.from_utc_datetime(&naive))
+}
+
+fn parse_optional_duration(ev: &IcalEvent) -> Option<Duration> {
+    let raw = prop_value(ev, "DURATION")?;
+    parse_iso_duration(raw)
+}
+
+fn parse_iso_duration(raw: &str) -> Option<Duration> {
+    // Minimal subset: PT#H#M#S, P#D, P#W. Sufficient for typical ICS feeds.
+    let (sign, rest) = if let Some(s) = raw.strip_prefix('-') {
+        (-1, s)
+    } else if let Some(s) = raw.strip_prefix('+') {
+        (1, s)
+    } else {
+        (1, raw)
+    };
+    let rest = rest.strip_prefix('P')?;
+    let mut total = Duration::zero();
+    let mut buf = String::new();
+    let mut in_time = false;
+    for ch in rest.chars() {
+        if ch == 'T' {
+            in_time = true;
+            continue;
+        }
+        if ch.is_ascii_digit() {
+            buf.push(ch);
+            continue;
+        }
+        let n: i64 = buf.parse().ok()?;
+        buf.clear();
+        let unit = match (ch, in_time) {
+            ('W', false) => Duration::weeks(n),
+            ('D', false) => Duration::days(n),
+            ('H', true) => Duration::hours(n),
+            ('M', true) => Duration::minutes(n),
+            ('S', true) => Duration::seconds(n),
+            _ => return None,
+        };
+        total = total + unit;
+    }
+    Some(total * sign as i32)
+}
+
+fn parse_organizer(ev: &IcalEvent) -> (Option<String>, Option<String>) {
+    let Some(p) = prop(ev, "ORGANIZER") else {
+        return (None, None);
+    };
+    let email = p
+        .value
+        .as_deref()
+        .and_then(|v| v.strip_prefix("mailto:").or(Some(v)))
+        .map(|s| s.trim().to_string());
+    let name = p
+        .params
+        .as_ref()
+        .and_then(|ps| ps.iter().find(|(k, _)| k.eq_ignore_ascii_case("CN")))
+        .and_then(|(_, v)| v.first().cloned());
+    (name, email)
+}
+
+fn parse_attendees(ev: &IcalEvent) -> Vec<Attendee> {
+    ev.properties
+        .iter()
+        .filter(|p| p.name == "ATTENDEE")
+        .map(|p| {
+            let email = p
+                .value
+                .as_deref()
+                .and_then(|v| v.strip_prefix("mailto:").or(Some(v)))
+                .map(|s| s.trim().to_string());
+            let mut name = None;
+            let mut role = None;
+            let mut status = None;
+            if let Some(ps) = &p.params {
+                for (k, vs) in ps {
+                    let v = vs.first().cloned();
+                    match k.to_ascii_uppercase().as_str() {
+                        "CN" => name = v,
+                        "ROLE" => role = v,
+                        "PARTSTAT" => status = v,
+                        _ => {}
+                    }
+                }
+            }
+            Attendee {
+                name,
+                email,
+                role,
+                status,
+                is_organizer: false,
+            }
+        })
+        .collect()
+}
+
+/// Reconstruct a minimal `DTSTART:...\nRRULE:...` block for the rrule crate.
+/// Returns None if the event has no RRULE.
+fn build_rrule_block(ev: &IcalEvent) -> Option<String> {
+    let rrule = prop(ev, "RRULE")?;
+    let rrule_value = rrule.value.as_deref()?;
+
+    let dtstart = prop(ev, "DTSTART")?;
+    let dtstart_str = serialize_property(dtstart);
+
+    let mut block = String::new();
+    block.push_str(&dtstart_str);
+    block.push('\n');
+    block.push_str(&format!("RRULE:{}", rrule_value));
+
+    for name in ["EXDATE", "RDATE", "EXRULE"] {
+        for p in ev.properties.iter().filter(|p| p.name == name) {
+            block.push('\n');
+            block.push_str(&serialize_property(p));
+        }
+    }
+
+    Some(block)
+}
+
+fn serialize_property(p: &Property) -> String {
+    let mut s = p.name.clone();
+    if let Some(params) = &p.params {
+        for (k, v) in params {
+            s.push(';');
+            s.push_str(k);
+            s.push('=');
+            s.push_str(&v.join(","));
+        }
+    }
+    s.push(':');
+    if let Some(v) = &p.value {
+        s.push_str(v);
+    }
+    s
+}
+
+fn serialize_event(ev: &IcalEvent) -> String {
+    let mut s = String::from("BEGIN:VEVENT\n");
+    for p in &ev.properties {
+        s.push_str(&serialize_property(p));
+        s.push('\n');
+    }
+    s.push_str("END:VEVENT");
+    s
+}
+
+/// Expand a master event's RRULE over the given window (UTC). For non-
+/// recurring events this returns a single occurrence at the master start
+/// (or empty if the master is outside the window).
+pub fn expand_event_window(
+    master: &ParsedEvent,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    max_occurrences: u16,
+) -> Vec<DateTime<Utc>> {
+    if let Some(block) = &master.rrule_block {
+        match block.parse::<RRuleSet>() {
+            Ok(set) => {
+                let result = set
+                    .after(rrule_dt(from))
+                    .before(rrule_dt(to))
+                    .all(max_occurrences);
+                return result
+                    .dates
+                    .into_iter()
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .collect();
+            }
+            Err(e) => {
+                log::warn!(
+                    "RRULE parse failed for uid={} ({}); falling back to single occurrence",
+                    master.ics_uid,
+                    e
+                );
+            }
+        }
+    }
+    if master.start_at >= from && master.start_at <= to {
+        vec![master.start_at]
+    } else {
+        Vec::new()
+    }
+}
+
+fn rrule_dt(dt: DateTime<Utc>) -> DateTime<rrule::Tz> {
+    dt.with_timezone(&rrule::Tz::UTC)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_ICS: &str = "BEGIN:VCALENDAR\r\n\
+VERSION:2.0\r\n\
+PRODID:-//Test//Test//EN\r\n\
+BEGIN:VEVENT\r\n\
+UID:abc-123@test\r\n\
+DTSTAMP:20260506T120000Z\r\n\
+DTSTART:20260506T143000Z\r\n\
+DTEND:20260506T153000Z\r\n\
+SUMMARY:Team Standup\r\n\
+DESCRIPTION:Daily sync\r\n\
+LOCATION:Zoom\r\n\
+ORGANIZER;CN=Alice Example:mailto:alice@example.com\r\n\
+ATTENDEE;CN=Bob;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED:mailto:bob@example.com\r\n\
+ATTENDEE;CN=Carol;ROLE=OPT-PARTICIPANT;PARTSTAT=TENTATIVE:mailto:carol@example.com\r\n\
+END:VEVENT\r\n\
+END:VCALENDAR\r\n";
+
+    #[test]
+    fn parses_simple_event() {
+        let events = parse_ics(SAMPLE_ICS).unwrap();
+        assert_eq!(events.len(), 1);
+        let e = &events[0];
+        assert_eq!(e.ics_uid, "abc-123@test");
+        assert_eq!(e.summary.as_deref(), Some("Team Standup"));
+        assert_eq!(e.location.as_deref(), Some("Zoom"));
+        assert_eq!(e.organizer_email.as_deref(), Some("alice@example.com"));
+        assert_eq!(e.organizer_name.as_deref(), Some("Alice Example"));
+        assert_eq!(e.attendees.len(), 2);
+        assert!(!e.is_all_day);
+        assert_eq!(e.rrule_block, None);
+    }
+
+    #[test]
+    fn expands_recurring_event() {
+        let ics = "BEGIN:VCALENDAR\r\n\
+VERSION:2.0\r\n\
+PRODID:-//Test//Test//EN\r\n\
+BEGIN:VEVENT\r\n\
+UID:rec-1@test\r\n\
+DTSTAMP:20260506T120000Z\r\n\
+DTSTART:20260506T140000Z\r\n\
+DTEND:20260506T150000Z\r\n\
+SUMMARY:Weekly\r\n\
+RRULE:FREQ=WEEKLY;COUNT=3\r\n\
+END:VEVENT\r\n\
+END:VCALENDAR\r\n";
+        let events = parse_ics(ics).unwrap();
+        let master = &events[0];
+        assert!(master.rrule_block.is_some());
+        let occurrences = expand_event_window(
+            master,
+            "2026-05-01T00:00:00Z".parse().unwrap(),
+            "2026-07-01T00:00:00Z".parse().unwrap(),
+            100,
+        );
+        assert_eq!(occurrences.len(), 3);
+    }
+
+    #[test]
+    fn parses_iso_duration() {
+        assert_eq!(parse_iso_duration("PT1H30M"), Some(Duration::minutes(90)));
+        assert_eq!(parse_iso_duration("P1D"), Some(Duration::days(1)));
+        assert_eq!(parse_iso_duration("P1W"), Some(Duration::weeks(1)));
+    }
+}

--- a/frontend/src-tauri/src/calendar/repository.rs
+++ b/frontend/src-tauri/src/calendar/repository.rs
@@ -1,0 +1,285 @@
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use super::fetcher::OccurrenceForUpsert;
+use super::models::{CalendarEvent, CalendarEventRow, CalendarSourceRow};
+
+pub struct CalendarRepository;
+
+impl CalendarRepository {
+    pub async fn list_sources(pool: &SqlitePool) -> Result<Vec<CalendarSourceRow>, sqlx::Error> {
+        sqlx::query_as::<_, CalendarSourceRow>(
+            "SELECT id, url, label, last_fetched_at, last_error, created_at, updated_at
+             FROM calendar_sources ORDER BY created_at ASC",
+        )
+        .fetch_all(pool)
+        .await
+    }
+
+    pub async fn get_source(
+        pool: &SqlitePool,
+        id: &str,
+    ) -> Result<Option<CalendarSourceRow>, sqlx::Error> {
+        sqlx::query_as::<_, CalendarSourceRow>(
+            "SELECT id, url, label, last_fetched_at, last_error, created_at, updated_at
+             FROM calendar_sources WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+    }
+
+    pub async fn add_source(
+        pool: &SqlitePool,
+        url: &str,
+        label: Option<&str>,
+    ) -> Result<CalendarSourceRow, sqlx::Error> {
+        let now = Utc::now().to_rfc3339();
+        let id = Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO calendar_sources (id, url, label, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(url)
+        .bind(label)
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await?;
+
+        Ok(CalendarSourceRow {
+            id,
+            url: url.to_string(),
+            label: label.map(|s| s.to_string()),
+            last_fetched_at: None,
+            last_error: None,
+            created_at: now.clone(),
+            updated_at: now,
+        })
+    }
+
+    pub async fn remove_source(pool: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+        let res = sqlx::query("DELETE FROM calendar_sources WHERE id = ?")
+            .bind(id)
+            .execute(pool)
+            .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    pub async fn update_source_label(
+        pool: &SqlitePool,
+        id: &str,
+        label: Option<&str>,
+    ) -> Result<bool, sqlx::Error> {
+        let now = Utc::now().to_rfc3339();
+        let res = sqlx::query(
+            "UPDATE calendar_sources SET label = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(label)
+        .bind(&now)
+        .bind(id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    pub async fn mark_source_fetched(
+        pool: &SqlitePool,
+        id: &str,
+        error: Option<&str>,
+    ) -> Result<(), sqlx::Error> {
+        let now = Utc::now().to_rfc3339();
+        sqlx::query(
+            "UPDATE calendar_sources
+             SET last_fetched_at = ?, last_error = ?, updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(&now)
+        .bind(error)
+        .bind(&now)
+        .bind(id)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Replace the full set of events for a source. Public ICS feeds are
+    /// authoritative for the source, so a clean replace is safer than
+    /// trying to diff individual occurrences (the ICS spec lets feeds
+    /// rewrite UIDs / restructure recurrence sets at any time).
+    pub async fn replace_events(
+        pool: &SqlitePool,
+        source_id: &str,
+        occurrences: &[OccurrenceForUpsert],
+    ) -> Result<usize, sqlx::Error> {
+        let mut tx = pool.begin().await?;
+
+        sqlx::query("DELETE FROM calendar_events WHERE source_id = ?")
+            .bind(source_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let now = Utc::now().to_rfc3339();
+        let mut inserted = 0usize;
+        for occ in occurrences {
+            let id = Uuid::new_v4().to_string();
+            let attendees_json =
+                serde_json::to_string(&occ.master.attendees).unwrap_or_else(|_| "[]".to_string());
+            let recurrence_id = occ.recurrence_id.map(|dt| dt.to_rfc3339());
+
+            sqlx::query(
+                "INSERT INTO calendar_events (
+                    id, source_id, ics_uid, recurrence_id, summary, description,
+                    location, organizer_name, organizer_email, start_at, end_at,
+                    is_all_day, attendees_json, raw_ics, fetched_at
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(source_id, ics_uid, COALESCE(recurrence_id, ''))
+                 DO UPDATE SET
+                    summary = excluded.summary,
+                    description = excluded.description,
+                    location = excluded.location,
+                    organizer_name = excluded.organizer_name,
+                    organizer_email = excluded.organizer_email,
+                    start_at = excluded.start_at,
+                    end_at = excluded.end_at,
+                    is_all_day = excluded.is_all_day,
+                    attendees_json = excluded.attendees_json,
+                    raw_ics = excluded.raw_ics,
+                    fetched_at = excluded.fetched_at",
+            )
+            .bind(&id)
+            .bind(source_id)
+            .bind(&occ.master.ics_uid)
+            .bind(&recurrence_id)
+            .bind(&occ.master.summary)
+            .bind(&occ.master.description)
+            .bind(&occ.master.location)
+            .bind(&occ.master.organizer_name)
+            .bind(&occ.master.organizer_email)
+            .bind(occ.start_at.to_rfc3339())
+            .bind(occ.end_at.to_rfc3339())
+            .bind(if occ.master.is_all_day { 1 } else { 0 })
+            .bind(&attendees_json)
+            .bind(&occ.master.raw_ics)
+            .bind(&now)
+            .execute(&mut *tx)
+            .await?;
+            inserted += 1;
+        }
+        tx.commit().await?;
+        Ok(inserted)
+    }
+
+    pub async fn list_events_in_range(
+        pool: &SqlitePool,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> Result<Vec<CalendarEvent>, sqlx::Error> {
+        let rows = sqlx::query_as::<_, CalendarEventRow>(
+            "SELECT id, source_id, ics_uid, recurrence_id, summary, description,
+                    location, organizer_name, organizer_email, start_at, end_at,
+                    is_all_day, attendees_json, raw_ics, fetched_at
+             FROM calendar_events
+             WHERE start_at < ? AND end_at > ?
+             ORDER BY start_at ASC",
+        )
+        .bind(to.to_rfc3339())
+        .bind(from.to_rfc3339())
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| match CalendarEvent::try_from(r) {
+                Ok(ev) => Some(ev),
+                Err(e) => {
+                    log::warn!("dropping malformed calendar_events row: {}", e);
+                    None
+                }
+            })
+            .collect())
+    }
+
+    pub async fn find_event_for_now(
+        pool: &SqlitePool,
+    ) -> Result<Option<CalendarEvent>, sqlx::Error> {
+        let now = Utc::now();
+        // Tolerate +/- 5 minutes so a slightly-late record-start still picks
+        // up the current event.
+        let from = now - chrono::Duration::minutes(15);
+        let to = now + chrono::Duration::minutes(5);
+
+        let row = sqlx::query_as::<_, CalendarEventRow>(
+            "SELECT id, source_id, ics_uid, recurrence_id, summary, description,
+                    location, organizer_name, organizer_email, start_at, end_at,
+                    is_all_day, attendees_json, raw_ics, fetched_at
+             FROM calendar_events
+             WHERE is_all_day = 0
+               AND start_at <= ?
+               AND end_at >= ?
+             ORDER BY start_at DESC
+             LIMIT 1",
+        )
+        .bind(to.to_rfc3339())
+        .bind(from.to_rfc3339())
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.and_then(|r| CalendarEvent::try_from(r).ok()))
+    }
+
+    pub async fn get_event(
+        pool: &SqlitePool,
+        event_id: &str,
+    ) -> Result<Option<CalendarEvent>, sqlx::Error> {
+        let row = sqlx::query_as::<_, CalendarEventRow>(
+            "SELECT id, source_id, ics_uid, recurrence_id, summary, description,
+                    location, organizer_name, organizer_email, start_at, end_at,
+                    is_all_day, attendees_json, raw_ics, fetched_at
+             FROM calendar_events WHERE id = ?",
+        )
+        .bind(event_id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.and_then(|r| CalendarEvent::try_from(r).ok()))
+    }
+
+    pub async fn link_meeting(
+        pool: &SqlitePool,
+        meeting_id: &str,
+        event_id: Option<&str>,
+    ) -> Result<bool, sqlx::Error> {
+        let now = Utc::now();
+        let res = sqlx::query(
+            "UPDATE meetings SET calendar_event_id = ?, updated_at = ? WHERE id = ?",
+        )
+        .bind(event_id)
+        .bind(now)
+        .bind(meeting_id)
+        .execute(pool)
+        .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    pub async fn get_event_for_meeting(
+        pool: &SqlitePool,
+        meeting_id: &str,
+    ) -> Result<Option<CalendarEvent>, sqlx::Error> {
+        let row = sqlx::query_as::<_, CalendarEventRow>(
+            "SELECT e.id, e.source_id, e.ics_uid, e.recurrence_id, e.summary, e.description,
+                    e.location, e.organizer_name, e.organizer_email, e.start_at, e.end_at,
+                    e.is_all_day, e.attendees_json, e.raw_ics, e.fetched_at
+             FROM calendar_events e
+             JOIN meetings m ON m.calendar_event_id = e.id
+             WHERE m.id = ?",
+        )
+        .bind(meeting_id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.and_then(|r| CalendarEvent::try_from(r).ok()))
+    }
+}

--- a/frontend/src-tauri/src/calendar/snapshot.rs
+++ b/frontend/src-tauri/src/calendar/snapshot.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sqlx::SqlitePool;
+
+use super::models::{Attendee, CalendarEvent};
+
+/// Filename used for the sidecar snapshot dropped into a meeting folder
+/// alongside `metadata.json` / `transcripts.json` when the meeting is
+/// linked to a calendar event.
+pub const SNAPSHOT_FILENAME: &str = "calendar_event.json";
+const SNAPSHOT_VERSION: &str = "1.0";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEventSnapshot {
+    pub version: String,
+    pub linked_at: String,
+    pub event: SnapshotEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotEvent {
+    pub id: String,
+    pub source_id: String,
+    pub ics_uid: String,
+    pub recurrence_id: Option<String>,
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub organizer: SnapshotOrganizer,
+    pub start_at: String,
+    pub end_at: String,
+    pub is_all_day: bool,
+    pub attendees: Vec<Attendee>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotOrganizer {
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+
+impl CalendarEventSnapshot {
+    pub fn from_event(event: &CalendarEvent) -> Self {
+        CalendarEventSnapshot {
+            version: SNAPSHOT_VERSION.to_string(),
+            linked_at: Utc::now().to_rfc3339(),
+            event: SnapshotEvent {
+                id: event.id.clone(),
+                source_id: event.source_id.clone(),
+                ics_uid: event.ics_uid.clone(),
+                recurrence_id: event.recurrence_id.clone(),
+                summary: event.summary.clone(),
+                description: event.description.clone(),
+                location: event.location.clone(),
+                organizer: SnapshotOrganizer {
+                    name: event.organizer_name.clone(),
+                    email: event.organizer_email.clone(),
+                },
+                start_at: event.start_at.to_rfc3339(),
+                end_at: event.end_at.to_rfc3339(),
+                is_all_day: event.is_all_day,
+                attendees: event.attendees.clone(),
+            },
+        }
+    }
+}
+
+/// Look up a meeting's `folder_path` so the calendar feature can write
+/// sidecar files alongside `metadata.json`. Returns None when the
+/// recording was saved without a folder (e.g. `auto_save = false`),
+/// in which case there's nothing to attach the snapshot to.
+pub async fn lookup_meeting_folder(
+    pool: &SqlitePool,
+    meeting_id: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    let row: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT folder_path FROM meetings WHERE id = ?")
+            .bind(meeting_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.and_then(|(p,)| p))
+}
+
+/// Write the snapshot atomically (`.tmp` → rename) so a partial write
+/// never leaves a corrupted sidecar in the user's recordings folder.
+pub fn write_snapshot(folder: &Path, snapshot: &CalendarEventSnapshot) -> Result<()> {
+    if !folder.exists() {
+        return Err(anyhow::anyhow!(
+            "meeting folder does not exist: {}",
+            folder.display()
+        ));
+    }
+    let target = folder.join(SNAPSHOT_FILENAME);
+    let tmp = folder.join(format!(".{}.tmp", SNAPSHOT_FILENAME));
+    let json = serde_json::to_string_pretty(snapshot).context("serialize snapshot")?;
+    std::fs::write(&tmp, json).context("write snapshot tmp file")?;
+    std::fs::rename(&tmp, &target).context("rename snapshot tmp into place")?;
+    Ok(())
+}
+
+/// Remove the snapshot if it exists. No-op when missing.
+pub fn delete_snapshot(folder: &Path) -> Result<()> {
+    let target = folder.join(SNAPSHOT_FILENAME);
+    if target.exists() {
+        std::fs::remove_file(&target).context("delete snapshot")?;
+    }
+    Ok(())
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ macro_rules! perf_trace {
 pub mod anthropic;
 pub mod api;
 pub mod audio;
+pub mod calendar;
 pub mod config;
 pub mod console_utils;
 pub mod database;
@@ -943,6 +944,17 @@ pub fn run() {
             audio::import::start_import_audio_command,
             audio::import::cancel_import_command,
             audio::import::is_import_in_progress_command,
+            // Calendar / ICS commands
+            calendar::commands::calendar_list_sources,
+            calendar::commands::calendar_add_source,
+            calendar::commands::calendar_remove_source,
+            calendar::commands::calendar_update_source_label,
+            calendar::commands::calendar_refresh_source,
+            calendar::commands::calendar_refresh_all,
+            calendar::commands::calendar_list_events,
+            calendar::commands::calendar_find_event_for_now,
+            calendar::commands::calendar_link_meeting,
+            calendar::commands::calendar_get_event_for_meeting,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/frontend/src-tauri/src/summary/commands.rs
+++ b/frontend/src-tauri/src/summary/commands.rs
@@ -46,6 +46,24 @@ pub async fn api_save_meeting_summary<R: Runtime>(
     match SummaryProcessesRepository::update_meeting_summary(pool, &meeting_id, &summary).await {
         Ok(true) => {
             log_info!("Summary saved successfully for meeting_id: {}", meeting_id);
+
+            // Mirror the saved markdown to summary.md in the meeting folder.
+            // Best-effort: if the meeting has no folder (auto_save was off)
+            // or the disk write fails, the DB save still succeeded.
+            if let Err(e) = crate::summary::markdown_export::write_summary_md(
+                pool,
+                &meeting_id,
+                &summary,
+            )
+            .await
+            {
+                log_warn!(
+                    "Failed to write summary.md sidecar for {}: {}",
+                    meeting_id,
+                    e
+                );
+            }
+
             Ok(serde_json::json!({
                 "message": "Meeting summary saved successfully"
             }))

--- a/frontend/src-tauri/src/summary/markdown_export.rs
+++ b/frontend/src-tauri/src/summary/markdown_export.rs
@@ -1,0 +1,66 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use sqlx::SqlitePool;
+
+use crate::calendar::snapshot::lookup_meeting_folder;
+
+const SUMMARY_FILENAME: &str = "summary.md";
+
+/// Pull the markdown body out of a stored summary `result` JSON. Both the
+/// auto-generation path and the manual save path write `{ "markdown":
+/// "...", "summary_json": [...] }`, so this is the single shape we read.
+pub fn extract_markdown(value: &Value) -> Option<String> {
+    value
+        .get("markdown")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Write `summary.md` to the meeting's recording folder atomically. No-op
+/// when the meeting has no folder (e.g. recordings made with auto_save
+/// disabled) or when the folder doesn't exist on disk.
+pub fn write_summary_md_to_folder(folder: &Path, markdown: &str) -> Result<()> {
+    if !folder.exists() {
+        return Err(anyhow::anyhow!(
+            "meeting folder does not exist: {}",
+            folder.display()
+        ));
+    }
+    let target = folder.join(SUMMARY_FILENAME);
+    let tmp = folder.join(format!(".{}.tmp", SUMMARY_FILENAME));
+    std::fs::write(&tmp, markdown).context("write summary.md tmp file")?;
+    std::fs::rename(&tmp, &target).context("rename summary.md tmp into place")?;
+    Ok(())
+}
+
+/// Convenience wrapper used by both the auto-generation completion path
+/// and the manual-save command. Looks up the meeting folder, extracts
+/// markdown from `result_value`, writes it to disk. All failures are
+/// returned to the caller — they're expected to log and continue (the
+/// DB stays the source of truth).
+pub async fn write_summary_md(
+    pool: &SqlitePool,
+    meeting_id: &str,
+    result_value: &Value,
+) -> Result<()> {
+    let Some(markdown) = extract_markdown(result_value) else {
+        return Err(anyhow::anyhow!(
+            "summary result has no `markdown` field; nothing to write"
+        ));
+    };
+
+    let folder = lookup_meeting_folder(pool, meeting_id)
+        .await
+        .with_context(|| format!("lookup folder for meeting {}", meeting_id))?;
+
+    let Some(folder) = folder else {
+        return Err(anyhow::anyhow!(
+            "meeting {} has no folder_path (auto_save disabled?)",
+            meeting_id
+        ));
+    };
+
+    write_summary_md_to_folder(&PathBuf::from(folder), &markdown)
+}

--- a/frontend/src-tauri/src/summary/mod.rs
+++ b/frontend/src-tauri/src/summary/mod.rs
@@ -31,6 +31,7 @@ pub struct CustomOpenAIConfig {
 
 pub mod commands;
 pub mod llm_client;
+pub mod markdown_export;
 pub mod processor;
 pub mod service;
 pub mod summary_engine;

--- a/frontend/src-tauri/src/summary/service.rs
+++ b/frontend/src-tauri/src/summary/service.rs
@@ -319,7 +319,7 @@ impl SummaryService {
                 if let Err(e) = SummaryProcessesRepository::update_process_completed(
                     &pool,
                     &meeting_id,
-                    result_json,
+                    result_json.clone(),
                     num_chunks,
                     duration,
                 )
@@ -328,6 +328,23 @@ impl SummaryService {
                     error!("Failed to save completed process for {}: {}", meeting_id, e);
                 } else {
                     info!("Summary saved successfully for meeting_id: {}", meeting_id);
+
+                    // Best-effort: drop a portable summary.md alongside
+                    // metadata.json / transcripts.json in the meeting
+                    // folder. Failure is non-fatal — the DB row is the
+                    // source of truth; the .md is a convenience export.
+                    if let Err(e) = crate::summary::markdown_export::write_summary_md(
+                        &pool,
+                        &meeting_id,
+                        &result_json,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "Failed to write summary.md sidecar for {}: {}",
+                            meeting_id, e
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import {
   ArrowLeft,
+  CalendarDays,
   Database as DatabaseIcon,
   FlaskConical,
   Mic,
@@ -18,6 +19,7 @@ import { PreferenceSettings } from "@/components/PreferenceSettings";
 import { SummaryModelSettings } from "@/components/SummaryModelSettings";
 import { BetaSettings } from "@/components/BetaSettings";
 import { SpeakerSettings } from "@/components/SpeakerSettings";
+import { CalendarSettings } from "@/components/CalendarSettings";
 import { useConfig } from "@/contexts/ConfigContext";
 import { Button } from "@/components/ui/button";
 import { Page, PageBody } from "@/components/layout/Page";
@@ -55,6 +57,12 @@ const CATEGORIES: readonly SettingsCategory[] = [
     label: "Summary",
     description: "AI engine + model that generates meeting summaries.",
     icon: SparkleIcon,
+  },
+  {
+    id: "calendar",
+    label: "Calendar",
+    description: "Public ICS feeds. Link recordings to calendar events.",
+    icon: CalendarDays,
   },
   {
     id: "beta",
@@ -140,6 +148,7 @@ export default function SettingsPage() {
                 />
               )}
               {active.id === "summary" && <SummaryModelSettings />}
+              {active.id === "calendar" && <CalendarSettings />}
               {active.id === "beta" && <BetaSettings />}
             </SettingsSection>
           </main>

--- a/frontend/src/components/CalendarSettings.tsx
+++ b/frontend/src/components/CalendarSettings.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Calendar, RefreshCw, Trash2, ExternalLink, Check } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { SettingsCard } from "@/app/settings/parts/SettingsCard";
+import {
+  addCalendarSource,
+  listCalendarSources,
+  refreshCalendarSource,
+  removeCalendarSource,
+  type CalendarSource,
+} from "@/lib/calendar";
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "Never";
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return iso;
+  const diffMs = Date.now() - ts;
+  if (diffMs < 0) return new Date(ts).toLocaleString();
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return "just now";
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ago`;
+  if (sec < 86_400) return `${Math.floor(sec / 3600)}h ago`;
+  return new Date(ts).toLocaleString();
+}
+
+export function CalendarSettings() {
+  const [sources, setSources] = useState<CalendarSource[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [url, setUrl] = useState("");
+  const [label, setLabel] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [recentRefreshCounts, setRecentRefreshCounts] = useState<Record<string, number>>({});
+
+  const reload = useCallback(async () => {
+    try {
+      const rows = await listCalendarSources();
+      setSources(rows);
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const created = await addCalendarSource(trimmed, label.trim() || null);
+      setUrl("");
+      setLabel("");
+      try {
+        const result = await refreshCalendarSource(created.id);
+        setRecentRefreshCounts((prev) => ({
+          ...prev,
+          [created.id]: result.eventCount,
+        }));
+      } catch (refreshErr) {
+        setSaveError(`Added, but initial fetch failed: ${refreshErr}`);
+      }
+      await reload();
+    } catch (err) {
+      setSaveError(String(err));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRefresh = async (id: string) => {
+    setRefreshingId(id);
+    try {
+      const result = await refreshCalendarSource(id);
+      setRecentRefreshCounts((prev) => ({ ...prev, [id]: result.eventCount }));
+      await reload();
+    } catch (err) {
+      setLoadError(String(err));
+      await reload();
+    } finally {
+      setRefreshingId(null);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    const ok = confirm(
+      "Remove this calendar source? Linked meetings will keep their event metadata snapshot.",
+    );
+    if (!ok) return;
+    try {
+      await removeCalendarSource(id);
+      await reload();
+    } catch (err) {
+      setLoadError(String(err));
+    }
+  };
+
+  const sortedSources = useMemo(() => {
+    if (!sources) return null;
+    return [...sources].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }, [sources]);
+
+  return (
+    <div className="space-y-6">
+      <SettingsCard
+        title="Public ICS feeds"
+        description="Add a public iCalendar URL (Google or Outlook published-calendar links work). Events from the next 90 days will be available to link to recordings."
+      >
+        <form onSubmit={handleAdd} className="space-y-3">
+          <div className="space-y-1">
+            <label
+              htmlFor="calendar-ics-url"
+              className="text-sm font-medium text-foreground"
+            >
+              ICS URL
+            </label>
+            <input
+              id="calendar-ics-url"
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://calendar.google.com/calendar/ical/.../basic.ics"
+              required
+              className="
+                h-9 w-full rounded-md border border-border bg-background px-3
+                text-sm placeholder:text-muted-foreground/70
+                focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none
+              "
+            />
+          </div>
+          <div className="space-y-1">
+            <label
+              htmlFor="calendar-ics-label"
+              className="text-sm font-medium text-foreground"
+            >
+              Label{" "}
+              <span className="font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </label>
+            <input
+              id="calendar-ics-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Work calendar"
+              className="
+                h-9 w-full rounded-md border border-border bg-background px-3
+                text-sm placeholder:text-muted-foreground/70
+                focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none
+              "
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button type="submit" disabled={isSaving || !url.trim()}>
+              {isSaving ? "Adding…" : "Add calendar"}
+            </Button>
+            {saveError && (
+              <span className="text-sm text-destructive">{saveError}</span>
+            )}
+          </div>
+        </form>
+      </SettingsCard>
+
+      <SettingsCard title="Connected calendars">
+        {loadError && (
+          <p className="mb-3 text-sm text-destructive">{loadError}</p>
+        )}
+        {sortedSources === null ? (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        ) : sortedSources.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No calendars yet. Add one above to start linking recordings to
+            calendar events.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {sortedSources.map((s) => {
+              const isRefreshing = refreshingId === s.id;
+              const recentCount = recentRefreshCounts[s.id];
+              return (
+                <li
+                  key={s.id}
+                  className="
+                    flex flex-col gap-2 rounded-md border border-border
+                    bg-background p-3 sm:flex-row sm:items-start
+                  "
+                >
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Calendar className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="truncate font-medium">
+                        {s.label?.trim() || s.url}
+                      </span>
+                    </div>
+                    <a
+                      href={s.url}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="
+                        flex items-center gap-1 truncate text-xs
+                        text-muted-foreground hover:text-foreground
+                      "
+                      title={s.url}
+                    >
+                      <ExternalLink className="size-3" />
+                      <span className="truncate">{s.url}</span>
+                    </a>
+                    <div className="text-xs text-muted-foreground">
+                      Last fetched {formatRelative(s.lastFetchedAt)}
+                      {typeof recentCount === "number" && (
+                        <span className="ml-1 text-foreground">
+                          · {recentCount} event{recentCount === 1 ? "" : "s"}
+                        </span>
+                      )}
+                    </div>
+                    {s.lastError && (
+                      <p className="text-xs text-destructive">
+                        Last error: {s.lastError}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void handleRefresh(s.id)}
+                      disabled={isRefreshing}
+                      className="gap-1.5"
+                    >
+                      {isRefreshing ? (
+                        <RefreshCw className="size-3.5 animate-spin" />
+                      ) : recentCount !== undefined && !s.lastError ? (
+                        <Check className="size-3.5" />
+                      ) : (
+                        <RefreshCw className="size-3.5" />
+                      )}
+                      <span>{isRefreshing ? "Fetching…" : "Refresh"}</span>
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void handleRemove(s.id)}
+                      aria-label="Remove calendar"
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </SettingsCard>
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingDetails/CalendarEventPanel.tsx
+++ b/frontend/src/components/MeetingDetails/CalendarEventPanel.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Calendar as CalendarIcon,
+  Link2,
+  Link2Off,
+  MapPin,
+  Users,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  getEventForMeeting,
+  linkMeetingToCalendarEvent,
+  type CalendarEvent,
+} from "@/lib/calendar";
+import { CalendarEventPicker } from "./CalendarEventPicker";
+
+interface CalendarEventPanelProps {
+  meetingId: string;
+}
+
+function formatTimeRange(startIso: string, endIso: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  const dateFmt = start.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const startTime = start.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const endTime = end.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  if (sameDay) {
+    return `${dateFmt} · ${startTime} – ${endTime}`;
+  }
+  return `${dateFmt} ${startTime} – ${end.toLocaleString()}`;
+}
+
+export function CalendarEventPanel({ meetingId }: CalendarEventPanelProps) {
+  const [event, setEvent] = useState<CalendarEvent | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const e = await getEventForMeeting(meetingId);
+      setEvent(e);
+    } catch (err) {
+      console.warn("getEventForMeeting failed:", err);
+      setEvent(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [meetingId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleUnlink = async () => {
+    setIsMutating(true);
+    try {
+      await linkMeetingToCalendarEvent(meetingId, null);
+      setEvent(null);
+    } catch (err) {
+      console.error("Failed to unlink:", err);
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  const handlePickEvent = async (eventId: string | null) => {
+    setIsMutating(true);
+    try {
+      await linkMeetingToCalendarEvent(meetingId, eventId);
+      setIsPickerOpen(false);
+      await reload();
+    } catch (err) {
+      console.error("Failed to link calendar event:", err);
+    } finally {
+      setIsMutating(false);
+    }
+  };
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!event) {
+    return (
+      <>
+        <div
+          className="
+            flex items-center justify-between gap-3 rounded-md border
+            border-dashed border-border px-3 py-2 text-sm
+          "
+        >
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <CalendarIcon className="size-4" />
+            <span>Not linked to a calendar event.</span>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsPickerOpen(true)}
+            className="gap-1.5"
+          >
+            <Link2 className="size-3.5" />
+            Link event
+          </Button>
+        </div>
+        {isPickerOpen && (
+          <CalendarEventPicker
+            onClose={() => setIsPickerOpen(false)}
+            onPick={handlePickEvent}
+            isSaving={isMutating}
+          />
+        )}
+      </>
+    );
+  }
+
+  const attendeeCount = event.attendees.length;
+
+  return (
+    <>
+      <div
+        className="
+          flex flex-col gap-2 rounded-md border border-border bg-muted/40 p-3
+          text-sm sm:flex-row sm:items-start sm:justify-between
+        "
+      >
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="font-medium">
+              {event.summary || "(untitled event)"}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {formatTimeRange(event.startAt, event.endAt)}
+          </div>
+          {event.location && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <MapPin className="size-3" />
+              <span className="truncate">{event.location}</span>
+            </div>
+          )}
+          {attendeeCount > 0 && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Users className="size-3" />
+              <span>
+                {attendeeCount} attendee{attendeeCount === 1 ? "" : "s"}
+                {event.organizerName ? ` · organized by ${event.organizerName}` : ""}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsPickerOpen(true)}
+            disabled={isMutating}
+          >
+            Change
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void handleUnlink()}
+            disabled={isMutating}
+            className="gap-1.5 text-muted-foreground hover:text-destructive"
+          >
+            <Link2Off className="size-3.5" />
+            Unlink
+          </Button>
+        </div>
+      </div>
+
+      {attendeeCount > 0 && (
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {event.attendees.map((a, idx) => {
+            const label = a.name?.trim() || a.email || "Unknown";
+            return (
+              <li
+                key={`${a.email ?? "noemail"}-${idx}`}
+                className="
+                  inline-flex items-center gap-1 rounded-full border border-border
+                  bg-background px-2 py-0.5 text-xs text-foreground
+                "
+                title={a.email ?? undefined}
+              >
+                <span className="truncate max-w-[12rem]">{label}</span>
+                {a.status && (
+                  <span
+                    className="text-[10px] uppercase tracking-wide text-muted-foreground"
+                    title={`Response: ${a.status}`}
+                  >
+                    · {a.status.toLowerCase()}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {isPickerOpen && (
+        <CalendarEventPicker
+          onClose={() => setIsPickerOpen(false)}
+          onPick={handlePickEvent}
+          isSaving={isMutating}
+          currentEventId={event.id}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/MeetingDetails/CalendarEventPanel.tsx
+++ b/frontend/src/components/MeetingDetails/CalendarEventPanel.tsx
@@ -19,6 +19,10 @@ import { CalendarEventPicker } from "./CalendarEventPicker";
 
 interface CalendarEventPanelProps {
   meetingId: string;
+  /** ISO-8601 timestamp the recording started. Used by the picker as the
+   *  anchor for "events around the same time as the transcript was
+   *  captured" instead of falling back to "now". */
+  meetingCreatedAt: string;
 }
 
 function formatTimeRange(startIso: string, endIso: string): string {
@@ -47,7 +51,10 @@ function formatTimeRange(startIso: string, endIso: string): string {
   return `${dateFmt} ${startTime} – ${end.toLocaleString()}`;
 }
 
-export function CalendarEventPanel({ meetingId }: CalendarEventPanelProps) {
+export function CalendarEventPanel({
+  meetingId,
+  meetingCreatedAt,
+}: CalendarEventPanelProps) {
   const [event, setEvent] = useState<CalendarEvent | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -128,6 +135,7 @@ export function CalendarEventPanel({ meetingId }: CalendarEventPanelProps) {
             onClose={() => setIsPickerOpen(false)}
             onPick={handlePickEvent}
             isSaving={isMutating}
+            anchorIso={meetingCreatedAt}
           />
         )}
       </>
@@ -228,6 +236,7 @@ export function CalendarEventPanel({ meetingId }: CalendarEventPanelProps) {
           onPick={handlePickEvent}
           isSaving={isMutating}
           currentEventId={event.id}
+          anchorIso={meetingCreatedAt}
         />
       )}
     </>

--- a/frontend/src/components/MeetingDetails/CalendarEventPicker.tsx
+++ b/frontend/src/components/MeetingDetails/CalendarEventPicker.tsx
@@ -11,7 +11,17 @@ interface CalendarEventPickerProps {
   onPick: (eventId: string | null) => Promise<void> | void;
   isSaving: boolean;
   currentEventId?: string;
+  /** Timestamp the meeting was recorded. The picker centers its event
+   *  window on this and sorts results by proximity so the most likely
+   *  matches surface first. Defaults to "now" when omitted. */
+  anchorIso?: string;
 }
+
+/** ±N days around the anchor when fetching events. Wide enough to cover
+ *  rescheduled meetings or recordings started slightly before/after the
+ *  scheduled slot, narrow enough that the list stays scannable. */
+const WINDOW_DAYS = 7;
+const DAY_MS = 24 * 3600 * 1000;
 
 function formatStart(iso: string): string {
   const d = new Date(iso);
@@ -24,27 +34,49 @@ function formatStart(iso: string): string {
   });
 }
 
+function formatOffset(eventStartMs: number, anchorMs: number): string {
+  const diff = eventStartMs - anchorMs;
+  const abs = Math.abs(diff);
+  if (abs < 60 * 1000) return "at recording time";
+  const sign = diff < 0 ? "before" : "after";
+  if (abs < 3600 * 1000) {
+    return `${Math.round(abs / 60_000)}m ${sign}`;
+  }
+  if (abs < DAY_MS) {
+    return `${Math.round(abs / 3_600_000)}h ${sign}`;
+  }
+  return `${Math.round(abs / DAY_MS)}d ${sign}`;
+}
+
 /**
- * Modal that lists calendar events from the previous 7 days through the
- * next 30 days and lets the user pick one to link a meeting to.
+ * Modal that lists calendar events near the meeting's recording time
+ * (default ±7 days centered on `anchorIso`, falling back to "now") and
+ * lets the user pick one to link the meeting to. Results are sorted by
+ * proximity to the anchor so the most likely matches surface first.
  */
 export function CalendarEventPicker({
   onClose,
   onPick,
   isSaving,
   currentEventId,
+  anchorIso,
 }: CalendarEventPickerProps) {
   const [events, setEvents] = useState<CalendarEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
 
+  const anchorMs = useMemo(() => {
+    if (!anchorIso) return Date.now();
+    const ts = Date.parse(anchorIso);
+    return Number.isFinite(ts) ? ts : Date.now();
+  }, [anchorIso]);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const now = new Date();
-        const from = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
-        const to = new Date(now.getTime() + 30 * 24 * 3600 * 1000);
+        const from = new Date(anchorMs - WINDOW_DAYS * DAY_MS);
+        const to = new Date(anchorMs + WINDOW_DAYS * DAY_MS);
         const list = await listCalendarEvents(from.toISOString(), to.toISOString());
         if (!cancelled) setEvents(list);
       } catch (err) {
@@ -54,18 +86,26 @@ export function CalendarEventPicker({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [anchorMs]);
 
   const filtered = useMemo(() => {
     if (!events) return null;
     const q = query.trim().toLowerCase();
-    if (!q) return events;
-    return events.filter((e) => {
-      const summary = e.summary?.toLowerCase() ?? "";
-      const loc = e.location?.toLowerCase() ?? "";
-      return summary.includes(q) || loc.includes(q);
+    const base = q
+      ? events.filter((e) => {
+          const summary = e.summary?.toLowerCase() ?? "";
+          const loc = e.location?.toLowerCase() ?? "";
+          return summary.includes(q) || loc.includes(q);
+        })
+      : events;
+    // Sort by absolute distance from the anchor so the closest match
+    // (i.e. the meeting that overlapped the recording) is at the top.
+    return [...base].sort((a, b) => {
+      const da = Math.abs(Date.parse(a.startAt) - anchorMs);
+      const db = Math.abs(Date.parse(b.startAt) - anchorMs);
+      return da - db;
     });
-  }, [events, query]);
+  }, [events, query, anchorMs]);
 
   return (
     <div
@@ -128,8 +168,8 @@ export function CalendarEventPicker({
           )}
           {!error && filtered && filtered.length === 0 && (
             <p className="px-3 py-2 text-sm text-muted-foreground">
-              No events in the past 7 days or next 30 days. Try refreshing
-              your calendar in Settings → Calendar.
+              No events within ±{WINDOW_DAYS} days of the recording. Try
+              refreshing your calendar in Settings → Calendar.
             </p>
           )}
           {filtered && filtered.length > 0 && (
@@ -162,6 +202,8 @@ export function CalendarEventPicker({
                         </div>
                         <div className="text-xs text-muted-foreground">
                           {formatStart(e.startAt)}
+                          {" · "}
+                          {formatOffset(Date.parse(e.startAt), anchorMs)}
                           {e.location ? ` · ${e.location}` : ""}
                         </div>
                       </div>

--- a/frontend/src/components/MeetingDetails/CalendarEventPicker.tsx
+++ b/frontend/src/components/MeetingDetails/CalendarEventPicker.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Calendar as CalendarIcon, Search, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { listCalendarEvents, type CalendarEvent } from "@/lib/calendar";
+
+interface CalendarEventPickerProps {
+  onClose: () => void;
+  onPick: (eventId: string | null) => Promise<void> | void;
+  isSaving: boolean;
+  currentEventId?: string;
+}
+
+function formatStart(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Modal that lists calendar events from the previous 7 days through the
+ * next 30 days and lets the user pick one to link a meeting to.
+ */
+export function CalendarEventPicker({
+  onClose,
+  onPick,
+  isSaving,
+  currentEventId,
+}: CalendarEventPickerProps) {
+  const [events, setEvents] = useState<CalendarEvent[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const now = new Date();
+        const from = new Date(now.getTime() - 7 * 24 * 3600 * 1000);
+        const to = new Date(now.getTime() + 30 * 24 * 3600 * 1000);
+        const list = await listCalendarEvents(from.toISOString(), to.toISOString());
+        if (!cancelled) setEvents(list);
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!events) return null;
+    const q = query.trim().toLowerCase();
+    if (!q) return events;
+    return events.filter((e) => {
+      const summary = e.summary?.toLowerCase() ?? "";
+      const loc = e.location?.toLowerCase() ?? "";
+      return summary.includes(q) || loc.includes(q);
+    });
+  }, [events, query]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick a calendar event"
+      className="
+        fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4
+      "
+      onClick={onClose}
+    >
+      <div
+        className="
+          flex w-full max-w-xl flex-col overflow-hidden rounded-lg border
+          border-border bg-background shadow-xl
+        "
+        style={{ maxHeight: "min(80vh, 640px)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold">Link calendar event</h2>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        <div className="border-b border-border p-3">
+          <div className="relative">
+            <Search className="
+              pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2
+              text-muted-foreground
+            " />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search events…"
+              className="
+                h-9 w-full rounded-md border border-border bg-background px-8
+                text-sm placeholder:text-muted-foreground/70
+                focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none
+              "
+              autoFocus
+            />
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          {error && (
+            <p className="px-3 py-2 text-sm text-destructive">{error}</p>
+          )}
+          {!error && filtered === null && (
+            <p className="px-3 py-2 text-sm text-muted-foreground">Loading…</p>
+          )}
+          {!error && filtered && filtered.length === 0 && (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              No events in the past 7 days or next 30 days. Try refreshing
+              your calendar in Settings → Calendar.
+            </p>
+          )}
+          {filtered && filtered.length > 0 && (
+            <ul className="space-y-1">
+              {filtered.map((e) => {
+                const isCurrent = e.id === currentEventId;
+                return (
+                  <li key={e.id}>
+                    <button
+                      type="button"
+                      disabled={isSaving}
+                      onClick={() => void onPick(e.id)}
+                      className={`
+                        flex w-full items-start gap-2 rounded-md px-2 py-2
+                        text-left text-sm
+                        ${isCurrent
+                          ? "bg-info/10 text-info"
+                          : "text-foreground hover:bg-muted"}
+                      `}
+                    >
+                      <CalendarIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium">
+                          {e.summary || "(untitled event)"}
+                          {isCurrent && (
+                            <span className="ml-2 text-xs text-info">
+                              currently linked
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatStart(e.startAt)}
+                          {e.location ? ` · ${e.location}` : ""}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -10,6 +10,7 @@ import { EmptyStateSummary } from "@/components/EmptyStateSummary";
 import { ModelConfig } from "@/components/ModelSettingsModal";
 import { SummaryGeneratorButtonGroup } from "./SummaryGeneratorButtonGroup";
 import { SummaryUpdaterButtonGroup } from "./SummaryUpdaterButtonGroup";
+import { CalendarEventPanel } from "./CalendarEventPanel";
 import { RefObject } from "react";
 
 interface SummaryPanelProps {
@@ -121,6 +122,11 @@ export function SummaryPanel({
           onFinishEditing={onFinishEditTitle}
           onChange={onTitleChange}
         /> */}
+
+        {/* Calendar event link / metadata */}
+        <div className="mb-3">
+          <CalendarEventPanel meetingId={meeting.id} />
+        </div>
 
         {/* Button groups - only show when summary exists */}
         {aiSummary && !isSummaryLoading && (

--- a/frontend/src/components/MeetingDetails/SummaryPanel.tsx
+++ b/frontend/src/components/MeetingDetails/SummaryPanel.tsx
@@ -125,7 +125,10 @@ export function SummaryPanel({
 
         {/* Calendar event link / metadata */}
         <div className="mb-3">
-          <CalendarEventPanel meetingId={meeting.id} />
+          <CalendarEventPanel
+            meetingId={meeting.id}
+            meetingCreatedAt={meeting.created_at}
+          />
         </div>
 
         {/* Button groups - only show when summary exists */}

--- a/frontend/src/hooks/useAudioLevels.ts
+++ b/frontend/src/hooks/useAudioLevels.ts
@@ -18,7 +18,7 @@ interface AudioLevelUpdate {
 }
 
 /**
- * Subscribe to the backend `audio-level-updates` event and start/stop the
+ * Subscribe to the backend `audio-levels` event and start/stop the
  * monitor for the requested device names. Returns the latest level keyed
  * by device_name.
  *
@@ -64,7 +64,7 @@ export function useAudioLevels(
 
       try {
         unlisten = await listen<AudioLevelUpdate>(
-          "audio-level-updates",
+          "audio-levels",
           (event) => {
             const next = new Map<string, AudioLevel>();
             for (const lvl of event.payload.levels) {
@@ -74,7 +74,7 @@ export function useAudioLevels(
           },
         );
       } catch (err) {
-        console.error("Failed to subscribe to audio-level-updates:", err);
+        console.error("Failed to subscribe to audio-levels:", err);
       }
     })();
 

--- a/frontend/src/hooks/useRecordingStart.ts
+++ b/frontend/src/hooks/useRecordingStart.ts
@@ -9,6 +9,7 @@ import {
 } from "@/contexts/RecordingStateContext";
 import { recordingService } from "@/services/recordingService";
 import { showRecordingNotification } from "@/lib/recordingNotification";
+import { prepareRecordingMetadata } from "@/lib/recordingCalendarLink";
 import { toast } from "sonner";
 import { getErrorMessage } from "@/lib/utils";
 
@@ -39,18 +40,6 @@ export function useRecordingStart(
   const { setIsMeetingActive } = useSidebar();
   const { selectedDevices } = useConfig();
   const { setStatus } = useRecordingState();
-
-  // Generate meeting title with timestamp
-  const generateMeetingTitle = useCallback(() => {
-    const now = new Date();
-    const day = String(now.getDate()).padStart(2, "0");
-    const month = String(now.getMonth() + 1).padStart(2, "0");
-    const year = String(now.getFullYear()).slice(-2);
-    const hours = String(now.getHours()).padStart(2, "0");
-    const minutes = String(now.getMinutes()).padStart(2, "0");
-    const seconds = String(now.getSeconds()).padStart(2, "0");
-    return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
-  }, []);
 
   // Check if a local Whisper transcription model is downloaded and ready.
   // Function name kept as `checkParakeetReady` for minimal call-site churn —
@@ -114,18 +103,24 @@ export function useRecordingStart(
 
       console.log("Parakeet ready - setting up meeting title and state");
 
-      const randomTitle = generateMeetingTitle();
-      setMeetingTitle(randomTitle);
+      const { meetingTitle, calendarEvent } = await prepareRecordingMetadata();
+      setMeetingTitle(meetingTitle);
+      if (calendarEvent) {
+        toast.info(`Linked to "${meetingTitle}" from your calendar`, {
+          description: "We'll attach the event details when the meeting saves.",
+          duration: 4000,
+        });
+      }
 
       // Set STARTING status before initiating backend recording
       setStatus(RecordingStatus.STARTING, "Initializing recording...");
 
       // Start the actual backend recording
-      console.log("Starting backend recording with meeting:", randomTitle);
+      console.log("Starting backend recording with meeting:", meetingTitle);
       await recordingService.startRecordingWithDevices(
         selectedDevices?.micDevice || null,
         selectedDevices?.systemDevice || null,
-        randomTitle,
+        meetingTitle,
       );
       console.log("Backend recording started successfully");
 
@@ -149,7 +144,6 @@ export function useRecordingStart(
       throw error;
     }
   }, [
-    generateMeetingTitle,
     setMeetingTitle,
     setIsRecording,
     clearTranscripts,
@@ -199,8 +193,18 @@ export function useRecordingStart(
 
           // Start the actual backend recording
           try {
-            // Generate meeting title
-            const generatedMeetingTitle = generateMeetingTitle();
+            const { meetingTitle: generatedMeetingTitle, calendarEvent } =
+              await prepareRecordingMetadata();
+            if (calendarEvent) {
+              toast.info(
+                `Linked to "${generatedMeetingTitle}" from your calendar`,
+                {
+                  description:
+                    "We'll attach the event details when the meeting saves.",
+                  duration: 4000,
+                },
+              );
+            }
 
             // Set STARTING status before initiating backend recording
             setStatus(RecordingStatus.STARTING, "Initializing recording...");
@@ -244,7 +248,6 @@ export function useRecordingStart(
     isRecording,
     isAutoStarting,
     selectedDevices,
-    generateMeetingTitle,
     setMeetingTitle,
     setIsRecording,
     clearTranscripts,
@@ -292,8 +295,18 @@ export function useRecordingStart(
       }
 
       try {
-        // Generate meeting title
-        const generatedMeetingTitle = generateMeetingTitle();
+        const { meetingTitle: generatedMeetingTitle, calendarEvent } =
+          await prepareRecordingMetadata();
+        if (calendarEvent) {
+          toast.info(
+            `Linked to "${generatedMeetingTitle}" from your calendar`,
+            {
+              description:
+                "We'll attach the event details when the meeting saves.",
+              duration: 4000,
+            },
+          );
+        }
 
         // Set STARTING status before initiating backend recording
         setStatus(RecordingStatus.STARTING, "Initializing recording...");
@@ -342,7 +355,6 @@ export function useRecordingStart(
     isRecording,
     isAutoStarting,
     selectedDevices,
-    generateMeetingTitle,
     setMeetingTitle,
     setIsRecording,
     clearTranscripts,

--- a/frontend/src/hooks/useRecordingStop.ts
+++ b/frontend/src/hooks/useRecordingStop.ts
@@ -11,6 +11,8 @@ import {
 import { storageService } from "@/services/storageService";
 import { transcriptService } from "@/services/transcriptService";
 import { getErrorMessage } from "@/lib/utils";
+import { linkMeetingToCalendarEvent } from "@/lib/calendar";
+import { consumePendingCalendarEventId } from "@/lib/recordingCalendarLink";
 
 type SummaryStatus =
   | "idle"
@@ -318,6 +320,25 @@ export function useRecordingStop(
             );
             console.log("   Transcripts:", freshTranscripts.length);
             console.log("   folder_path:", folderPath);
+
+            // If a calendar event was matched at recording start, link the
+            // saved meeting to it now that we have a meeting_id. Failure is
+            // non-fatal — the user can still link manually from the meeting
+            // detail page.
+            const pendingEventId = consumePendingCalendarEventId();
+            if (pendingEventId) {
+              try {
+                await linkMeetingToCalendarEvent(meetingId, pendingEventId);
+                console.log(
+                  "📅 Linked meeting",
+                  meetingId,
+                  "to calendar event",
+                  pendingEventId,
+                );
+              } catch (err) {
+                console.warn("Failed to link meeting to calendar event:", err);
+              }
+            }
 
             // Mark meeting as saved in IndexedDB (for recovery system)
             await markMeetingAsSaved();

--- a/frontend/src/lib/calendar.ts
+++ b/frontend/src/lib/calendar.ts
@@ -1,0 +1,113 @@
+// Frontend wrappers for the calendar/ICS Tauri commands. Keeps command
+// names and DTO shapes in one place — the Rust side serializes events
+// using camelCase via `#[serde(rename = ...)]` so the TS shapes match
+// directly.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface CalendarSource {
+  id: string;
+  url: string;
+  label: string | null;
+  lastFetchedAt: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CalendarAttendee {
+  name: string | null;
+  email: string | null;
+  role: string | null;
+  status: string | null;
+  isOrganizer: boolean;
+}
+
+export interface CalendarEvent {
+  id: string;
+  sourceId: string;
+  icsUid: string;
+  recurrenceId: string | null;
+  summary: string | null;
+  description: string | null;
+  location: string | null;
+  organizerName: string | null;
+  organizerEmail: string | null;
+  /** ISO-8601 UTC string. */
+  startAt: string;
+  /** ISO-8601 UTC string. */
+  endAt: string;
+  isAllDay: boolean;
+  attendees: CalendarAttendee[];
+}
+
+export interface CalendarRefreshResult {
+  sourceId: string;
+  eventCount: number;
+}
+
+export async function listCalendarSources(): Promise<CalendarSource[]> {
+  return invoke<CalendarSource[]>("calendar_list_sources");
+}
+
+export async function addCalendarSource(
+  url: string,
+  label?: string | null,
+): Promise<CalendarSource> {
+  return invoke<CalendarSource>("calendar_add_source", {
+    url,
+    label: label ?? null,
+  });
+}
+
+export async function removeCalendarSource(sourceId: string): Promise<boolean> {
+  return invoke<boolean>("calendar_remove_source", { sourceId });
+}
+
+export async function updateCalendarSourceLabel(
+  sourceId: string,
+  label: string | null,
+): Promise<boolean> {
+  return invoke<boolean>("calendar_update_source_label", { sourceId, label });
+}
+
+export async function refreshCalendarSource(
+  sourceId: string,
+): Promise<CalendarRefreshResult> {
+  return invoke<CalendarRefreshResult>("calendar_refresh_source", { sourceId });
+}
+
+export async function refreshAllCalendarSources(): Promise<CalendarRefreshResult[]> {
+  return invoke<CalendarRefreshResult[]>("calendar_refresh_all");
+}
+
+export async function listCalendarEvents(
+  fromIso: string,
+  toIso: string,
+): Promise<CalendarEvent[]> {
+  return invoke<CalendarEvent[]>("calendar_list_events", {
+    request: { from: fromIso, to: toIso },
+  });
+}
+
+export async function findCalendarEventForNow(): Promise<CalendarEvent | null> {
+  return invoke<CalendarEvent | null>("calendar_find_event_for_now");
+}
+
+export async function linkMeetingToCalendarEvent(
+  meetingId: string,
+  eventId: string | null,
+): Promise<boolean> {
+  return invoke<boolean>("calendar_link_meeting", {
+    meetingId,
+    eventId,
+  });
+}
+
+export async function getEventForMeeting(
+  meetingId: string,
+): Promise<CalendarEvent | null> {
+  return invoke<CalendarEvent | null>("calendar_get_event_for_meeting", {
+    meetingId,
+  });
+}

--- a/frontend/src/lib/recordingCalendarLink.ts
+++ b/frontend/src/lib/recordingCalendarLink.ts
@@ -1,0 +1,90 @@
+// Glue between the recording lifecycle and the calendar feature.
+//
+// The Tauri side only inserts the meeting row when the transcript is saved
+// (after the recording stops), so we can't pass a calendar_event_id at
+// `start_recording_with_devices_and_meeting` time. Instead the start path
+// resolves "what event is happening right now?" from the calendar
+// repository and stashes the event id; the stop path reads it back after
+// `api_save_transcript` returns a `meeting_id` and creates the link.
+//
+// sessionStorage is sufficient because the recording lifecycle is single-
+// tab and the value's only consumer is the stop hook in the same tab.
+
+import {
+  findCalendarEventForNow,
+  type CalendarEvent,
+} from "./calendar";
+
+const PENDING_EVENT_KEY = "calendar:pendingEventId";
+const PENDING_EVENT_SUMMARY_KEY = "calendar:pendingEventSummary";
+
+export interface RecordingMetadata {
+  meetingTitle: string;
+  calendarEvent: CalendarEvent | null;
+}
+
+function timestampTitle(): string {
+  const now = new Date();
+  const day = String(now.getDate()).padStart(2, "0");
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const year = String(now.getFullYear()).slice(-2);
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+  return `Meeting ${day}_${month}_${year}_${hours}_${minutes}_${seconds}`;
+}
+
+/**
+ * Resolve the meeting title + matching calendar event for a recording that
+ * is about to start. Prefers the calendar event's summary as the title
+ * when an event is currently active; falls back to a timestamp-based
+ * title otherwise. Stashes the event id (if any) so the stop hook can
+ * link the freshly-saved meeting to it.
+ */
+export async function prepareRecordingMetadata(): Promise<RecordingMetadata> {
+  let event: CalendarEvent | null = null;
+  try {
+    event = await findCalendarEventForNow();
+  } catch (err) {
+    console.warn("calendar lookup for current event failed:", err);
+  }
+
+  const summary = event?.summary?.trim();
+  const title = summary || timestampTitle();
+
+  if (typeof window !== "undefined") {
+    if (event) {
+      sessionStorage.setItem(PENDING_EVENT_KEY, event.id);
+      sessionStorage.setItem(PENDING_EVENT_SUMMARY_KEY, summary || "");
+    } else {
+      sessionStorage.removeItem(PENDING_EVENT_KEY);
+      sessionStorage.removeItem(PENDING_EVENT_SUMMARY_KEY);
+    }
+  }
+
+  return { meetingTitle: title, calendarEvent: event };
+}
+
+/** Read + clear the pending calendar event id stashed at recording start. */
+export function consumePendingCalendarEventId(): string | null {
+  if (typeof window === "undefined") return null;
+  const id = sessionStorage.getItem(PENDING_EVENT_KEY);
+  sessionStorage.removeItem(PENDING_EVENT_KEY);
+  sessionStorage.removeItem(PENDING_EVENT_SUMMARY_KEY);
+  return id;
+}
+
+/** Peek without clearing — used by UI surfaces that want to show the link
+ *  during recording. */
+export function peekPendingCalendarEvent(): {
+  id: string;
+  summary: string;
+} | null {
+  if (typeof window === "undefined") return null;
+  const id = sessionStorage.getItem(PENDING_EVENT_KEY);
+  if (!id) return null;
+  return {
+    id,
+    summary: sessionStorage.getItem(PENDING_EVENT_SUMMARY_KEY) ?? "",
+  };
+}


### PR DESCRIPTION
## Summary

Adds an ICS calendar integration that auto-links recordings to whatever event is happening *now*, plus a couple of unrelated tactical fixes that landed on this branch.

### Calendar (main feature, 5 commits)
- **Rust core** — `calendar_sources` + `calendar_events` schema (with `meetings.calendar_event_id` link), `ical`-based parser with `rrule` expansion over a -7d/+90d window, `reqwest` fetcher, sqlx repository, and Tauri commands for source CRUD, refresh, range queries, find-event-for-now, and meeting↔event linking. Tests cover simple parse, recurring expansion, and ISO duration parsing.
- **Settings panel** — new "Calendar" section to add public ICS URLs (with optional label) and manage connected sources, including last-fetched / recent-event-count / last-error status and per-source Refresh / Remove.
- **Auto-link on record** — recording start resolves the current event, sets it as the meeting title, and on stop calls `calendar_link_meeting`. Toast confirms.
- **Manual picker** — `CalendarEventPanel` + `CalendarEventPicker` on the meeting detail page. Anchored on the meeting's `created_at` so old recordings find the right event, sorted by distance from anchor with "5m before" / "1h after" offsets shown.
- **Sidecar snapshot** — drop `calendar_event.json` (summary/description/location/organizer/attendees/time range) in the meeting folder on link; re-link overwrites, unlink deletes. DB row stays the source of truth.

### Audio fixes (bundled, not calendar-related)
- **PulseAudio monitor sources via `pactl`** — cpal's ALSA backend can't see `*.monitor` sources on PipeWire/PulseAudio, which hid every "System Audio" picker entry on modern Linux. Now shelled out via `pactl list sources`, with `PIPEWIRE_NODE` set when opening cpal to bind to the right source. Falls back to the previous cpal scan when `pactl` isn't available.
- **Recording-page level meter actually works** — the Rust `simple_level_monitor` was a sine-wave stub *and* the frontend listened for the wrong event name. Replaced with a real cpal-based monitor that emits the event name the hook already listens for, with the same `PIPEWIRE_NODE` redirect for `(System Audio)` entries.

### Other
- **`summary.md` mirror** — both auto-generated and manually-saved summaries now drop a portable `summary.md` next to `metadata.json` / `transcripts.json` in the recording folder (atomic write, non-fatal on failure).

## Test plan
- [ ] Add a public ICS URL in Settings → Calendar; verify fetch succeeds and events appear with status
- [ ] Start a recording during a scheduled event → title auto-fills, link toast appears
- [ ] Open an older meeting → calendar picker shows events within ±7d of `created_at`, sorted by distance
- [ ] Change / unlink an event from the picker → `calendar_event.json` updates / disappears
- [ ] On Linux/PipeWire: pick a `(System Audio)` source in the device picker → recording captures system audio
- [ ] Recording page level meter shows real RMS for both mic and system devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)