### PR TITLE
feat(diarization): accurate offline speaker diarization on import (+ number-of-speakers)

### DIFF
--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -254,6 +254,7 @@ pub async fn start_import<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    num_speakers: i32,
 ) -> Result<ImportResult> {
     // Acquire guard - ensures flag is cleared even on panic/early return
     let _guard = ImportGuard::acquire().map_err(|e| anyhow!(e))?;
@@ -261,7 +262,16 @@ pub async fn start_import<R: Runtime>(
     // Reset cancellation flag
     IMPORT_CANCELLED.store(false, Ordering::SeqCst);
 
-    let result = run_import(app.clone(), source_path, title, language, model, provider).await;
+    let result = run_import(
+        app.clone(),
+        source_path,
+        title,
+        language,
+        model,
+        provider,
+        num_speakers,
+    )
+    .await;
 
     // Unload the engine after the batch job (success, failure, or cancellation)
     super::common::unload_engine_after_batch().await;
@@ -302,6 +312,7 @@ async fn run_import<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    num_speakers: i32,
 ) -> Result<ImportResult> {
     let source = PathBuf::from(&source_path);
 
@@ -410,6 +421,10 @@ async fn run_import<R: Runtime>(
         let _ = std::fs::remove_dir_all(&meeting_folder);
         return Err(anyhow!("Import cancelled"));
     }
+
+    // Keep a copy of the full 16 kHz buffer for offline diarization — the VAD
+    // spawn_blocking below moves `audio_samples` into its closure.
+    let audio_for_diar = audio_samples.clone();
 
     // Use VAD to find speech segments
     let app_for_vad = app.clone();
@@ -533,6 +548,48 @@ async fn run_import<R: Runtime>(
         info!("Speaker diarization enabled for import");
     }
 
+    // Accurate (offline) diarization over the WHOLE file: pyannote segmentation
+    // + global clustering, optionally told the exact speaker count. This is far
+    // more accurate than the per-segment online clusterer, and — since import
+    // is a single clean source — is the right tool here. Falls back to the
+    // online diarizer above if the segmentation model isn't present.
+    let offline_turns: Option<Vec<crate::speaker_diarization::offline::SpeakerTurn>> =
+        if total_segments > 0 {
+            match (
+                crate::speaker_diarization::model::pyannote_segmentation_path(),
+                crate::speaker_diarization::model::default_model_path(),
+            ) {
+                (Some(seg), Some(emb)) if seg.exists() && emb.exists() => {
+                    match crate::speaker_diarization::offline::diarize_offline(
+                        &audio_for_diar,
+                        &seg,
+                        &emb,
+                        num_speakers,
+                        2,
+                    ) {
+                        Ok(turns) => {
+                            info!(
+                                "Offline diarization ready: {} turns (num_speakers={})",
+                                turns.len(),
+                                num_speakers
+                            );
+                            Some(turns)
+                        }
+                        Err(e) => {
+                            warn!("Offline diarization failed ({e}); using online diarizer");
+                            None
+                        }
+                    }
+                }
+                _ => {
+                    info!("Pyannote segmentation model absent; using online diarizer");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
     // Split very long segments at silence boundaries for better transcription quality.
     // Hard cuts at arbitrary sample positions lose words at boundaries. Instead, scan
     // for the lowest-energy window near the target split point and cut there.
@@ -620,19 +677,27 @@ async fn run_import<R: Runtime>(
                     trimmed
                 }
             );
-            // Run the diarizer (if available) on the segment audio.
-            let (speaker, voice_profile_id) = match diarizer.as_ref() {
-                Some(d) => match d.process(i as u64, &segment.samples) {
-                    Ok(result) => (Some(result.label), result.voice_profile_id),
-                    Err(e) => {
-                        debug!(
-                            "Diarization fallback for import segment {}: {}",
-                            i, e
-                        );
-                        (None, None)
-                    }
-                },
-                None => (None, None),
+            // Speaker attribution: prefer the accurate offline diarization
+            // (label this segment by which speaker turn overlaps it most);
+            // fall back to the per-segment online diarizer if offline is off.
+            let (speaker, voice_profile_id) = if let Some(turns) = offline_turns.as_ref() {
+                let start_s = segment.start_timestamp_ms as f32 / 1000.0;
+                let end_s = segment.end_timestamp_ms as f32 / 1000.0;
+                (
+                    crate::speaker_diarization::offline::speaker_for_range(turns, start_s, end_s),
+                    None,
+                )
+            } else {
+                match diarizer.as_ref() {
+                    Some(d) => match d.process(i as u64, &segment.samples) {
+                        Ok(result) => (Some(result.label), result.voice_profile_id),
+                        Err(e) => {
+                            debug!("Diarization fallback for import segment {}: {}", i, e);
+                            (None, None)
+                        }
+                    },
+                    None => (None, None),
+                }
             };
 
             all_transcripts.push(BatchTranscript {
@@ -968,15 +1033,20 @@ pub async fn start_import_audio_command<R: Runtime>(
     language: Option<String>,
     model: Option<String>,
     provider: Option<String>,
+    num_speakers: Option<i32>,
 ) -> Result<ImportStarted, String> {
     // Check if import is already in progress (guard will be acquired in start_import)
     if IMPORT_IN_PROGRESS.load(Ordering::SeqCst) {
         return Err("Import already in progress".to_string());
     }
 
+    // 0 / absent → auto-estimate the speaker count.
+    let num_speakers = num_speakers.unwrap_or(0);
+
     // Spawn import in background
     tauri::async_runtime::spawn(async move {
-        let result = start_import(app, source_path, title, language, model, provider).await;
+        let result =
+            start_import(app, source_path, title, language, model, provider, num_speakers).await;
 
         if let Err(e) = result {
             error!("Import failed: {}", e);

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -502,6 +502,28 @@ async fn ensure_required_models_downloaded<R: Runtime>(app: &AppHandle<R>) {
         }
     }
 
+    // ── Pyannote segmentation (offline / accurate diarization) ──
+    if let Some(seg_path) = speaker_diarization::model::pyannote_segmentation_path() {
+        if !speaker_diarization::model::model_is_ready(&seg_path) {
+            let url = speaker_diarization::model::pyannote_segmentation_download_url();
+            log::info!(
+                "[startup-download] pyannote segmentation missing — fetching {} (~5.7MB, one-time)",
+                url
+            );
+            match download_file_to(url, &seg_path).await {
+                Ok(()) => log::info!(
+                    "[startup-download] pyannote segmentation downloaded → {}",
+                    seg_path.display()
+                ),
+                Err(e) => log::warn!(
+                    "[startup-download] pyannote segmentation download failed: {} \
+                     (accurate offline diarization falls back to the online clusterer)",
+                    e
+                ),
+            }
+        }
+    }
+
     // ── Speaker embedding ──
     let Some(speaker_path) = speaker_diarization::default_model_path() else {
         log::warn!(

--- a/frontend/src-tauri/src/speaker_diarization/mod.rs
+++ b/frontend/src-tauri/src/speaker_diarization/mod.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, Mutex};
 pub(crate) mod clusterer;
 mod embedder;
 pub mod model;
+pub mod offline;
 mod profile_matcher;
 mod refinement;
 

--- a/frontend/src-tauri/src/speaker_diarization/model.rs
+++ b/frontend/src-tauri/src/speaker_diarization/model.rs
@@ -22,6 +22,16 @@ pub const DEFAULT_MODEL_FILENAME: &str =
 /// runtime artefacts. Tiny (~2.3 MB).
 pub const SILERO_VAD_FILENAME: &str = "silero_vad.onnx";
 
+/// Pyannote segmentation model (ONNX) used by sherpa-onnx's *offline* speaker
+/// diarization. Unlike the online cosine clusterer, offline diarization does
+/// proper global clustering (and can be told the exact number of speakers),
+/// which is far more accurate. ~5.7 MB. Only needed for Import / re-diarize.
+pub const PYANNOTE_SEG_FILENAME: &str = "pyannote_segmentation_3_0.onnx";
+
+/// Direct ONNX download (HuggingFace), matching the single-file downloader.
+const PYANNOTE_SEG_URL: &str =
+    "https://huggingface.co/csukuangfj/sherpa-onnx-pyannote-segmentation-3-0/resolve/main/model.onnx";
+
 const MODEL_BASE_URL: &str =
     "https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models";
 
@@ -80,6 +90,16 @@ pub fn silero_vad_path() -> Option<PathBuf> {
 /// Download URL for the silero-vad model.
 pub fn silero_vad_download_url() -> &'static str {
     SILERO_VAD_URL
+}
+
+/// Path to the pyannote segmentation model (offline diarization).
+pub fn pyannote_segmentation_path() -> Option<PathBuf> {
+    models_dir().map(|d| d.join(PYANNOTE_SEG_FILENAME))
+}
+
+/// Download URL for the pyannote segmentation model.
+pub fn pyannote_segmentation_download_url() -> &'static str {
+    PYANNOTE_SEG_URL
 }
 
 /// True when the model file exists on disk and is non-empty.

--- a/frontend/src-tauri/src/speaker_diarization/offline.rs
+++ b/frontend/src-tauri/src/speaker_diarization/offline.rs
@@ -1,0 +1,117 @@
+//! Offline (batch) speaker diarization via sherpa-onnx.
+//!
+//! Unlike the online cosine clusterer (which greedily seeds a new speaker
+//! whenever a snippet dips below a similarity threshold, and so over-counts),
+//! this runs pyannote segmentation + speaker embeddings + global clustering
+//! over the *entire* recording at once. It can be told the exact number of
+//! speakers (`num_speakers`) for an exact result, or auto-estimate.
+//!
+//! Requires the whole audio buffer, so it only runs on Import / re-diarize,
+//! never live. Input must be 16 kHz mono f32 (what the import path produces).
+
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use sherpa_onnx::{
+    FastClusteringConfig, OfflineSpeakerDiarization, OfflineSpeakerDiarizationConfig,
+    OfflineSpeakerSegmentationModelConfig, OfflineSpeakerSegmentationPyannoteModelConfig,
+    SpeakerEmbeddingExtractorConfig,
+};
+
+/// A diarized speaker turn: `[start, end)` seconds → 0-based speaker index.
+#[derive(Debug, Clone, Copy)]
+pub struct SpeakerTurn {
+    pub start: f32,
+    pub end: f32,
+    pub speaker: i32,
+}
+
+/// Run offline diarization on 16 kHz mono `samples`.
+///
+/// `num_speakers > 0` forces exactly that many clusters; `<= 0` auto-estimates.
+pub fn diarize_offline(
+    samples: &[f32],
+    segmentation_model: &Path,
+    embedding_model: &Path,
+    num_speakers: i32,
+    num_threads: i32,
+) -> Result<Vec<SpeakerTurn>> {
+    if !segmentation_model.exists() {
+        return Err(anyhow!(
+            "Pyannote segmentation model missing at {}",
+            segmentation_model.display()
+        ));
+    }
+    if !embedding_model.exists() {
+        return Err(anyhow!(
+            "Speaker embedding model missing at {}",
+            embedding_model.display()
+        ));
+    }
+
+    let config = OfflineSpeakerDiarizationConfig {
+        segmentation: OfflineSpeakerSegmentationModelConfig {
+            pyannote: OfflineSpeakerSegmentationPyannoteModelConfig {
+                model: Some(segmentation_model.to_string_lossy().into_owned()),
+            },
+            num_threads,
+            debug: false,
+            provider: Some("cpu".to_string()),
+        },
+        embedding: SpeakerEmbeddingExtractorConfig {
+            model: Some(embedding_model.to_string_lossy().into_owned()),
+            num_threads,
+            debug: false,
+            provider: Some("cpu".to_string()),
+        },
+        clustering: FastClusteringConfig {
+            num_clusters: if num_speakers > 0 { num_speakers } else { -1 },
+            threshold: 0.5,
+        },
+        min_duration_on: 0.3,
+        min_duration_off: 0.5,
+    };
+
+    let sd = OfflineSpeakerDiarization::create(&config)
+        .ok_or_else(|| anyhow!("Failed to create OfflineSpeakerDiarization"))?;
+
+    let result = sd
+        .process(samples)
+        .ok_or_else(|| anyhow!("Offline diarization returned no result"))?;
+
+    let turns: Vec<SpeakerTurn> = result
+        .sort_by_start_time()
+        .into_iter()
+        .map(|s| SpeakerTurn {
+            start: s.start,
+            end: s.end,
+            speaker: s.speaker,
+        })
+        .collect();
+
+    log::info!(
+        "Offline diarization: {} turns across {} speaker(s) (requested={})",
+        turns.len(),
+        result.num_speakers(),
+        num_speakers
+    );
+
+    Ok(turns)
+}
+
+/// Label a transcript segment `[start_s, end_s]` with the speaker whose turn
+/// overlaps it the most. Returns e.g. `"Speaker 1"`, or `None` if no overlap.
+pub fn speaker_for_range(turns: &[SpeakerTurn], start_s: f32, end_s: f32) -> Option<String> {
+    let mut best: Option<(i32, f32)> = None;
+    for t in turns {
+        let overlap = (end_s.min(t.end) - start_s.max(t.start)).max(0.0);
+        if overlap <= 0.0 {
+            continue;
+        }
+        match best {
+            Some((_, best_overlap)) if best_overlap >= overlap => {}
+            _ => best = Some((t.speaker, overlap)),
+        }
+    }
+    best.map(|(spk, _)| format!("Speaker {}", spk + 1))
+}

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -8,6 +8,7 @@ import React, {
 import {
   Upload,
   Globe,
+  Users,
   AlertCircle,
   CheckCircle2,
   X,
@@ -85,6 +86,8 @@ export function ImportAudioDialog({
 
   const [title, setTitle] = useState("");
   const [selectedLang, setSelectedLang] = useState(selectedLanguage || "auto");
+  // 0 = auto-estimate the number of speakers; >0 forces exactly that many.
+  const [numSpeakers, setNumSpeakers] = useState(0);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [titleModifiedByUser, setTitleModifiedByUser] = useState(false);
 
@@ -215,6 +218,7 @@ export function ImportAudioDialog({
       effectiveLang === "auto" ? null : effectiveLang,
       selectedModel?.name || null,
       selectedModel?.provider || null,
+      numSpeakers,
     );
   };
 
@@ -421,6 +425,36 @@ export function ImportAudioDialog({
                             ))}
                           </SelectContent>
                         </Select>
+                      </div>
+
+                      {/* Number of speakers (accurate offline diarization) */}
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Users className="size-4 text-muted-foreground" />
+                          <span className="text-sm font-medium">
+                            Number of speakers
+                          </span>
+                        </div>
+                        <Select
+                          value={String(numSpeakers)}
+                          onValueChange={(v) => setNumSpeakers(Number(v))}
+                        >
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Auto-detect" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="0">Auto-detect</SelectItem>
+                            {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
+                              <SelectItem key={n} value={String(n)}>
+                                {n} speaker{n > 1 ? "s" : ""}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <p className="text-xs text-muted-foreground">
+                          Set the exact count for the most accurate labels, or
+                          leave on Auto-detect.
+                        </p>
                       </div>
 
                       {/* Model selector */}

--- a/frontend/src/hooks/meeting-details/useCopyOperations.ts
+++ b/frontend/src/hooks/meeting-details/useCopyOperations.ts
@@ -75,10 +75,16 @@ export function useCopyOperations({
     const date = `## Date: ${new Date(meeting.created_at).toLocaleDateString()}\n\n`;
     // Old transcripts predate audio_start_time and fall back to wall-clock time
     const fullTranscript = allTranscripts
-      .map(
-        (t) =>
-          `${t.audio_start_time !== undefined ? formatRecordingTime(t.audio_start_time) : t.timestamp} ${t.text}  `,
-      )
+      .map((t) => {
+        const time =
+          t.audio_start_time !== undefined
+            ? formatRecordingTime(t.audio_start_time)
+            : t.timestamp;
+        // Include the diarized speaker when present so exported/copied
+        // transcripts carry "who said what", not just timestamped text.
+        const who = t.speaker ? `${t.speaker}: ` : "";
+        return `${time} ${who}${t.text}  `;
+      })
       .join("\n");
 
     await navigator.clipboard.writeText(header + date + fullTranscript);

--- a/frontend/src/hooks/useImportAudio.ts
+++ b/frontend/src/hooks/useImportAudio.ts
@@ -54,6 +54,7 @@ export interface UseImportAudioReturn {
     language?: string | null,
     model?: string | null,
     provider?: string | null,
+    numSpeakers?: number | null,
   ) => Promise<void>;
   cancelImport: () => Promise<void>;
   reset: () => void;
@@ -213,6 +214,7 @@ export function useImportAudio({
       language?: string | null,
       model?: string | null,
       provider?: string | null,
+      numSpeakers?: number | null,
     ) => {
       isCancelledRef.current = false;
       setStatus("processing");
@@ -226,6 +228,8 @@ export function useImportAudio({
           language: language || null,
           model: model || null,
           provider: provider || null,
+          // 0 / null → auto-estimate the number of speakers.
+          numSpeakers: numSpeakers ?? null,
         });
       } catch (err: any) {
         setStatus("error");


### PR DESCRIPTION
## Description

Adds accurate **offline speaker diarization** on the Import path via sherpa-onnx's `OfflineSpeakerDiarization` (pyannote segmentation + global clustering), with an optional **"Number of speakers"** control.

The existing online cosine-similarity clusterer seeds a new speaker whenever a snippet dips below a fixed threshold, so it over-clusters (observed ~9 "speakers" for a 3-person clip, same utterance split across IDs). Offline clustering is global over the whole file and can be told the exact count.

## Related Issue

Closes #9

## Type of Change
- [x] New feature
- [x] Bug fix (transcript copy/export dropped the speaker label)

## Changes
- New `speaker_diarization::offline` module: `diarize_offline()` + `speaker_for_range()` (overlap-based per-segment labeling).
- Reuses the existing CAM++ embedding model; downloads the pyannote segmentation model (~6 MB) at startup alongside the current silero-vad / embedding models.
- Import dialog: **"Number of speakers"** selector (Auto-detect, or 1–8).
- Threads `num_speakers` through `start_import_audio_command` → `start_import` → `run_import`.
- Falls back to the existing online diarizer when the segmentation model is absent; **live recording is unchanged** (offline needs the whole file).
- Fixes transcript copy/export to include the diarized speaker label.

## Testing
- [x] Manual testing performed — Import a multi-speaker clip, set **Number of speakers = 3**, verify clean labels + no duplication; also verified Auto-detect
- [ ] Unit tests added/updated
- [x] Builds & runs (macOS / Apple Silicon)

## Documentation
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed

## Notes
Developed and verified on **macOS (Apple Silicon)**. Platform-agnostic Rust + React reusing the existing `sherpa-onnx` dependency, but I don't have Windows/Linux to build-test those targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
