### PR TITLE
Performance and packaging batch: model residency, transcript journal, render fixes, CI AppImage checks

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -48,8 +48,9 @@ concurrency:
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
-  WHISPER_NO_AVX: ON
-  WHISPER_NO_AVX2: ON
+  # linuxdeploy's bundled `strip` chokes on SHT_RELR sections in modern libs
+  # (same workaround as build.sh); the release profile already strips symbols.
+  NO_STRIP: 1
 
 jobs:
   build-linux:
@@ -87,13 +88,11 @@ jobs:
 
           # Determine bundle arguments
           BUNDLE_TYPE="${{ github.event.inputs.bundle-type }}"
+          # AppImage is the only supported bundle: deb/rpm do not carry
+          # libsherpa-onnx-c-api.so and fail on a clean host (see
+          # docs/building_in_linux.md). Keep the input for experiments only.
           if [[ "$BUNDLE_TYPE" == "all" ]] || [[ -z "$BUNDLE_TYPE" ]]; then
-            # Default based on Ubuntu version
-            if [[ "${{ github.event.inputs.ubuntu-version }}" == "ubuntu-24.04" ]]; then
-              BUNDLES="appimage,rpm"
-            else
-              BUNDLES="deb"
-            fi
+            BUNDLES="appimage"
           else
             BUNDLES="$BUNDLE_TYPE"
           fi
@@ -144,7 +143,7 @@ jobs:
         if: github.event.inputs.ubuntu-version == 'ubuntu-24.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev \
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libpipewire-0.3-dev libclang-dev meson ninja-build \
             libwebkit2gtk-4.1-0=2.44.0-2 \
             libwebkit2gtk-4.1-dev=2.44.0-2 \
             libjavascriptcoregtk-4.1-0=2.44.0-2 \
@@ -156,25 +155,7 @@ jobs:
         if: github.event.inputs.ubuntu-version == 'ubuntu-22.04' || github.event.inputs.ubuntu-version == ''
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
-
-      - name: Prepare Vulkan SDK (Ubuntu 24.04)
-        if: github.event.inputs.ubuntu-version == 'ubuntu-24.04'
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
-          sudo apt update
-          sudo apt install vulkan-sdk -y
-          sudo apt-get install -y mesa-vulkan-drivers
-
-      - name: Prepare Vulkan SDK (Ubuntu 22.04)
-        if: github.event.inputs.ubuntu-version == 'ubuntu-22.04' || github.event.inputs.ubuntu-version == ''
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
-          sudo apt update
-          sudo apt install vulkan-sdk -y
-          sudo apt-get install -y mesa-vulkan-drivers
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libpipewire-0.3-dev libclang-dev meson ninja-build
 
       - name: Install FUSE for AppImage
         run: |
@@ -198,10 +179,21 @@ jobs:
           echo "Copied llama-helper to frontend/src-tauri/binaries/"
           ls -la frontend/src-tauri/binaries/
 
+      - name: Cache FFmpeg binary
+        uses: actions/cache@v4
+        with:
+          path: frontend/src-tauri/binaries/ffmpeg-*
+          key: ${{ runner.os }}-ffmpeg-${{ hashFiles('frontend/src-tauri/build.rs', 'frontend/src-tauri/build/ffmpeg.rs') }}
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # sherpa-onnx-sys drops libsherpa-onnx-c-api.so into the cargo output
+          # dir without a RUNPATH on the binary; linuxdeploy needs this to find
+          # and bundle it (same as build.sh). Without it the AppImage is either
+          # missing the lib or truncated (issue #3).
+          LD_LIBRARY_PATH: ${{ github.workspace }}/target/x86_64-unknown-linux-gnu/release:${{ github.workspace }}/target/release
           # Tauri updater signing (ALWAYS enabled for .sig files)
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -218,6 +210,20 @@ jobs:
         run: |
           echo "Build artifacts:"
           find target/x86_64-unknown-linux-gnu/${{ steps.build-profile.outputs.profile }}/bundle -type f
+          # A bundling failure can leave a tiny/empty AppImage behind (issue #3).
+          # Refuse to ship anything implausibly small or missing sherpa-onnx.
+          for f in target/x86_64-unknown-linux-gnu/${{ steps.build-profile.outputs.profile }}/bundle/appimage/*.AppImage; do
+            [ -f "$f" ] || { echo "::error::no AppImage produced"; exit 1; }
+            size=$(stat -c%s "$f")
+            echo "$f: $size bytes"
+            if [ "$size" -lt 50000000 ]; then echo "::error::AppImage is only $size bytes"; exit 1; fi
+            chmod +x "$f"
+            (cd "$(dirname "$f")" && "./$(basename "$f")" --appimage-extract >/dev/null 2>&1) || { echo "::error::AppImage does not extract"; exit 1; }
+            if ! find "$(dirname "$f")/squashfs-root" -name 'libsherpa-onnx-c-api.so*' | grep -q .; then
+              echo "::error::libsherpa-onnx-c-api.so is not bundled in the AppImage"; exit 1
+            fi
+            rm -rf "$(dirname "$f")/squashfs-root"
+          done
 
       - name: Remove libwayland-client.so from AppImage
         if: contains(steps.build-profile.outputs.args, 'appimage')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,13 +108,13 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-          key: ${{ inputs.platform }}-${{ inputs.target }}-vulkan-v2
+          key: ${{ inputs.platform }}-${{ inputs.target }}-openblas-v3
 
       - name: install dependencies (ubuntu 24.04)
         if: contains(inputs.platform, 'ubuntu-24.04')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev \
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libpipewire-0.3-dev libclang-dev meson ninja-build \
             libwebkit2gtk-4.1-0=2.44.0-2 \
             libwebkit2gtk-4.1-dev=2.44.0-2 \
             libjavascriptcoregtk-4.1-0=2.44.0-2 \
@@ -126,25 +126,7 @@ jobs:
         if: contains(inputs.platform, 'ubuntu-22.04')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
-
-      - name: Prepare Vulkan SDK for Ubuntu 24.04
-        if: contains(inputs.platform, 'ubuntu-24.04')
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-noble.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-noble.list
-          sudo apt update
-          sudo apt install vulkan-sdk -y
-          sudo apt-get install -y mesa-vulkan-drivers
-
-      - name: Prepare Vulkan SDK for Ubuntu 22.04
-        if: contains(inputs.platform, 'ubuntu-22.04')
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.290-jammy.list https://packages.lunarg.com/vulkan/1.3.290/lunarg-vulkan-1.3.290-jammy.list
-          sudo apt update
-          sudo apt install vulkan-sdk -y
-          sudo apt-get install -y mesa-vulkan-drivers
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev libpipewire-0.3-dev libclang-dev meson ninja-build
 
       - name: Install frontend dependencies
         run: |
@@ -214,6 +196,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # linuxdeploy: keep strip off (SHT_RELR) and let it find
+          # libsherpa-onnx-c-api.so in the cargo output dir (see build.sh and
+          # issue #3). The release profile strips symbols itself.
+          NO_STRIP: 1
+          LD_LIBRARY_PATH: ${{ github.workspace }}/target/release:${{ github.workspace }}/target/${{ inputs.target }}/release
           # Tauri updater signing (ALWAYS enabled for .sig files)
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -234,6 +221,21 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y fuse libfuse2
+
+      - name: Verify AppImage before post-processing
+        if: contains(inputs.platform, 'ubuntu')
+        run: |
+          # A bundling failure can leave a tiny/empty AppImage behind (issue #3).
+          f=$(find target/${{ steps.build-profile.outputs.profile }}/bundle/appimage -name "*.AppImage" | head -1)
+          [ -n "$f" ] || { echo "::error::no AppImage produced"; exit 1; }
+          size=$(stat -c%s "$f"); echo "$f: $size bytes"
+          if [ "$size" -lt 50000000 ]; then echo "::error::AppImage is only $size bytes"; exit 1; fi
+          chmod +x "$f"
+          (cd "$(dirname "$f")" && "./$(basename "$f")" --appimage-extract >/dev/null 2>&1) || { echo "::error::AppImage does not extract"; exit 1; }
+          if ! find "$(dirname "$f")/squashfs-root" -name 'libsherpa-onnx-c-api.so*' | grep -q .; then
+            echo "::error::libsherpa-onnx-c-api.so is not bundled in the AppImage"; exit 1
+          fi
+          rm -rf "$(dirname "$f")/squashfs-root"
 
       - name: Remove libwayland-client.so from AppImage
         if: contains(inputs.platform, 'ubuntu')
@@ -271,6 +273,8 @@ jobs:
 
             # Repackage AppImage with no-appstream to avoid warnings
             ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream squashfs-root "$APPIMAGE_NAME"
+            size=$(stat -c%s "$APPIMAGE_NAME"); echo "repacked $APPIMAGE_NAME: $size bytes"
+            if [ "$size" -lt 50000000 ]; then echo "::error::repacked AppImage is only $size bytes"; exit 1; fi
 
             # Clean up
             rm -rf squashfs-root appimagetool-x86_64.AppImage
@@ -286,7 +290,6 @@ jobs:
         with:
           name: ${{ inputs.asset-prefix }}-${{ inputs.platform }}-${{ inputs.target }}
           path: |
-            target/${{ steps.build-profile.outputs.profile }}/bundle/deb/*.deb
             target/${{ steps.build-profile.outputs.profile }}/bundle/appimage/*.AppImage
             target/${{ steps.build-profile.outputs.profile }}/bundle/rpm/*.rpm
           retention-days: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,20 @@ tokio = { version = "1.32.0", features = ["full"] }
 # Profiles must live at the workspace root (cargo ignores them in member
 # manifests). meetily uses cargo's default release profile (opt-level=3)
 # while llama-helper wants size-optimised "s" for faster sidecar startup.
+#
+# lto/strip are workspace-profile-only settings (cargo rejects `lto` at the
+# per-package [profile.release.package.*] level — see below), so they live
+# here and apply to every crate in the workspace, including llama-helper and
+# meetily-mcp; those two keep their own opt-level/codegen-units overrides.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true
+
+# NOTE: `NO_STRIP` in build.sh works around a Fedora linuxdeploy SHT_RELR
+# issue in the *bundler* step (AppImage packaging), not this cargo profile —
+# `strip = true` here still runs during `cargo build --release` regardless
+# of that env var; it only suppresses linuxdeploy's own separate strip pass.
 [profile.release.package.llama-helper]
 codegen-units = 1
 opt-level = "s"

--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,9 @@ case "$(uname -s)" in
         export CMAKE_POSITION_INDEPENDENT_CODE="${CMAKE_POSITION_INDEPENDENT_CODE:-ON}"
 
         # linuxdeploy's bundled `strip` chokes on SHT_RELR sections in modern Fedora libs.
+        # NOTE: this only disables linuxdeploy's own strip pass during AppImage bundling —
+        # it does not affect cargo's `strip = true` in the workspace [profile.release]
+        # (see root Cargo.toml), which still strips every binary during `cargo build --release`.
         export NO_STRIP="${NO_STRIP:-1}"
 
         # sherpa-onnx-sys drops `libsherpa-onnx-c-api.so` into target/release/ but

--- a/docs/building_in_linux.md
+++ b/docs/building_in_linux.md
@@ -16,14 +16,45 @@ selection, the gnarly Fedora/CUDA build-environment quirks, and the
 sudo apt update
 sudo apt install build-essential cmake git \
   libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
-  libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev
+  libasound2-dev libopenblas-dev libx11-dev libxtst-dev libxrandr-dev \
+  libpipewire-0.3-dev libclang-dev meson ninja-build
 
 # Fedora/RHEL
-sudo dnf install gcc-c++ cmake git llvm openmp-devel
+sudo dnf install gcc-c++ cmake git llvm openmp-devel \
+  webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel patchelf \
+  alsa-lib-devel openblas-devel pipewire-devel clang-devel meson ninja-build
 
 # Arch Linux
-sudo pacman -S base-devel cmake git
+sudo pacman -S base-devel cmake git webkit2gtk-4.1 libappindicator-gtk3 \
+  librsvg patchelf alsa-lib openblas pipewire clang meson ninja
 ```
+
+`libpipewire` is the audio capture backend (PipeWire ≥ 0.3.44 at runtime),
+`libclang` is needed by its Rust bindings, and `meson` + `ninja` build the
+bundled WebRTC echo-cancellation library (the app no longer needs the system
+`webrtc-audio-processing-2` package).
+
+### Building offline or behind a proxy
+
+Three things are fetched at build time: whisper.cpp sources (via
+`whisper-rs-sys`), a prebuilt `sherpa-onnx` archive (via `sherpa-onnx-sys`),
+and a static `ffmpeg` binary (via `build.rs`). Cargo's registry proxy settings
+cover the first; the other two can be pre-seeded:
+
+```bash
+# sherpa-onnx: download the archive the sys crate expects and point it there
+mkdir -p ~/.cache/sherpa-onnx
+curl -L -o ~/.cache/sherpa-onnx/sherpa-onnx-v1.13.7-linux-x64-shared-lib.tar.bz2 \
+  https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.7/sherpa-onnx-v1.13.7-linux-x64-shared-lib.tar.bz2
+export SHERPA_ONNX_ARCHIVE_DIR=~/.cache/sherpa-onnx
+
+# ffmpeg: drop a static binary at this path and build.rs will skip the download
+cp /path/to/ffmpeg frontend/src-tauri/binaries/ffmpeg-x86_64-unknown-linux-gnu
+```
+
+The exact sherpa-onnx version is the one pinned in `Cargo.lock`
+(`sherpa-onnx-sys`); once built, the archive is cached under
+`target/sherpa-onnx-prebuilt/`.
 
 You'll also need [pnpm](https://pnpm.io/installation) and a Rust toolchain
 (`rustup`).
@@ -177,8 +208,12 @@ embeds all native libs via linuxdeploy.
   bundled `strip`).
 
 ### `Could not find dependency: libsherpa-onnx-c-api.so`
-- **Fix:** Already handled — `build.sh` points linuxdeploy at
-  `target/release` via `LD_LIBRARY_PATH` so it can find and bundle the lib.
+- **Fix:** Already handled — `build.sh` (and the CI workflows) point
+  linuxdeploy at `target/release` via `LD_LIBRARY_PATH` so it can find and
+  bundle the lib. If you invoke `cargo tauri build` by hand, export it
+  yourself; a build without it produces an AppImage that is missing the
+  library or is truncated to a few bytes. CI now refuses to upload an
+  AppImage under 50 MB or without the library inside.
 
 ### Build works but no GPU acceleration
 - **Check:** `nvidia-smi` (NVIDIA) should work before `./build.sh` (or

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -65,9 +65,11 @@ base64 = "0.22"
 # instead. `default-features = false` keeps only cpal output (no decoders).
 rodio = { version = "0.19", default-features = false }
 # Acoustic echo cancellation (WebRTC AEC3) for the microphone: subtracts the
-# system audio the mic picks up from the speakers. Links the system
-# webrtc-audio-processing lib (build needs webrtc-audio-processing-devel).
-webrtc-audio-processing = "2.1"
+# system audio the mic picks up from the speakers. `bundled` builds the
+# library from the crate's vendored sources (needs `meson` + `ninja` at build
+# time) instead of requiring the system `webrtc-audio-processing-2` package,
+# which Ubuntu/Debian/Fedora do not ship in a compatible version.
+webrtc-audio-processing = { version = "2.1", features = ["bundled"] }
 once_cell = "1.17.1"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 

--- a/frontend/src-tauri/migrations/20260910000000_add_meetings_created_at_index.sql
+++ b/frontend/src-tauri/migrations/20260910000000_add_meetings_created_at_index.sql
@@ -1,0 +1,3 @@
+-- MeetingsRepository::get_meetings orders by created_at DESC (issue #53);
+-- index it so that scan stays cheap as the meetings table grows.
+CREATE INDEX IF NOT EXISTS idx_meetings_created_at ON meetings(created_at DESC);

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use log::{debug, info};
+use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -162,6 +162,190 @@ pub(crate) fn create_transcript_segments(
             }
         })
         .collect()
+}
+
+/// Filename of the append-only transcript journal written incrementally
+/// during a live recording (issue #48). Each line is one JSON-encoded
+/// [`TranscriptSegment`]; an updated segment is simply appended again, so
+/// upsert semantics are "the last line for a given `sequence_id` wins" on
+/// replay (see [`replay_transcript_journal`]). This lets the live path avoid
+/// re-serialising and rewriting the whole `transcripts.json` on every single
+/// segment — see [`load_transcripts_from_folder`] for how a reader recovers
+/// the true segment set from folder + journal.
+pub(crate) const TRANSCRIPTS_JOURNAL_FILENAME: &str = "transcripts.ndjson";
+
+/// Sort transcript segments chronologically by `audio_start_time`, using
+/// `sequence_id` as a tie-breaker when the start time is equal or absent.
+///
+/// Segments can arrive (or be journaled) out of chronological order: with
+/// dual-VAD (mic + system) sources, a segment that started earlier can
+/// finish later (e.g. a long system-audio segment force-cut well after a
+/// short mic segment that started after it). Every persisted view of a
+/// transcript (transcripts.json, and a journal replay) is re-ordered through
+/// this before being written or handed to a caller.
+pub(crate) fn sort_segments_chronologically(segments: &mut [TranscriptSegment]) {
+    segments.sort_by(|a, b| {
+        let a_time = a.audio_start_time.unwrap_or(f64::MAX);
+        let b_time = b.audio_start_time.unwrap_or(f64::MAX);
+        a_time
+            .partial_cmp(&b_time)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                a.sequence_id
+                    .unwrap_or(u64::MAX)
+                    .cmp(&b.sequence_id.unwrap_or(u64::MAX))
+            })
+    });
+}
+
+/// Append one segment as a single JSON line to `transcripts.ndjson` in
+/// `folder`, creating the file if it doesn't exist yet. Never truncates —
+/// callers upsert by simply appending the updated segment again.
+///
+/// Async (uses `tokio::fs`) so it can run directly on the dedicated journal
+/// writer task (see `RecordingSaver`) without blocking a tokio worker.
+pub(crate) async fn append_transcript_journal_line(
+    folder: &Path,
+    segment: &TranscriptSegment,
+) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let path = folder.join(TRANSCRIPTS_JOURNAL_FILENAME);
+    let mut line = serde_json::to_string(segment)?;
+    line.push('\n');
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    file.write_all(line.as_bytes()).await?;
+    // tokio::fs::File buffers writes internally; write_all() completing
+    // does not by itself guarantee the data has reached the OS file (Drop
+    // best-effort-flushes but can't be awaited). Without this, a reader
+    // racing a fresh append — including this same journal being replayed
+    // moments later — can observe a torn/short file. flush() drives the
+    // buffered write through before the handle goes out of scope.
+    file.flush().await?;
+    Ok(())
+}
+
+/// Unique key a journal replay dedupes on: `sequence_id` is the meaningful
+/// upsert key for the live-recording path (a segment is re-appended under
+/// the same `sequence_id` when Whisper refines a partial transcription into
+/// a final one), so segments carrying one are keyed on it. Segments with no
+/// `sequence_id` (shouldn't happen on the live path, but keep this robust)
+/// fall back to `id`, so they never spuriously collide with each other.
+fn journal_replay_key(segment: &TranscriptSegment) -> String {
+    match segment.sequence_id {
+        Some(sequence_id) => format!("seq:{}", sequence_id),
+        None => format!("id:{}", segment.id),
+    }
+}
+
+/// Replay `transcripts.ndjson` from `folder`: parse every line as a
+/// [`TranscriptSegment`], keep only the last line written for each
+/// `sequence_id` (upsert semantics), and return the result sorted
+/// chronologically via [`sort_segments_chronologically`].
+///
+/// A line that fails to parse (e.g. a torn write from a crash mid-append) is
+/// skipped with a warning rather than failing the whole replay — the journal
+/// is a recovery aid, so best-effort beats losing everything to one bad line.
+pub(crate) fn replay_transcript_journal(folder: &Path) -> Result<Vec<TranscriptSegment>> {
+    let path = folder.join(TRANSCRIPTS_JOURNAL_FILENAME);
+    let contents = std::fs::read_to_string(&path)?;
+
+    let mut by_key: std::collections::HashMap<String, TranscriptSegment> =
+        std::collections::HashMap::new();
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<TranscriptSegment>(line) {
+            Ok(segment) => {
+                by_key.insert(journal_replay_key(&segment), segment);
+            }
+            Err(e) => warn!(
+                "Skipping malformed line in {}: {}",
+                TRANSCRIPTS_JOURNAL_FILENAME, e
+            ),
+        }
+    }
+
+    let mut segments: Vec<TranscriptSegment> = by_key.into_values().collect();
+    sort_segments_chronologically(&mut segments);
+    Ok(segments)
+}
+
+/// Load the true set of transcript segments for a meeting folder, preferring
+/// a fresher `transcripts.ndjson` journal over a possibly-stale
+/// `transcripts.json` (issue #48: `transcripts.json` is only rewritten from
+/// the journal at most every 5s while recording, and can lag behind by that
+/// much right up until the final rewrite at stop).
+///
+/// Every reader of a meeting folder's transcripts (crash-recovery / audio
+/// import / retranscription code, and anything else that wants "the current
+/// transcript for this folder") should go through this rather than reading
+/// `transcripts.json` directly, so it can't observe up to 5s of missing
+/// segments from a recording that's still in progress or was interrupted.
+///
+/// Returns an empty vec if neither file exists. Returns `Err` only for a
+/// `transcripts.json` that exists but fails to parse — deliberately not
+/// silently ignored, since that's the "no journal, or a same-or-older
+/// journal" fallback and hiding a genuine parse failure behind an empty
+/// result would look like "this meeting has no transcript" instead of "this
+/// meeting's transcript file is corrupt".
+pub(crate) fn load_transcripts_from_folder(folder: &Path) -> Result<Vec<TranscriptSegment>> {
+    let json_path = folder.join("transcripts.json");
+    let journal_path = folder.join(TRANSCRIPTS_JOURNAL_FILENAME);
+
+    let json_segments = if json_path.exists() {
+        let contents = std::fs::read_to_string(&json_path)?;
+        let value: serde_json::Value = serde_json::from_str(&contents)?;
+        // Current `write_transcripts_json` output is `{ "segments": [...],
+        // ... }`; also accept a bare top-level array for compatibility with
+        // any older on-disk files that predate the wrapper object.
+        let segments_value = match &value {
+            serde_json::Value::Object(_) => value
+                .get("segments")
+                .cloned()
+                .unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
+            serde_json::Value::Array(_) => value.clone(),
+            _ => serde_json::Value::Array(Vec::new()),
+        };
+        serde_json::from_value::<Vec<TranscriptSegment>>(segments_value)?
+    } else {
+        Vec::new()
+    };
+
+    if !journal_path.exists() {
+        return Ok(json_segments);
+    }
+
+    let journal_segments = replay_transcript_journal(folder)?;
+
+    let journal_is_fresher = if !json_path.exists() {
+        true
+    } else {
+        let journal_mtime = std::fs::metadata(&journal_path).and_then(|m| m.modified());
+        let json_mtime = std::fs::metadata(&json_path).and_then(|m| m.modified());
+        let journal_newer = matches!((journal_mtime, json_mtime), (Ok(j), Ok(t)) if j > t);
+        journal_newer || journal_segments.len() > json_segments.len()
+    };
+
+    if journal_is_fresher {
+        info!(
+            "Preferring {} ({} segments) over transcripts.json ({} segments) for {}",
+            TRANSCRIPTS_JOURNAL_FILENAME,
+            journal_segments.len(),
+            json_segments.len(),
+            folder.display()
+        );
+        Ok(journal_segments)
+    } else {
+        Ok(json_segments)
+    }
 }
 
 /// Write transcripts.json to a meeting folder (atomic write with temp file).
@@ -651,4 +835,116 @@ pub(crate) fn split_segment_at_silence(
     }
 
     result
+}
+
+#[cfg(test)]
+mod journal_tests {
+    use super::*;
+
+    fn segment(id: &str, text: &str, audio_start_time: f64, sequence_id: u64) -> TranscriptSegment {
+        TranscriptSegment {
+            id: id.to_string(),
+            text: text.to_string(),
+            timestamp: None,
+            audio_start_time: Some(audio_start_time),
+            audio_end_time: None,
+            duration: None,
+            display_time: None,
+            confidence: None,
+            sequence_id: Some(sequence_id),
+            speaker: None,
+            voice_profile_id: None,
+            source: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn journal_append_and_replay_dedupes_by_sequence_id_and_orders_chronologically() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Two segments arrive out of chronological order, then the first
+        // (seq 1) is updated in place (e.g. VAD partial -> final) by
+        // appending it again under the same sequence_id.
+        append_transcript_journal_line(tmp.path(), &segment("a", "partial", 10.0, 1))
+            .await
+            .unwrap();
+        append_transcript_journal_line(tmp.path(), &segment("b", "second", 5.0, 2))
+            .await
+            .unwrap();
+        append_transcript_journal_line(tmp.path(), &segment("a", "final", 10.0, 1))
+            .await
+            .unwrap();
+
+        let replayed = replay_transcript_journal(tmp.path()).unwrap();
+
+        // Deduped: only the last line for sequence_id 1 survives.
+        assert_eq!(replayed.len(), 2);
+        // Ordered chronologically by audio_start_time (seq 2 started earlier).
+        assert_eq!(replayed[0].id, "b");
+        assert_eq!(replayed[1].id, "a");
+        assert_eq!(replayed[1].text, "final");
+    }
+
+    #[tokio::test]
+    async fn debounced_rebuild_matches_the_replayed_journal() {
+        // Mirrors what the RecordingSaver journal writer task does on its
+        // periodic debounced rebuild: replay the journal, then write it out
+        // as transcripts.json via the same helper used for the final save.
+        let tmp = tempfile::tempdir().unwrap();
+
+        append_transcript_journal_line(tmp.path(), &segment("s1", "hello", 1.0, 0))
+            .await
+            .unwrap();
+        append_transcript_journal_line(tmp.path(), &segment("s2", "world", 3.0, 1))
+            .await
+            .unwrap();
+        append_transcript_journal_line(tmp.path(), &segment("s2", "world!", 3.0, 1))
+            .await
+            .unwrap();
+
+        let replayed = replay_transcript_journal(tmp.path()).unwrap();
+        write_transcripts_json(tmp.path(), &replayed).unwrap();
+
+        let loaded = load_transcripts_from_folder(tmp.path()).unwrap();
+        // transcripts.json is at least as fresh as (same mtime as-or-newer
+        // than, same segment count as) the journal here, so the json copy
+        // is authoritative and should match the replay exactly.
+        assert_eq!(loaded.len(), replayed.len());
+        for (a, b) in loaded.iter().zip(replayed.iter()) {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.text, b.text);
+            assert_eq!(a.sequence_id, b.sequence_id);
+        }
+    }
+
+    #[test]
+    fn load_prefers_a_fresher_journal_over_a_stale_transcripts_json() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Stale transcripts.json with just one segment.
+        write_transcripts_json(tmp.path(), &[segment("old", "stale", 0.0, 0)]).unwrap();
+
+        // Journal has more (and more recent) segments — write it after a
+        // small delay so its mtime is unambiguously newer than the json's.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let journal_path = tmp.path().join(TRANSCRIPTS_JOURNAL_FILENAME);
+        let lines = [
+            serde_json::to_string(&segment("old", "stale", 0.0, 0)).unwrap(),
+            serde_json::to_string(&segment("new", "fresh", 1.0, 1)).unwrap(),
+        ]
+        .join("\n")
+            + "\n";
+        std::fs::write(&journal_path, lines).unwrap();
+
+        let loaded = load_transcripts_from_folder(tmp.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert!(loaded.iter().any(|s| s.id == "new"));
+    }
+
+    #[test]
+    fn load_returns_empty_when_neither_file_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let loaded = load_transcripts_from_folder(tmp.path()).unwrap();
+        assert!(loaded.is_empty());
+    }
 }

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -870,61 +870,54 @@ pub async fn stop_recording<R: Runtime>(
     // it's needed (owned) for the final save in Step 4.
     let manager_for_cleanup = { RECORDING_MANAGER.lock().unwrap().take() };
 
-    // Step 3: Now safely unload Whisper model after ALL chunks are processed
-    let _ = app.emit(
-        "recording-shutdown-progress",
-        serde_json::json!({
-            "stage": "unloading_model",
-            "message": "Unloading speech recognition model...",
-            "progress": 70
-        }),
-    );
+    // Step 3: Whisper model stays resident across recordings by default
+    // (#47) — reloading it at the start of every recording was the main
+    // cost this shutdown path used to pay for no benefit, since the same
+    // model is almost always used for the next recording too. Only unload
+    // it here when the user has explicitly opted into freeing it between
+    // recordings via `unload_model_after_recording` (see
+    // `recording_preferences::should_unload_after_stop`); otherwise it's
+    // left loaded and idle (no background work runs against it while no
+    // recording or batch job is using it).
+    let preferences = super::recording_preferences::load_recording_preferences(&app)
+        .await
+        .unwrap_or_default();
 
-    info!("🧠 All transcript chunks processed. Now safely unloading transcription model...");
+    if super::recording_preferences::should_unload_after_stop(&preferences) {
+        let _ = app.emit(
+            "recording-shutdown-progress",
+            serde_json::json!({
+                "stage": "unloading_model",
+                "message": "Unloading speech recognition model...",
+                "progress": 70
+            }),
+        );
 
-    // Determine which provider was used and unload the appropriate model (with timeout)
-    let config = match tokio::time::timeout(
-        tokio::time::Duration::from_secs(30), // 30 seconds max for DB operation
-        crate::api::api::api_get_transcript_config(app.clone(), app.clone().state()),
-    )
-    .await
-    {
-        Ok(Ok(Some(config))) => Some(config.provider),
-        Ok(Ok(None)) => None,
-        Ok(Err(e)) => {
-            warn!("⚠️ Failed to get transcript config: {:?}", e);
-            None
-        }
-        Err(_) => {
-            warn!("⏱️ Transcript config timeout (30s), continuing shutdown");
-            None
-        }
-    };
+        info!("🧠 unload_model_after_recording is set — unloading Whisper model...");
+        let engine_clone = {
+            let engine_guard = crate::whisper_engine::commands::WHISPER_ENGINE
+                .lock()
+                .unwrap();
+            engine_guard.as_ref().cloned()
+        };
 
-    // Whisper is the only local ASR engine now; unload it after recording stops.
-    let _ = config; // config provider isn't consulted any more — kept for future routing.
-    info!("🎤 Unloading Whisper model...");
-    let engine_clone = {
-        let engine_guard = crate::whisper_engine::commands::WHISPER_ENGINE
-            .lock()
-            .unwrap();
-        engine_guard.as_ref().cloned()
-    };
+        if let Some(engine) = engine_clone {
+            let current_model = engine
+                .get_current_model()
+                .await
+                .unwrap_or_else(|| "unknown".to_string());
+            info!("Current Whisper model before unload: '{}'", current_model);
 
-    if let Some(engine) = engine_clone {
-        let current_model = engine
-            .get_current_model()
-            .await
-            .unwrap_or_else(|| "unknown".to_string());
-        info!("Current Whisper model before unload: '{}'", current_model);
-
-        if engine.unload_model().await {
-            info!("✅ Whisper model '{}' unloaded successfully", current_model);
+            if engine.unload_model().await {
+                info!("✅ Whisper model '{}' unloaded successfully", current_model);
+            } else {
+                warn!("⚠️ Failed to unload Whisper model '{}'", current_model);
+            }
         } else {
-            warn!("⚠️ Failed to unload Whisper model '{}'", current_model);
+            warn!("⚠️ No Whisper engine found to unload model");
         }
     } else {
-        warn!("⚠️ No Whisper engine found to unload model");
+        info!("🧠 All transcript chunks processed. Keeping Whisper model resident for the next recording.");
     }
 
     // Step 4: Finalize recording state and cleanup resources safely

--- a/frontend/src-tauri/src/audio/recording_preferences.rs
+++ b/frontend/src-tauri/src/audio/recording_preferences.rs
@@ -37,6 +37,14 @@ pub struct RecordingPreferences {
     /// transcript is unaffected when off. Defaults on.
     #[serde(default = "default_true")]
     pub streaming_partials: bool,
+    /// Unload the Whisper model from memory after each recording stops
+    /// instead of keeping it resident (see #47). Off by default: keeping
+    /// the model loaded avoids paying the (multi-second, on some hardware
+    /// much longer) reload cost at the start of the next recording. Turn
+    /// this on to free the model's memory/VRAM between recordings instead,
+    /// at the cost of a reload next time.
+    #[serde(default)]
+    pub unload_model_after_recording: bool,
 }
 
 fn default_true() -> bool {
@@ -54,8 +62,18 @@ impl Default for RecordingPreferences {
             show_recording_notification: true,
             auto_refine: true,
             streaming_partials: true,
+            unload_model_after_recording: false,
         }
     }
+}
+
+/// Whether the Whisper model should be unloaded once a recording finishes,
+/// per issue #47. Pure decision function (no I/O) so it's unit-testable
+/// without a `RecordingPreferences` round-trip: defaults to `false` (keep
+/// the model resident across recordings) unless the user has opted into
+/// `unload_model_after_recording`.
+pub fn should_unload_after_stop(preferences: &RecordingPreferences) -> bool {
+    preferences.unload_model_after_recording
 }
 
 /// Get the default recordings folder (~/Documents/meetily-recordings)
@@ -267,4 +285,36 @@ pub async fn select_recording_folder<R: Runtime>(
     // when it's available in the Cargo.toml
     warn!("Folder selection not yet implemented - using dialog plugin");
     Ok(None)
+}
+
+#[cfg(test)]
+mod unload_after_stop_tests {
+    use super::{should_unload_after_stop, RecordingPreferences};
+
+    #[test]
+    fn defaults_to_keeping_model_loaded() {
+        let prefs = RecordingPreferences::default();
+        assert!(!prefs.unload_model_after_recording);
+        assert!(!should_unload_after_stop(&prefs));
+    }
+
+    #[test]
+    fn honors_opt_in_flag() {
+        let mut prefs = RecordingPreferences::default();
+        prefs.unload_model_after_recording = true;
+        assert!(should_unload_after_stop(&prefs));
+    }
+
+    #[test]
+    fn deserializes_missing_field_as_false() {
+        // Old preferences JSON predating this field should not suddenly
+        // start unloading the model.
+        let json = serde_json::json!({
+            "save_folder": "/tmp/x",
+            "auto_save": true,
+            "file_format": "mp4",
+        });
+        let prefs: RecordingPreferences = serde_json::from_value(json).unwrap();
+        assert!(!prefs.unload_model_after_recording);
+    }
 }

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use log::{error, info, warn};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Runtime};
 use tokio::sync::mpsc;
@@ -8,8 +8,8 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use super::audio_processing::create_meeting_folder;
 use super::common::{
-    write_metadata as common_write_metadata, write_transcripts_json as common_write_transcripts_json,
-    DeviceInfo, MeetingMetadata,
+    self, write_metadata as common_write_metadata, write_transcripts_json as common_write_transcripts_json,
+    DeviceInfo, MeetingMetadata, TRANSCRIPTS_JOURNAL_FILENAME,
 };
 use super::incremental_saver::IncrementalAudioSaver;
 use super::recording_state::AudioChunk;
@@ -34,6 +34,17 @@ pub struct RecordingSaver {
     // `stop_and_save` can wait for it to fully drain the channel (and write
     // every already-queued chunk) instead of racing it with a fixed sleep.
     accumulation_task: Option<tokio::task::JoinHandle<()>>,
+    // Sender side of the dedicated transcript journal writer task (issue
+    // #48). `add_transcript_segment` pushes every segment here instead of
+    // synchronously rewriting the whole transcripts.json on every call; the
+    // writer task appends it to transcripts.ndjson and periodically rebuilds
+    // transcripts.json in the background. `None` before `start_accumulation`
+    // sets up a meeting folder, and set back to `None` (closing the channel)
+    // once the writer task is stopped in `stop_and_save`/`discard_empty_session`.
+    journal_sender: Option<mpsc::UnboundedSender<TranscriptSegment>>,
+    // Handle to the journal writer task, joined (stop_and_save) or aborted
+    // (discard_empty_session) alongside dropping `journal_sender`.
+    journal_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl RecordingSaver {
@@ -47,6 +58,8 @@ impl RecordingSaver {
             chunk_receiver: None,
             is_saving: Arc::new(Mutex::new(false)),
             accumulation_task: None,
+            journal_sender: None,
+            journal_task: None,
         }
     }
 
@@ -106,11 +119,25 @@ impl RecordingSaver {
             );
         }
 
-        // NEW: Save incrementally to disk
-        if let Some(folder) = &self.meeting_folder {
-            if let Err(e) = self.write_transcripts_json(folder) {
-                warn!("Failed to write incremental transcript update: {}", e);
+        // Persist incrementally via the dedicated journal writer task
+        // (issue #48) rather than synchronously re-serialising and
+        // rewriting the whole transcripts.json here on every segment: this
+        // is a cheap, non-blocking channel send, and it's the writer task
+        // that appends the line to transcripts.ndjson and periodically (at
+        // most every 5s while dirty) rebuilds transcripts.json in the
+        // background.
+        if let Some(sender) = &self.journal_sender {
+            if sender.send(segment.clone()).is_err() {
+                warn!(
+                    "Transcript journal writer task is gone; segment {} not persisted to disk",
+                    segment.id
+                );
             }
+        } else if self.meeting_folder.is_some() {
+            warn!(
+                "No transcript journal writer available; segment {} not persisted to disk",
+                segment.id
+            );
         }
     }
 
@@ -284,10 +311,124 @@ impl RecordingSaver {
         // Write initial metadata.json
         self.write_metadata(&meeting_folder, &metadata)?;
 
+        // Start the dedicated transcript journal writer task (issue #48).
+        // Any writer left over from a previous session should already have
+        // been stopped by `stop_and_save`/`discard_empty_session`, but drop
+        // it defensively rather than leak a task talking to the old folder.
+        self.journal_sender = None;
+        if let Some(old_task) = self.journal_task.take() {
+            old_task.abort();
+        }
+        let (sender, task) =
+            Self::spawn_journal_writer(meeting_folder.clone(), self.transcript_segments.clone());
+        self.journal_sender = Some(sender);
+        self.journal_task = Some(task);
+
         self.meeting_folder = Some(meeting_folder);
         self.metadata = Some(metadata);
 
         Ok(())
+    }
+
+    /// Spawn the dedicated transcript journal writer task (issue #48).
+    ///
+    /// Owns the write side of `transcripts.ndjson`: every segment received
+    /// from `rx` is appended as one JSON line (never blocking a tokio
+    /// worker — the append itself runs on this task, off the caller's
+    /// path), and `transcripts.json` is rebuilt from `segments` (the same
+    /// `Arc<Mutex<Vec<TranscriptSegment>>>` `add_transcript_segment` already
+    /// keeps deduped/upserted) at most once every `DEBOUNCE` while dirty.
+    /// The task exits once `rx` closes (all senders dropped) — it does not
+    /// perform a final rebuild itself; the caller (`stop_and_save`) does
+    /// that explicitly after joining this task, so the "always write at
+    /// stop" guarantee doesn't depend on debounce timing.
+    fn spawn_journal_writer(
+        folder: PathBuf,
+        segments: Arc<Mutex<Vec<TranscriptSegment>>>,
+    ) -> (
+        mpsc::UnboundedSender<TranscriptSegment>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        const DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(5);
+
+        let (sender, mut receiver) = mpsc::unbounded_channel::<TranscriptSegment>();
+
+        let task = tokio::spawn(async move {
+            info!("Transcript journal writer task started for {}", folder.display());
+            let mut dirty = false;
+
+            loop {
+                tokio::select! {
+                    biased;
+
+                    maybe_segment = receiver.recv() => {
+                        match maybe_segment {
+                            Some(segment) => {
+                                if let Err(e) = common::append_transcript_journal_line(&folder, &segment).await {
+                                    warn!(
+                                        "Failed to append transcript journal line for {}: {}",
+                                        segment.id, e
+                                    );
+                                }
+                                dirty = true;
+                            }
+                            None => {
+                                info!("Transcript journal writer task ended (channel closed)");
+                                break;
+                            }
+                        }
+                    }
+
+                    _ = tokio::time::sleep(DEBOUNCE), if dirty => {
+                        Self::rebuild_transcripts_json(&folder, &segments).await;
+                        dirty = false;
+                    }
+                }
+            }
+        });
+
+        (sender, task)
+    }
+
+    /// Rebuild transcripts.json from the current in-memory segment set.
+    /// Used both by the journal writer task's debounced rebuild and, via
+    /// `write_transcripts_json`'s callers, at final save time.
+    async fn rebuild_transcripts_json(folder: &Path, segments: &Arc<Mutex<Vec<TranscriptSegment>>>) {
+        let mut segments_clone = match segments.lock() {
+            Ok(guard) => guard.clone(),
+            Err(e) => {
+                error!("Failed to lock transcript segments for debounced rebuild: {}", e);
+                return;
+            }
+        };
+        Self::sort_segments_chronologically(&mut segments_clone);
+
+        let folder = folder.to_path_buf();
+        let write_result =
+            tokio::task::spawn_blocking(move || common_write_transcripts_json(&folder, &segments_clone))
+                .await;
+        match write_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!("Debounced transcripts.json rebuild failed: {}", e),
+            Err(e) => warn!("Debounced transcripts.json rebuild task panicked: {}", e),
+        }
+    }
+
+    /// Stop the transcript journal writer task, waiting (bounded) for it to
+    /// drain and append every already-queued segment before returning. Used
+    /// by `stop_and_save` so the journal on disk is complete before the
+    /// caller does the final `transcripts.json` rewrite from it.
+    async fn stop_journal_writer(&mut self) {
+        // Dropping the sender closes the channel, which is what lets the
+        // writer task's `receiver.recv()` return `None` and exit its loop.
+        self.journal_sender = None;
+        if let Some(task) = self.journal_task.take() {
+            match tokio::time::timeout(std::time::Duration::from_secs(5), task).await {
+                Ok(Ok(())) => info!("Transcript journal writer task drained cleanly"),
+                Ok(Err(e)) => warn!("Transcript journal writer task panicked: {}", e),
+                Err(_) => warn!("Timed out waiting for transcript journal writer task to drain"),
+            }
+        }
     }
 
     /// Write metadata.json to disk (atomic write with temp file, merging
@@ -404,6 +545,14 @@ impl RecordingSaver {
         self.meeting_folder = None;
         self.metadata = None;
         self.incremental_saver = None;
+        // Drop the sender (closing its channel) and abort the journal
+        // writer task rather than waiting for a graceful drain: this
+        // session produced no data and its folder is already gone, so
+        // there's nothing left for the writer to usefully flush.
+        self.journal_sender = None;
+        if let Some(task) = self.journal_task.take() {
+            task.abort();
+        }
         if let Ok(mut segments) = self.transcript_segments.lock() {
             segments.clear();
         }
@@ -418,8 +567,10 @@ impl RecordingSaver {
     /// — safe to silently delete rather than leaving it for crash recovery
     /// to offer — only when `.checkpoints/` holds no `audio_chunk_*` files
     /// (covers both the current `.f32` checkpoints and the legacy `.mp4`
-    /// ones) and `transcripts.json` is either absent or contains no
-    /// segments.
+    /// ones) and neither `transcripts.json` nor `transcripts.ndjson`
+    /// (issue #48: a session can have produced segments that only made it
+    /// into the journal, not yet into a debounced transcripts.json rewrite)
+    /// contains any segments.
     fn session_is_empty(meeting_folder: &std::path::Path) -> bool {
         let checkpoints_dir = meeting_folder.join(".checkpoints");
         let has_checkpoint_audio = match std::fs::read_dir(&checkpoints_dir) {
@@ -437,17 +588,13 @@ impl RecordingSaver {
             return false;
         }
 
-        let transcripts_path = meeting_folder.join("transcripts.json");
-        let has_transcript_segments = match std::fs::read_to_string(&transcripts_path) {
-            Ok(contents) => match serde_json::from_str::<serde_json::Value>(&contents) {
-                Ok(serde_json::Value::Array(segments)) => !segments.is_empty(),
-                // Any other shape (or an object wrapper) — treat non-empty
-                // content as "has data" rather than risk deleting real
-                // transcripts on a format we don't recognize.
-                Ok(other) => !other.is_null(),
-                Err(_) => true,
-            },
-            Err(_) => false,
+        let has_transcript_segments = match common::load_transcripts_from_folder(meeting_folder) {
+            Ok(segments) => !segments.is_empty(),
+            // A transcripts.json that exists but fails to parse — treat
+            // non-empty/unrecognized content as "has data" rather than risk
+            // deleting real transcripts on a format we don't recognize
+            // (mirrors the previous direct-read behavior here).
+            Err(_) => true,
         };
 
         !has_transcript_segments
@@ -500,12 +647,61 @@ impl RecordingSaver {
             }
         }
 
+        // Stop the transcript journal writer task and wait (bounded) for it
+        // to drain: every segment already queued gets appended to
+        // transcripts.ndjson before we replay the in-memory segment set
+        // into the final transcripts.json rewrite below (issue #48 —
+        // guarantees the "always write transcripts.json at stop" contract
+        // doesn't race the debounce timer).
+        self.stop_journal_writer().await;
+
+        // Save final transcripts.json with validation. Done unconditionally
+        // (regardless of whether audio auto-save is enabled below) since
+        // the debounced background rebuild may be up to 5s stale.
+        if let Some(folder) = self.meeting_folder.clone() {
+            if let Err(e) = self.write_transcripts_json(&folder) {
+                error!("❌ Failed to write final transcripts: {}", e);
+                return Err(format!("Failed to save transcripts: {}", e));
+            }
+
+            // Verify transcripts were written correctly
+            let transcript_path = folder.join("transcripts.json");
+            if !transcript_path.exists() {
+                error!(
+                    "❌ Transcript file was not created at: {}",
+                    transcript_path.display()
+                );
+                return Err("Transcript file verification failed".to_string());
+            }
+            info!(
+                "✅ Transcripts saved and verified at: {}",
+                transcript_path.display()
+            );
+
+            // The journal is now fully superseded by this fresh
+            // transcripts.json — remove it so a stale ndjson never shadows
+            // the just-written json for a later reader (see
+            // `common::load_transcripts_from_folder`). Deliberately left in
+            // place on every earlier error-return above, so crash recovery
+            // can still replay it if something above failed.
+            let journal_path = folder.join(TRANSCRIPTS_JOURNAL_FILENAME);
+            if journal_path.exists() {
+                if let Err(e) = std::fs::remove_file(&journal_path) {
+                    warn!(
+                        "Failed to remove transcript journal {}: {}",
+                        journal_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
         // Check if incremental saver exists (indicates auto_save was enabled)
         let should_save_audio = self.incremental_saver.is_some();
 
         if !should_save_audio {
             info!("⚠️  No audio saver initialized (auto-save was disabled) - skipping audio finalization");
-            info!("✅ Transcripts and metadata already saved incrementally");
+            info!("✅ Transcripts and metadata already saved");
             return Ok(None);
         }
 
@@ -526,28 +722,6 @@ impl RecordingSaver {
             error!("No incremental saver initialized - cannot save recording");
             return Err("No incremental saver initialized".to_string());
         };
-
-        // Save final transcripts.json with validation
-        if let Some(folder) = &self.meeting_folder {
-            if let Err(e) = self.write_transcripts_json(folder) {
-                error!("❌ Failed to write final transcripts: {}", e);
-                return Err(format!("Failed to save transcripts: {}", e));
-            }
-
-            // Verify transcripts were written correctly
-            let transcript_path = folder.join("transcripts.json");
-            if !transcript_path.exists() {
-                error!(
-                    "❌ Transcript file was not created at: {}",
-                    transcript_path.display()
-                );
-                return Err("Transcript file verification failed".to_string());
-            }
-            info!(
-                "✅ Transcripts saved and verified at: {}",
-                transcript_path.display()
-            );
-        }
 
         // Update metadata to completed status with actual recording duration
         if let (Some(folder), Some(mut metadata)) = (&self.meeting_folder, self.metadata.clone()) {
@@ -618,20 +792,12 @@ impl RecordingSaver {
 
     /// Sort transcript segments chronologically by `audio_start_time`, using
     /// `sequence_id` as a tie-breaker when the start time is equal or absent.
-    /// See `write_transcripts_json` for why this ordering matters.
+    /// See `write_transcripts_json` for why this ordering matters. Thin
+    /// wrapper over `common::sort_segments_chronologically` so it's shared
+    /// with journal-replay callers (kept as an associated fn here since the
+    /// existing tests below call it as `RecordingSaver::sort_segments_chronologically`).
     fn sort_segments_chronologically(segments: &mut [TranscriptSegment]) {
-        segments.sort_by(|a, b| {
-            let a_time = a.audio_start_time.unwrap_or(f64::MAX);
-            let b_time = b.audio_start_time.unwrap_or(f64::MAX);
-            a_time
-                .partial_cmp(&b_time)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| {
-                    a.sequence_id
-                        .unwrap_or(u64::MAX)
-                        .cmp(&b.sequence_id.unwrap_or(u64::MAX))
-                })
-        });
+        common::sort_segments_chronologically(segments);
     }
 }
 
@@ -822,5 +988,77 @@ mod tests {
     fn discard_empty_session_is_a_no_op_with_no_meeting_folder() {
         let mut saver = RecordingSaver::new();
         assert!(!saver.discard_empty_session());
+    }
+
+    // ---- transcript journal writer (issue #48) ----------------------------
+
+    #[tokio::test]
+    async fn journal_writer_drains_queued_segments_and_stop_removes_the_journal_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meeting_folder = tmp.path().join("Meeting");
+        std::fs::create_dir_all(&meeting_folder).unwrap();
+
+        let mut saver = RecordingSaver::new();
+        saver.meeting_folder = Some(meeting_folder.clone());
+        let (sender, task) = RecordingSaver::spawn_journal_writer(
+            meeting_folder.clone(),
+            saver.transcript_segments.clone(),
+        );
+        saver.journal_sender = Some(sender);
+        saver.journal_task = Some(task);
+
+        // add_transcript_segment both updates the in-memory (deduped) vec
+        // and enqueues the segment for the journal writer task.
+        saver.add_transcript_segment(segment("seg-1", Some(1.0), Some(0)));
+        saver.add_transcript_segment(segment("seg-2", Some(2.0), Some(1)));
+
+        // Draining (as stop_and_save does) waits for every queued segment
+        // to actually land in transcripts.ndjson before returning.
+        saver.stop_journal_writer().await;
+
+        let journal_path = meeting_folder.join(common::TRANSCRIPTS_JOURNAL_FILENAME);
+        assert!(journal_path.exists(), "journal should exist after draining");
+        let contents = std::fs::read_to_string(&journal_path).unwrap();
+        assert!(contents.contains("seg-1"));
+        assert!(contents.contains("seg-2"));
+
+        // Mirror stop_and_save's final-write step: rewrite transcripts.json
+        // from the (already up to date) in-memory vec, then remove the
+        // now-superseded journal — exactly what stop_and_save does after a
+        // successful final write.
+        saver.write_transcripts_json(&meeting_folder).unwrap();
+        assert!(meeting_folder.join("transcripts.json").exists());
+        std::fs::remove_file(&journal_path).unwrap();
+
+        assert!(
+            !journal_path.exists(),
+            "journal should be removed once transcripts.json is finalized"
+        );
+
+        // A reader loading the folder afterwards sees the same two segments
+        // purely from transcripts.json, with no journal left to consult.
+        let loaded = common::load_transcripts_from_folder(&meeting_folder).unwrap();
+        assert_eq!(loaded.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn discard_empty_session_stops_the_journal_writer_without_hanging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meeting_folder = tmp.path().join("Meeting");
+        std::fs::create_dir_all(meeting_folder.join(".checkpoints")).unwrap();
+
+        let mut saver = RecordingSaver::new();
+        saver.meeting_folder = Some(meeting_folder.clone());
+        let (sender, task) = RecordingSaver::spawn_journal_writer(
+            meeting_folder.clone(),
+            saver.transcript_segments.clone(),
+        );
+        saver.journal_sender = Some(sender);
+        saver.journal_task = Some(task);
+
+        assert!(saver.discard_empty_session());
+        assert!(saver.journal_sender.is_none());
+        assert!(saver.journal_task.is_none());
+        assert!(!meeting_folder.exists());
     }
 }

--- a/frontend/src-tauri/src/audio/transcription/partial_worker.rs
+++ b/frontend/src-tauri/src/audio/transcription/partial_worker.rs
@@ -237,6 +237,7 @@ async fn decode_and_emit<R: Runtime>(
     let options = crate::whisper_engine::TranscribeOptions {
         max_threads: Some(max_threads),
         greedy: true,
+        purpose: crate::whisper_engine::DecodePurpose::Partial,
     };
     let (text, _conf, _partial) = engine
         .transcribe_audio_with_confidence_opts(windowed, language, None, options)

--- a/frontend/src-tauri/src/database/manager.rs
+++ b/frontend/src-tauri/src/database/manager.rs
@@ -1,6 +1,8 @@
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::{migrate::MigrateDatabase, Result, Sqlite, SqlitePool, Transaction};
 use std::fs;
 use std::path::Path;
+use std::time::Duration;
 use tauri::Manager;
 
 #[derive(Clone)]
@@ -21,7 +23,27 @@ impl DatabaseManager {
             Sqlite::create_database(tauri_db_path).await?;
         }
 
-        let pool = SqlitePool::connect(tauri_db_path).await?;
+        // #53: tuned connect options instead of the bare `SqlitePool::connect`
+        // default (a single connection, journal_mode left at whatever the
+        // file already has, no busy handling). WAL + a busy timeout let
+        // concurrent readers/writers from the several repositories in this
+        // process coexist without "database is locked" errors; `synchronous
+        // = NORMAL` is the standard safe pairing with WAL (still durable
+        // across app crashes, just not against an OS-level power loss
+        // mid-checkpoint, which is an acceptable tradeoff for a local
+        // desktop app's own data).
+        let connect_options = SqliteConnectOptions::new()
+            .filename(tauri_db_path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5))
+            .foreign_keys(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(connect_options)
+            .await?;
 
         sqlx::migrate!("./migrations").run(&pool).await?;
 

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -981,6 +981,35 @@ pub fn run() {
                     if let Err(e) = summary::summary_engine::force_shutdown_sidecar().await {
                         log::error!("Failed to force shutdown sidecar: {}", e);
                     }
+
+                    // Unload the Whisper model (see #47 — it otherwise stays
+                    // resident across recordings, and would leak until
+                    // process death). Best-effort and bounded: this happens
+                    // before `_exit` below, so it's safe (unlike the
+                    // GPU-driver-teardown hazard `_exit` itself works around,
+                    // this runs while the process is still fully alive), but
+                    // it must never hang app shutdown if the engine is
+                    // wedged.
+                    let engine_clone = {
+                        let engine_guard = whisper_engine::commands::WHISPER_ENGINE
+                            .lock()
+                            .unwrap();
+                        engine_guard.as_ref().cloned()
+                    };
+                    if let Some(engine) = engine_clone {
+                        match tokio::time::timeout(
+                            tokio::time::Duration::from_secs(3),
+                            engine.unload_model(),
+                        )
+                        .await
+                        {
+                            Ok(true) => log::info!("Whisper model unloaded on exit"),
+                            Ok(false) => log::debug!("No Whisper model was loaded on exit"),
+                            Err(_) => log::warn!(
+                                "Whisper model unload timed out on exit; continuing shutdown"
+                            ),
+                        }
+                    }
                 });
                 log::info!("Application cleanup complete");
 

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -8,8 +8,10 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
-use tokio::sync::RwLock;
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+use tokio::sync::{Mutex as AsyncMutex, RwLock};
+use whisper_rs::{
+    FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModelStatus {
@@ -25,11 +27,25 @@ pub enum ModelStatus {
     },
 }
 
+/// Which long-lived `WhisperState` a decode should use (see #49). The final
+/// path (`worker.rs`) and the streaming partial-decode path
+/// (`partial_worker.rs`) run concurrently against the same loaded model, so
+/// each gets its own state to avoid serializing on one another or racing on
+/// a shared `whisper_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum DecodePurpose {
+    /// The authoritative, committed transcript.
+    #[default]
+    Final,
+    /// A discarded streaming preview of the in-progress utterance.
+    Partial,
+}
+
 /// Per-call overrides for `transcribe_audio_with_confidence_opts`.
 ///
 /// Defaults (`TranscribeOptions::default()`) reproduce the historical
 /// behavior of `transcribe_audio_with_confidence`: full adaptive thread
-/// budget, beam search at the hardware-adaptive beam size.
+/// budget, beam search at the hardware-adaptive beam size, final-path state.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TranscribeOptions {
     /// Upper bound on the number of whisper threads to use for this call.
@@ -42,12 +58,33 @@ pub struct TranscribeOptions {
     /// which are discarded previews, not the committed transcript — greedy
     /// decoding is faster and the lower quality is acceptable there.
     pub greedy: bool,
+    /// Which pooled `WhisperState` to decode on (see `DecodePurpose`).
+    pub purpose: DecodePurpose,
 }
 
 /// Cap `default` (the hardware-adaptive thread count) at `requested`, if
 /// given, flooring the result at 1 so a caller can never request zero or
 /// negative threads. Pure function so the cap logic is unit-testable
 /// without spinning up a whisper context.
+/// Re-check-under-write-lock + lazily-insert helper backing the
+/// `DecodePurpose` state pool (#49): if `purpose` is already present,
+/// return its `Arc` (a caller may have raced us between dropping the read
+/// lock and taking the write lock); otherwise construct a fresh value with
+/// `make`, insert it, and return it. Generic and pure of any whisper-rs
+/// type so it's unit-testable without a real model loaded.
+fn pool_get_or_insert<T, E>(
+    pool: &mut HashMap<DecodePurpose, Arc<AsyncMutex<T>>>,
+    purpose: DecodePurpose,
+    make: impl FnOnce() -> Result<T, E>,
+) -> Result<Arc<AsyncMutex<T>>, E> {
+    if let Some(existing) = pool.get(&purpose) {
+        return Ok(existing.clone());
+    }
+    let value = Arc::new(AsyncMutex::new(make()?));
+    pool.insert(purpose, value.clone());
+    Ok(value)
+}
+
 fn effective_threads(default: i32, requested: Option<i32>) -> i32 {
     let capped = match requested {
         Some(requested) => default.min(requested),
@@ -74,6 +111,15 @@ pub struct WhisperEngine {
     // WhisperContext itself) across the blocking call.
     current_context: Arc<RwLock<Option<Arc<WhisperContext>>>>,
     current_model: Arc<RwLock<Option<String>>>,
+    // Long-lived `WhisperState`s, keyed by `DecodePurpose`, reused across
+    // decodes instead of calling `ctx.create_state()` per call (#49).
+    // Created lazily on first use after `load_model`, dropped in
+    // `unload_model` (and thus whenever the model changes, since
+    // `load_model` unloads the previous one first). Each entry is behind
+    // its own `tokio::sync::Mutex` so the final and partial paths never
+    // block on each other — only concurrent decodes for the *same*
+    // purpose serialize.
+    state_pool: Arc<RwLock<HashMap<DecodePurpose, Arc<AsyncMutex<WhisperState>>>>>,
     available_models: Arc<RwLock<HashMap<String, ModelInfo>>>,
     // Tracks in-flight downloads and cooperative cancellation requests
     // (shared with summary_engine::model_manager's downloader).
@@ -287,6 +333,7 @@ impl WhisperEngine {
         let engine = Self {
             models_dir,
             current_context: Arc::new(RwLock::new(None)),
+            state_pool: Arc::new(RwLock::new(HashMap::new())),
             current_model: Arc::new(RwLock::new(None)),
             available_models: Arc::new(RwLock::new(HashMap::new())),
             // Initialize download tracking
@@ -454,6 +501,12 @@ impl WhisperEngine {
         let mut model_name_guard = self.current_model.write().await;
         model_name_guard.take();
 
+        // Pooled states borrow the (now-gone) context's underlying weights
+        // via their own `Arc<WhisperInnerContext>` clone — drop them here
+        // so nothing keeps the model's memory alive past unload, and so the
+        // next `load_model` starts from an empty pool (see #49).
+        self.state_pool.write().await.clear();
+
         unloaded
     }
 
@@ -463,6 +516,31 @@ impl WhisperEngine {
 
     pub async fn is_model_loaded(&self) -> bool {
         self.current_context.read().await.is_some()
+    }
+
+    /// Get the pooled `WhisperState` for `purpose`, creating it lazily on
+    /// first use. Reused across calls (#49) instead of `ctx.create_state()`
+    /// per decode — `WhisperState` is safe to reuse across `full()` calls
+    /// and owns its own reference to the context, so it isn't invalidated
+    /// by anything short of `unload_model`/`load_model`.
+    async fn get_or_create_state(
+        &self,
+        purpose: DecodePurpose,
+    ) -> Result<Arc<AsyncMutex<WhisperState>>> {
+        if let Some(state) = self.state_pool.read().await.get(&purpose) {
+            return Ok(state.clone());
+        }
+
+        let ctx = {
+            let ctx_lock = self.current_context.read().await;
+            ctx_lock
+                .as_ref()
+                .cloned()
+                .ok_or_else(|| anyhow!("No model loaded. Please load a model first."))?
+        };
+
+        let mut pool = self.state_pool.write().await;
+        Ok(pool_get_or_insert(&mut pool, purpose, || ctx.create_state())?)
     }
 
     // Enhanced function to clean repetitive text patterns and meaningless outputs
@@ -699,13 +777,10 @@ impl WhisperEngine {
         context_prompt: Option<String>,
         options: TranscribeOptions,
     ) -> Result<(String, f32, bool)> {
-        let ctx = {
-            let ctx_lock = self.current_context.read().await;
-            ctx_lock
-                .as_ref()
-                .cloned()
-                .ok_or_else(|| anyhow!("No model loaded. Please load a model first."))?
-        };
+        // Reuse the long-lived state for this purpose instead of creating a
+        // fresh `WhisperState` per decode (#49). Final and partial decodes
+        // never contend on the same lock since each purpose gets its own.
+        let state_lock = self.get_or_create_state(options.purpose).await?;
 
         let duration_seconds = audio_data.len() as f64 / 16000.0;
         let is_partial = duration_seconds < 15.0; // Consider chunks under 15s as partial
@@ -808,7 +883,9 @@ impl WhisperEngine {
                 // Zero-pad the tail up to a safe floor before decoding.
                 let audio_data = pad_to_min_whisper_input(audio_data);
 
-                let mut state = ctx.create_state()?;
+                // `blocking_lock()` — never held across an `.await`, this
+                // closure runs entirely inside `spawn_blocking`.
+                let mut state = state_lock.blocking_lock();
                 state.full(params, &audio_data)?;
                 let num_segments = state.full_n_segments();
                 // Suppressor dropped here, stderr restored
@@ -1226,6 +1303,58 @@ mod min_input_tests {
         let input = vec![0.25; 40_000];
         let out = pad_to_min_whisper_input(input.clone());
         assert_eq!(out, input);
+    }
+}
+
+#[cfg(test)]
+mod state_pool_tests {
+    use super::{pool_get_or_insert, AsyncMutex, DecodePurpose};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // No real whisper model is available in this environment, so these
+    // exercise the pooling algorithm (`pool_get_or_insert`) against a
+    // trivial stand-in type rather than an actual `WhisperState` — it's
+    // generic over the pooled value, so the behavior under test (distinct
+    // entries per purpose, same entry on repeated calls, lazy construction)
+    // is identical either way.
+    #[tokio::test]
+    async fn distinct_states_per_purpose() {
+        let mut pool: HashMap<DecodePurpose, Arc<AsyncMutex<u32>>> = HashMap::new();
+        let final_state =
+            pool_get_or_insert(&mut pool, DecodePurpose::Final, || Ok::<_, ()>(1)).unwrap();
+        let partial_state =
+            pool_get_or_insert(&mut pool, DecodePurpose::Partial, || Ok::<_, ()>(2)).unwrap();
+
+        assert!(!Arc::ptr_eq(&final_state, &partial_state));
+        assert_eq!(*final_state.lock().await, 1);
+        assert_eq!(*partial_state.lock().await, 2);
+    }
+
+    #[tokio::test]
+    async fn same_state_on_repeated_calls() {
+        let mut pool: HashMap<DecodePurpose, Arc<AsyncMutex<u32>>> = HashMap::new();
+        let mut construct_calls = 0;
+
+        let first = pool_get_or_insert(&mut pool, DecodePurpose::Final, || {
+            construct_calls += 1;
+            Ok::<_, ()>(42)
+        })
+        .unwrap();
+        let second = pool_get_or_insert(&mut pool, DecodePurpose::Final, || {
+            construct_calls += 1;
+            Ok::<_, ()>(99) // would prove reuse if this ever got called again
+        })
+        .unwrap();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(construct_calls, 1, "constructor should only run once");
+        assert_eq!(*second.lock().await, 42);
+    }
+
+    #[test]
+    fn default_purpose_is_final() {
+        assert_eq!(DecodePurpose::default(), DecodePurpose::Final);
     }
 }
 

--- a/frontend/src/app/_components/TranscriptPanel.tsx
+++ b/frontend/src/app/_components/TranscriptPanel.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Copy, GlobeIcon } from "lucide-react";
 import { useTranscripts } from "@/contexts/TranscriptContext";
+import { useTranscriptPartials } from "@/contexts/TranscriptPartialsContext";
 import { useConfig } from "@/contexts/ConfigContext";
 import { useRecordingState } from "@/contexts/RecordingStateContext";
 import { ModalType } from "@/hooks/useModalState";
@@ -33,8 +34,8 @@ export function TranscriptPanel({
     transcriptContainerRef,
     copyTranscript,
     currentMeetingId,
-    partials,
   } = useTranscripts();
+  const { partials } = useTranscriptPartials();
   const { transcriptModelConfig } = useConfig();
   const { isRecording, isPaused } = useRecordingState();
 

--- a/frontend/src/app/_components/recording-page/RecordingTopBar.tsx
+++ b/frontend/src/app/_components/recording-page/RecordingTopBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Pause, Play, Square } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
@@ -8,6 +8,7 @@ import { appDataDir } from "@tauri-apps/api/path";
 import { useConfig } from "@/contexts/ConfigContext";
 import { useRecordingState } from "@/contexts/RecordingStateContext";
 import { useAudioLevels } from "@/hooks/useAudioLevels";
+import { useElapsedTime } from "@/hooks/useElapsedTime";
 import { SignalBars } from "@/components/AudioLevelMeter";
 import { Button } from "@/components/ui/button";
 
@@ -54,14 +55,10 @@ export function RecordingTopBar({
   const isPaused = recordingState.isPaused;
 
   const [startedAt] = useState(() => Date.now());
-  const [now, setNow] = useState(() => Date.now());
   const [pausing, setPausing] = useState(false);
   const [resuming, setResuming] = useState(false);
 
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, []);
+  const elapsed = useElapsedTime(startedAt);
 
   // Fall back to "default" when the user hasn't picked specific devices —
   // matches the hero's behaviour and ensures meters render even with the
@@ -144,7 +141,7 @@ export function RecordingTopBar({
           {isPaused ? "Paused" : "Recording"}
         </span>
         <span className="font-mono text-sm tabular-nums text-muted-foreground">
-          {formatElapsed(now - startedAt)}
+          {formatElapsed(elapsed)}
         </span>
       </div>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { listen } from "@tauri-apps/api/event";
@@ -30,6 +30,14 @@ import { RecordingHero } from "./_components/recording-page/RecordingHero";
 import { RecordingTopBar } from "./_components/recording-page/RecordingTopBar";
 import { LiveActionItemsBar } from "./_components/recording-page/LiveActionItemsBar";
 import { useLiveActionItems } from "@/hooks/useLiveActionItems";
+
+// Module-level guard (issue #51): the IndexedDB cleanup scans
+// (`deleteOldMeetings` / `deleteSavedMeetings`) are cheap housekeeping that
+// only needs to happen once per app session, not on every render/status
+// change that returns to idle. Lives outside the component so it survives
+// remounts of this page within the same app session (SPA navigation), and
+// resets naturally on a full app restart.
+let didRunSessionCleanupScans = false;
 
 export default function Home() {
   const router = useRouter();
@@ -80,36 +88,62 @@ export default function Home() {
   } = useTranscriptRecovery();
   void _isRecovering;
 
-  // Startup checks (cleanup + recovery dialog) — same intent as the
-  // previous version, just lifted into this composer.
+  // Tracks whether the previous idle-transition check found us in a
+  // stop-flow status, so the effect below can tell "just returned to idle
+  // after a recording stopped" (when a new recoverable meeting could have
+  // appeared) apart from any other re-render while already idle.
+  const wasInStopFlowRef = useRef(false);
+
+  // Startup checks (cleanup + recovery dialog). The two IndexedDB cleanup
+  // scans only need to run once per app session — they were previously
+  // re-running on every transition back to idle (issue #51). The
+  // recoverable-transcripts check also only needs to run once per session,
+  // *plus* right after a recording stops, since that's the only time a new
+  // recoverable meeting can appear.
   useEffect(() => {
+    const inStopFlow =
+      recordingState.isRecording ||
+      status === RecordingStatus.STOPPING ||
+      status === RecordingStatus.PROCESSING_TRANSCRIPTS ||
+      status === RecordingStatus.SAVING;
+
+    if (inStopFlow) {
+      wasInStopFlowRef.current = true;
+      return;
+    }
+
+    const justStoppedRecording = wasInStopFlowRef.current;
+    wasInStopFlowRef.current = false;
+
     (async () => {
       try {
-        if (
-          recordingState.isRecording ||
-          status === RecordingStatus.STOPPING ||
-          status === RecordingStatus.PROCESSING_TRANSCRIPTS ||
-          status === RecordingStatus.SAVING
-        ) {
-          return;
+        if (!didRunSessionCleanupScans) {
+          didRunSessionCleanupScans = true;
+          try {
+            await indexedDBService.deleteOldMeetings(7);
+          } catch (err) {
+            console.warn("Failed to clean up old meetings:", err);
+          }
+          try {
+            await indexedDBService.deleteSavedMeetings(24);
+          } catch (err) {
+            console.warn("Failed to clean up saved meetings:", err);
+          }
         }
-        try {
-          await indexedDBService.deleteOldMeetings(7);
-        } catch (err) {
-          console.warn("Failed to clean up old meetings:", err);
-        }
-        try {
-          await indexedDBService.deleteSavedMeetings(24);
-        } catch (err) {
-          console.warn("Failed to clean up saved meetings:", err);
-        }
-        const meetings = await checkForRecoverableTranscripts();
-        if (
-          meetings.length > 0 &&
-          !sessionStorage.getItem("recovery_dialog_shown")
-        ) {
-          setShowRecoveryDialog(true);
-          sessionStorage.setItem("recovery_dialog_shown", "true");
+
+        const alreadyCheckedThisSession = sessionStorage.getItem(
+          "recovery_check_done",
+        );
+        if (!alreadyCheckedThisSession || justStoppedRecording) {
+          sessionStorage.setItem("recovery_check_done", "true");
+          const meetings = await checkForRecoverableTranscripts();
+          if (
+            meetings.length > 0 &&
+            !sessionStorage.getItem("recovery_dialog_shown")
+          ) {
+            setShowRecoveryDialog(true);
+            sessionStorage.setItem("recovery_dialog_shown", "true");
+          }
         }
       } catch (err) {
         console.error("Startup checks failed:", err);

--- a/frontend/src/components/Sidebar/SidebarProvider.tsx
+++ b/frontend/src/components/Sidebar/SidebarProvider.tsx
@@ -141,9 +141,9 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
     [meetings],
   );
 
-  const toggleCollapse = () => {
-    setIsCollapsed(!isCollapsed);
-  };
+  const toggleCollapse = React.useCallback(() => {
+    setIsCollapsed((prev) => !prev);
+  }, []);
 
   // Reset current meeting when navigating to home page (genuine pathname-driven reset)
   useEffect(() => {
@@ -154,7 +154,7 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
   }, [pathname]);
 
   // Function to handle recording toggle from sidebar
-  const handleRecordingToggle = () => {
+  const handleRecordingToggle = React.useCallback(() => {
     if (!isRecording) {
       // A previous recording's stop is still draining/finalising (or this
       // window's local stop flow is mid-flight) — starting now would race
@@ -183,10 +183,10 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
       }
     }
     // The actual recording start/stop is handled in the Home component
-  };
+  }, [isRecording, isStopFlowActive, pathname, router]);
 
   // Function to search through meeting transcripts
-  const searchTranscripts = async (query: string) => {
+  const searchTranscripts = React.useCallback(async (query: string) => {
     if (!query.trim()) {
       setSearchResults([]);
       return;
@@ -205,7 +205,7 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setIsSearching(false);
     }
-  };
+  }, []);
 
   // Summary polling management
   const startSummaryPolling = React.useCallback(
@@ -314,30 +314,49 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
     };
   }, [activeSummaryPolls]);
 
+  const value: SidebarContextType = useMemo(
+    () => ({
+      currentMeeting,
+      setCurrentMeeting,
+      sidebarItems,
+      isCollapsed,
+      toggleCollapse,
+      meetings,
+      setMeetings,
+      isMeetingActive,
+      setIsMeetingActive,
+      handleRecordingToggle,
+      searchTranscripts,
+      searchResults,
+      isSearching,
+      transcriptServerAddress,
+      setTranscriptServerAddress,
+      activeSummaryPolls,
+      startSummaryPolling,
+      stopSummaryPolling,
+      refetchMeetings: fetchMeetings,
+    }),
+    [
+      currentMeeting,
+      sidebarItems,
+      isCollapsed,
+      toggleCollapse,
+      meetings,
+      isMeetingActive,
+      handleRecordingToggle,
+      searchTranscripts,
+      searchResults,
+      isSearching,
+      transcriptServerAddress,
+      activeSummaryPolls,
+      startSummaryPolling,
+      stopSummaryPolling,
+      fetchMeetings,
+    ],
+  );
+
   return (
-    <SidebarContext.Provider
-      value={{
-        currentMeeting,
-        setCurrentMeeting,
-        sidebarItems,
-        isCollapsed,
-        toggleCollapse,
-        meetings,
-        setMeetings,
-        isMeetingActive,
-        setIsMeetingActive,
-        handleRecordingToggle,
-        searchTranscripts,
-        searchResults,
-        isSearching,
-        transcriptServerAddress,
-        setTranscriptServerAddress,
-        activeSummaryPolls,
-        startSummaryPolling,
-        stopSummaryPolling,
-        refetchMeetings: fetchMeetings,
-      }}
-    >
+    <SidebarContext.Provider value={value}>
       {children}
     </SidebarContext.Provider>
   );

--- a/frontend/src/components/Sidebar/parts/SidebarRecordingButton.tsx
+++ b/frontend/src/components/Sidebar/parts/SidebarRecordingButton.tsx
@@ -2,6 +2,7 @@
 
 import { Mic, Square } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useElapsedTime } from "@/hooks/useElapsedTime";
 
 interface SidebarRecordingButtonProps {
   isRecording: boolean;
@@ -45,7 +46,6 @@ export function SidebarRecordingButton({
   collapsed = false,
 }: SidebarRecordingButtonProps) {
   const [startedAt, setStartedAt] = useState<number | null>(null);
-  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     if (!isRecording) {
@@ -53,11 +53,9 @@ export function SidebarRecordingButton({
       return;
     }
     setStartedAt((prev) => prev ?? Date.now());
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
   }, [isRecording]);
 
-  const elapsed = isRecording && startedAt ? now - startedAt : 0;
+  const elapsed = useElapsedTime(isRecording ? startedAt : null);
   const handleClick = isRecording ? onResumeView : onStart;
 
   if (collapsed) {

--- a/frontend/src/contexts/RecordingStateContext.tsx
+++ b/frontend/src/contexts/RecordingStateContext.tsx
@@ -186,15 +186,32 @@ export function RecordingStateProvider({
       const backendState = await recordingService.getRecordingState();
       const isFinalising = backendState.is_finalising ?? false;
 
-      setState((prev) => ({
-        ...prev,
-        isRecording: backendState.is_recording,
-        isPaused: backendState.is_paused,
-        isActive: backendState.is_active,
-        recordingDuration: backendState.recording_duration,
-        activeDuration: backendState.active_duration,
-        isBackendFinalising: isFinalising,
-      }));
+      // Skip the setState when nothing the backend reports has actually
+      // changed - `syncWithBackend` runs every 500ms while a recording/stop
+      // is in flight, and re-creating the state object on every tick forces
+      // every consumer (page.tsx, the sidebar, the top bar, ...) to
+      // re-render for no reason (issue #51).
+      setState((prev) => {
+        if (
+          prev.isRecording === backendState.is_recording &&
+          prev.isPaused === backendState.is_paused &&
+          prev.isActive === backendState.is_active &&
+          prev.recordingDuration === backendState.recording_duration &&
+          prev.activeDuration === backendState.active_duration &&
+          prev.isBackendFinalising === isFinalising
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          isRecording: backendState.is_recording,
+          isPaused: backendState.is_paused,
+          isActive: backendState.is_active,
+          recordingDuration: backendState.recording_duration,
+          activeDuration: backendState.active_duration,
+          isBackendFinalising: isFinalising,
+        };
+      });
 
       const inStopFlow = [
         RecordingStatus.STOPPING,

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -7,20 +7,22 @@ import React, {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
   ReactNode,
   MutableRefObject,
 } from "react";
-import {
-  Transcript,
-  TranscriptUpdate,
-  TranscriptPartialUpdate,
-  PartialsBySource,
-} from "@/types";
+import { Transcript, TranscriptUpdate, TranscriptPartialUpdate } from "@/types";
 import { toast } from "sonner";
 import { useRecordingState } from "./RecordingStateContext";
 import { transcriptService } from "@/services/transcriptService";
 import { recordingService } from "@/services/recordingService";
 import { indexedDBService } from "@/services/indexedDBService";
+import { upsertSorted } from "@/lib/transcriptOrder";
+import { debugLog } from "@/lib/debugLog";
+import {
+  TranscriptPartialsProvider,
+  useTranscriptPartials,
+} from "./TranscriptPartialsContext";
 
 interface TranscriptContextType {
   transcripts: Transcript[];
@@ -34,22 +36,34 @@ interface TranscriptContextType {
   clearTranscripts: () => void;
   currentMeetingId: string | null;
   markMeetingAsSaved: () => Promise<void>;
-  /** Ephemeral streaming preview text, keyed by source. Never enters
-   *  `transcripts` / IndexedDB / sequence_id ordering — overlay only. */
-  partials: PartialsBySource;
 }
 
 const TranscriptContext = createContext<TranscriptContextType | undefined>(
   undefined,
 );
 
+// Batch IndexedDB writes for finalised segments: queue them and flush every
+// ~1s or once 20 accumulate, instead of one transaction per segment.
+const SAVE_BATCH_SIZE = 20;
+const SAVE_BATCH_INTERVAL_MS = 1000;
+
 export function TranscriptProvider({ children }: { children: ReactNode }) {
+  return (
+    <TranscriptPartialsProvider>
+      <TranscriptProviderInner>{children}</TranscriptProviderInner>
+    </TranscriptPartialsProvider>
+  );
+}
+
+function TranscriptProviderInner({ children }: { children: ReactNode }) {
   const [transcripts, setTranscripts] = useState<Transcript[]>([]);
   const [meetingTitle, setMeetingTitle] = useState("+ New Call");
   const [currentMeetingId, setCurrentMeetingId] = useState<string | null>(null);
-  // Ephemeral streaming preview overlay (transcript-partial events). Purely
-  // additive - never touches `transcripts`, IndexedDB, or sequence ordering.
-  const [partials, setPartials] = useState<PartialsBySource>({});
+
+  // Ephemeral streaming preview overlay (transcript-partial events) now
+  // lives in its own context so its high-frequency updates don't re-render
+  // committed-transcript consumers of this context.
+  const { setPartialForSource, clearPartials } = useTranscriptPartials();
 
   // Recording state context - provides backend-synced state
   const recordingState = useRecordingState();
@@ -59,6 +73,10 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
   const isUserAtBottomRef = useRef<boolean>(true);
   const transcriptContainerRef = useRef<HTMLDivElement>(null);
   const finalFlushRef = useRef<(() => void) | null>(null);
+  // Flushes any queued (not-yet-persisted) IndexedDB segment batch.
+  // Populated by the main listener effect; called from the
+  // recording-started/stopped effect and on unmount.
+  const flushSaveQueueRef = useRef<(() => void) | null>(null);
 
   // Keep ref updated with current transcripts
   useEffect(() => {
@@ -183,7 +201,11 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
           async (payload) => {
             // Recording has ended - there is no "finishing" utterance left
             // to preview, so drop any in-flight partial previews.
-            setPartials({});
+            clearPartials();
+
+            // Nothing left to accumulate - flush anything still queued so
+            // it isn't lost before the meeting gets marked saved.
+            flushSaveQueueRef.current?.();
 
             try {
               if (currentMeetingId) {
@@ -221,7 +243,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
         console.log("🧹 Recording stopped listener cleaned up");
       }
     };
-  }, [currentMeetingId]);
+  }, [currentMeetingId, clearPartials]);
 
   // Main transcript buffering logic with sequence_id ordering
   useEffect(() => {
@@ -230,6 +252,35 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     const transcriptBuffer = new Map<number, Transcript>();
     let lastProcessedSequence = 0;
     let processingTimer: NodeJS.Timeout | undefined;
+
+    // Queue of finalised segments awaiting a batched IndexedDB write.
+    let saveQueue: TranscriptUpdate[] = [];
+    let saveFlushTimer: NodeJS.Timeout | undefined;
+
+    const flushSaveQueue = () => {
+      if (saveFlushTimer) {
+        clearTimeout(saveFlushTimer);
+        saveFlushTimer = undefined;
+      }
+      if (saveQueue.length === 0 || !currentMeetingId) return;
+      const batch = saveQueue;
+      saveQueue = [];
+      indexedDBService
+        .saveTranscripts(currentMeetingId, batch)
+        .catch((err) => console.warn("IndexedDB batch save failed:", err));
+    };
+    flushSaveQueueRef.current = flushSaveQueue;
+
+    const queueForSave = (update: TranscriptUpdate) => {
+      saveQueue.push(update);
+      if (saveQueue.length >= SAVE_BATCH_SIZE) {
+        flushSaveQueue();
+        return;
+      }
+      if (!saveFlushTimer) {
+        saveFlushTimer = setTimeout(flushSaveQueue, SAVE_BATCH_INTERVAL_MS);
+      }
+    };
 
     const processBufferedTranscripts = (forceFlush = false) => {
       const sortedTranscripts: Transcript[] = [];
@@ -257,7 +308,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
           // Force flush mode: process ALL remaining transcripts regardless of timing
           forceFlushTranscripts.push(transcript);
           transcriptBuffer.delete(sequenceId);
-          console.log(
+          debugLog(
             `Force flush: processing transcript with sequence_id ${sequenceId}`,
           );
         } else {
@@ -270,40 +321,22 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             // Process immediately (0ms threshold with serial workers)
             recentTranscripts.push(transcript);
             transcriptBuffer.delete(sequenceId);
-            console.log(
+            debugLog(
               `Processing transcript with sequence_id ${sequenceId}, age: ${transcriptAge}ms`,
             );
           }
         }
       }
 
-      // Sort both stale and recent transcripts by audio_start_time (falling
-      // back to chunk_start_time), then by sequence_id. audio_start_time is
-      // the true chronological anchor across sources — dual-VAD segments can
-      // complete out of order (e.g. a long system-audio segment force-cut
-      // well after a shorter, later-starting mic segment finishes), so
-      // arrival/sequence order alone is not chronological (issue #37).
-      const sortTranscripts = (transcripts: Transcript[]) => {
-        return transcripts.sort((a, b) => {
-          const timeDiff =
-            (a.audio_start_time ?? a.chunk_start_time ?? 0) -
-            (b.audio_start_time ?? b.chunk_start_time ?? 0);
-          if (timeDiff !== 0) return timeDiff;
-          return (a.sequence_id || 0) - (b.sequence_id || 0);
-        });
-      };
-
-      const sortedStaleTranscripts = sortTranscripts(staleTranscripts);
-      const sortedRecentTranscripts = sortTranscripts(recentTranscripts);
-      const sortedForceFlushTranscripts = sortTranscripts(
-        forceFlushTranscripts,
-      );
-
+      // Order within each bucket doesn't matter here — each item is
+      // individually inserted into the already-sorted `transcripts` array
+      // below via binary search (see transcriptOrder.ts), rather than
+      // re-sorting the whole combined array.
       const allNewTranscripts = [
         ...sortedTranscripts,
-        ...sortedRecentTranscripts,
-        ...sortedStaleTranscripts,
-        ...sortedForceFlushTranscripts,
+        ...recentTranscripts,
+        ...staleTranscripts,
+        ...forceFlushTranscripts,
       ];
 
       if (allNewTranscripts.length > 0) {
@@ -322,33 +355,29 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
           // Only combine if we have unique new transcripts
           if (uniqueNewTranscripts.length === 0) {
-            console.log("No unique transcripts to add - all were duplicates");
+            debugLog("No unique transcripts to add - all were duplicates");
             return prev; // No new unique transcripts to add
           }
 
-          console.log(
+          debugLog(
             `Adding ${uniqueNewTranscripts.length} unique transcripts out of ${allNewTranscripts.length} received`,
           );
 
-          // Merge with existing transcripts, maintaining chronological order
-          const combined = [...prev, ...uniqueNewTranscripts];
-
-          // Sort by audio_start_time first (falling back to chunk_start_time),
-          // then by sequence_id. See sortTranscripts above for why.
-          return combined.sort((a, b) => {
-            const timeDiff =
-              (a.audio_start_time ?? a.chunk_start_time ?? 0) -
-              (b.audio_start_time ?? b.chunk_start_time ?? 0);
-            if (timeDiff !== 0) return timeDiff;
-            return (a.sequence_id || 0) - (b.sequence_id || 0);
-          });
+          // Insert each into the already-sorted array via binary search
+          // (audio_start_time, falling back to chunk_start_time, then
+          // sequence_id) instead of re-sorting the whole array.
+          let result = prev;
+          for (const transcript of uniqueNewTranscripts) {
+            result = upsertSorted(result, transcript);
+          }
+          return result;
         });
 
         // Log the processing summary
         const logMessage = forceFlush
           ? `Force flush processed ${allNewTranscripts.length} transcripts (${sortedTranscripts.length} sequential, ${forceFlushTranscripts.length} forced)`
           : `Processed ${allNewTranscripts.length} transcripts (${sortedTranscripts.length} sequential, ${recentTranscripts.length} recent, ${staleTranscripts.length} stale)`;
-        console.log(logMessage);
+        debugLog(logMessage);
       }
     };
 
@@ -357,12 +386,12 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
     const setupListener = async () => {
       try {
-        console.log(
+        debugLog(
           "🔥 Setting up MAIN transcript listener during component initialization...",
         );
         unlistenFn = await transcriptService.onTranscriptUpdate((update) => {
           const now = Date.now();
-          console.log("🎯 MAIN LISTENER: Received transcript update:", {
+          debugLog("🎯 MAIN LISTENER: Received transcript update:", {
             sequence_id: update.sequence_id,
             text: update.text.substring(0, 50) + "...",
             timestamp: update.timestamp,
@@ -379,14 +408,12 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
             ? update.source
             : undefined;
           if (finalSource) {
-            setPartials((prev) =>
-              prev[finalSource] ? { ...prev, [finalSource]: undefined } : prev,
-            );
+            setPartialForSource(finalSource, undefined);
           }
 
           // Check for duplicate sequence_id before processing
           if (transcriptBuffer.has(update.sequence_id)) {
-            console.log(
+            debugLog(
               "🚫 MAIN LISTENER: Duplicate sequence_id, skipping buffer:",
               update.sequence_id,
             );
@@ -413,15 +440,13 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
 
           // Add to buffer
           transcriptBuffer.set(update.sequence_id, newTranscript);
-          console.log(
+          debugLog(
             `✅ MAIN LISTENER: Buffered transcript with sequence_id ${update.sequence_id}. Buffer size: ${transcriptBuffer.size}, Last processed: ${lastProcessedSequence}`,
           );
 
-          // Save to IndexedDB (non-blocking)
+          // Queue for a batched IndexedDB write (non-blocking)
           if (currentMeetingId) {
-            indexedDBService
-              .saveTranscript(currentMeetingId, update)
-              .catch((err) => console.warn("IndexedDB save failed:", err));
+            queueForSave(update);
           }
 
           // Clear any existing timer and set a new one
@@ -432,7 +457,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
           // Process buffer with minimal delay for immediate UI updates (serial workers = sequential order)
           processingTimer = setTimeout(processBufferedTranscripts, 10);
         });
-        console.log("✅ MAIN transcript listener setup complete");
+        debugLog("✅ MAIN transcript listener setup complete");
       } catch (error) {
         console.error("❌ Failed to setup MAIN transcript listener:", error);
         toast.error(
@@ -442,25 +467,28 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     };
 
     setupListener();
-    console.log("Started enhanced listener setup");
+    debugLog("Started enhanced listener setup");
 
     return () => {
-      console.log("🧹 CLEANUP: Cleaning up MAIN transcript listener...");
+      debugLog("🧹 CLEANUP: Cleaning up MAIN transcript listener...");
       if (processingTimer) {
         clearTimeout(processingTimer);
-        console.log("🧹 CLEANUP: Cleared processing timer");
+        debugLog("🧹 CLEANUP: Cleared processing timer");
       }
+      // Flush anything still queued so nothing is lost on unmount / when
+      // currentMeetingId changes and this effect re-runs.
+      flushSaveQueue();
       if (unlistenFn) {
         unlistenFn();
-        console.log("🧹 CLEANUP: MAIN transcript listener cleaned up");
+        debugLog("🧹 CLEANUP: MAIN transcript listener cleaned up");
       }
     };
-  }, [currentMeetingId]); // Add currentMeetingId dependency
+  }, [currentMeetingId, setPartialForSource]); // Add currentMeetingId dependency
 
   // Streaming partial-transcription preview listener. Single registration,
   // cleaned up on unmount. This is a pure overlay: it never writes to
   // `transcripts`, IndexedDB, or the sequence_id buffer above - only to the
-  // ephemeral `partials` state.
+  // ephemeral partials context.
   useEffect(() => {
     let unlistenPartial: (() => void) | undefined;
 
@@ -474,20 +502,15 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
                 : undefined;
             if (!source) return;
 
-            setPartials((prev) => {
-              // Empty text clears the source's partial (explicit clear, or
-              // a new utterance that hasn't produced stabilized text yet).
-              if (!update.text) {
-                if (!prev[source]) return prev;
-                return { ...prev, [source]: undefined };
-              }
-              return {
-                ...prev,
-                [source]: {
-                  text: update.text,
-                  utterance_id: update.utterance_id,
-                },
-              };
+            // Empty text clears the source's partial (explicit clear, or
+            // a new utterance that hasn't produced stabilized text yet).
+            if (!update.text) {
+              setPartialForSource(source, undefined);
+              return;
+            }
+            setPartialForSource(source, {
+              text: update.text,
+              utterance_id: update.utterance_id,
             });
           },
         );
@@ -503,7 +526,7 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
         unlistenPartial();
       }
     };
-  }, []);
+  }, [setPartialForSource]);
 
   // Sync transcript history and meeting name from backend on reload
   // This fixes the issue where reloading during active recording causes state desync
@@ -565,9 +588,16 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recordingState.isRecording]);
 
+  // Flush any queued IndexedDB writes on unmount so nothing is lost.
+  useEffect(() => {
+    return () => {
+      flushSaveQueueRef.current?.();
+    };
+  }, []);
+
   // Manual transcript update handler (for RecordingControls component)
   const addTranscript = useCallback((update: TranscriptUpdate) => {
-    console.log("🎯 addTranscript called with:", {
+    debugLog("🎯 addTranscript called with:", {
       sequence_id: update.sequence_id,
       text: update.text.substring(0, 50) + "...",
       timestamp: update.timestamp,
@@ -592,33 +622,27 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     };
 
     setTranscripts((prev) => {
-      console.log("📊 Current transcripts count before update:", prev.length);
+      debugLog("📊 Current transcripts count before update:", prev.length);
 
       // Check if this transcript already exists
       const exists = prev.some(
         (t) => t.text === update.text && t.timestamp === update.timestamp,
       );
       if (exists) {
-        console.log(
+        debugLog(
           "🚫 Duplicate transcript detected, skipping:",
           update.text.substring(0, 30) + "...",
         );
         return prev;
       }
 
-      // Add new transcript and sort by audio_start_time (falling back to
-      // chunk_start_time), then sequence_id, to maintain chronological order.
-      const updated = [...prev, newTranscript];
-      const sorted = updated.sort((a, b) => {
-        const timeDiff =
-          (a.audio_start_time ?? a.chunk_start_time ?? 0) -
-          (b.audio_start_time ?? b.chunk_start_time ?? 0);
-        if (timeDiff !== 0) return timeDiff;
-        return (a.sequence_id || 0) - (b.sequence_id || 0);
-      });
+      // Insert into the already-sorted array via binary search
+      // (audio_start_time, falling back to chunk_start_time, then
+      // sequence_id) to maintain chronological order.
+      const sorted = upsertSorted(prev, newTranscript);
 
-      console.log("✅ Added new transcript. New count:", sorted.length);
-      console.log("📝 Latest transcript:", {
+      debugLog("✅ Added new transcript. New count:", sorted.length);
+      debugLog("📝 Latest transcript:", {
         id: newTranscript.id,
         text: newTranscript.text.substring(0, 30) + "...",
         sequence_id: newTranscript.sequence_id,
@@ -691,20 +715,31 @@ export function TranscriptProvider({ children }: { children: ReactNode }) {
     }
   }, [currentMeetingId]);
 
-  const value: TranscriptContextType = {
-    transcripts,
-    transcriptsRef,
-    addTranscript,
-    copyTranscript,
-    flushBuffer,
-    transcriptContainerRef,
-    meetingTitle,
-    setMeetingTitle,
-    clearTranscripts,
-    currentMeetingId,
-    markMeetingAsSaved,
-    partials,
-  };
+  const value: TranscriptContextType = useMemo(
+    () => ({
+      transcripts,
+      transcriptsRef,
+      addTranscript,
+      copyTranscript,
+      flushBuffer,
+      transcriptContainerRef,
+      meetingTitle,
+      setMeetingTitle,
+      clearTranscripts,
+      currentMeetingId,
+      markMeetingAsSaved,
+    }),
+    [
+      transcripts,
+      addTranscript,
+      copyTranscript,
+      flushBuffer,
+      meetingTitle,
+      clearTranscripts,
+      currentMeetingId,
+      markMeetingAsSaved,
+    ],
+  );
 
   return (
     <TranscriptContext.Provider value={value}>

--- a/frontend/src/contexts/TranscriptPartialsContext.tsx
+++ b/frontend/src/contexts/TranscriptPartialsContext.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { PartialsBySource } from "@/types";
+
+interface TranscriptPartialsContextType {
+  /** Ephemeral streaming preview text, keyed by source. Never enters
+   *  `transcripts` / IndexedDB / sequence_id ordering — overlay only. */
+  partials: PartialsBySource;
+  setPartialForSource: (
+    source: "mic" | "system",
+    value: PartialsBySource["mic"],
+  ) => void;
+  clearPartials: () => void;
+}
+
+const TranscriptPartialsContext = createContext<
+  TranscriptPartialsContextType | undefined
+>(undefined);
+
+/**
+ * Isolated from `TranscriptProvider` on purpose: `partials` updates on
+ * every `transcript-partial` event (high frequency, mid-utterance), and
+ * only the live-preview UI needs to re-render on those updates. Keeping it
+ * out of `TranscriptContext`'s value means the (much larger) set of
+ * committed-transcript consumers doesn't re-render every time a partial
+ * ticks over.
+ */
+export function TranscriptPartialsProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [partials, setPartials] = useState<PartialsBySource>({});
+
+  const setPartialForSource = useCallback(
+    (source: "mic" | "system", value: PartialsBySource["mic"]) => {
+      setPartials((prev) => {
+        if (prev[source] === value) return prev;
+        if (!value && !prev[source]) return prev;
+        return { ...prev, [source]: value };
+      });
+    },
+    [],
+  );
+
+  const clearPartials = useCallback(() => {
+    setPartials((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+  }, []);
+
+  const value = useMemo(
+    () => ({ partials, setPartialForSource, clearPartials }),
+    [partials, setPartialForSource, clearPartials],
+  );
+
+  return (
+    <TranscriptPartialsContext.Provider value={value}>
+      {children}
+    </TranscriptPartialsContext.Provider>
+  );
+}
+
+export function useTranscriptPartials() {
+  const context = useContext(TranscriptPartialsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useTranscriptPartials must be used within a TranscriptPartialsProvider",
+    );
+  }
+  return context;
+}

--- a/frontend/src/hooks/useElapsedTime.ts
+++ b/frontend/src/hooks/useElapsedTime.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Ticks `Date.now()` once a second for as long as `startedAt` is set, and
+ * returns the elapsed milliseconds since `startedAt` (0 when `startedAt` is
+ * null). The interval is created only while `startedAt` is non-null and is
+ * torn down as soon as it goes back to null - unlike the two independent
+ * always-on 1Hz clocks this replaces (SidebarRecordingButton,
+ * RecordingTopBar - issue #51), it does no work when there's nothing to
+ * tick.
+ */
+export function useElapsedTime(startedAt: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (startedAt === null) {
+      return;
+    }
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [startedAt]);
+
+  return startedAt === null ? 0 : now - startedAt;
+}

--- a/frontend/src/hooks/useRecordingStateSync.ts
+++ b/frontend/src/hooks/useRecordingStateSync.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { recordingService } from "@/services/recordingService";
+import { useEffect, useState } from "react";
+import { useRecordingState } from "@/contexts/RecordingStateContext";
 
 interface UseRecordingStateSyncReturn {
   isBackendRecording: boolean;
@@ -8,46 +8,33 @@ interface UseRecordingStateSyncReturn {
 }
 
 /**
- * Custom hook for synchronizing frontend recording state with backend.
- * Polls backend every 1 second to detect recording state changes.
+ * Thin adapter between page.tsx's page-local `isRecording` mirror and
+ * RecordingStateContext's `isRecording` (the single source of truth, kept
+ * in sync with the backend via Tauri event listeners plus a 500ms poll
+ * while a recording/stop is in flight - see
+ * `contexts/RecordingStateContext.tsx`).
  *
- * Features:
- * - Backend state synchronization (1-second polling)
- * - Recording disabled flag management (prevents re-recording during processing)
+ * Previously this hook ran its own unconditional 1-second backend poll for
+ * the entire lifetime of the home page, duplicating the context's polling
+ * (issue #51). It now just reacts to the context's already-synced value -
+ * no interval of its own.
  */
 export function useRecordingStateSync(
   isRecording: boolean,
   setIsRecording: (value: boolean) => void,
   setIsMeetingActive: (value: boolean) => void,
 ): UseRecordingStateSyncReturn {
+  const { isRecording: backendIsRecording } = useRecordingState();
   const [isRecordingDisabled, setIsRecordingDisabled] = useState(false);
 
   useEffect(() => {
-    const checkRecordingState = async () => {
-      try {
-        const isCurrentlyRecording = await recordingService.isRecording();
-
-        if (isCurrentlyRecording && !isRecording) {
-          setIsRecording(true);
-          setIsMeetingActive(true);
-        } else if (!isCurrentlyRecording && isRecording) {
-          setIsRecording(false);
-        }
-      } catch (error) {
-        console.error("Failed to check recording state:", error);
-      }
-    };
-
-    if (typeof window !== "undefined" && (window as any).__TAURI__) {
-      checkRecordingState();
-
-      const interval = setInterval(checkRecordingState, 1000);
-
-      return () => {
-        clearInterval(interval);
-      };
+    if (backendIsRecording && !isRecording) {
+      setIsRecording(true);
+      setIsMeetingActive(true);
+    } else if (!backendIsRecording && isRecording) {
+      setIsRecording(false);
     }
-  }, [isRecording, setIsRecording, setIsMeetingActive]);
+  }, [backendIsRecording, isRecording, setIsRecording, setIsMeetingActive]);
 
   return {
     isBackendRecording: isRecording,

--- a/frontend/src/hooks/useTranscriptStreaming.ts
+++ b/frontend/src/hooks/useTranscriptStreaming.ts
@@ -1,9 +1,21 @@
 import { useState, useEffect, useRef } from "react";
 import { TranscriptSegmentData } from "@/types";
 
-const INTERVAL_MS = 15; // Character reveal interval
-const DURATION_MS = 800; // Total streaming duration
+const INTERVAL_MS = 50; // Character reveal interval (throttled from 15ms)
+const DURATION_MS = 800; // Total streaming duration (unchanged - fewer, bigger reveals per tick)
 const INITIAL_CHARS = 5; // Show first N characters immediately
+
+function prefersReducedMotion(): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  } catch {
+    return false;
+  }
+}
 
 interface StreamingSegment {
   id: string;
@@ -26,7 +38,12 @@ export function useTranscriptStreaming(
   const streamingIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
-    if (!isRecording || !enableStreaming || segments.length === 0) {
+    if (
+      !isRecording ||
+      !enableStreaming ||
+      segments.length === 0 ||
+      prefersReducedMotion()
+    ) {
       // Clear streaming when not recording — reset on prop change.
       if (streamingIntervalRef.current) {
         clearInterval(streamingIntervalRef.current);

--- a/frontend/src/lib/debugLog.ts
+++ b/frontend/src/lib/debugLog.ts
@@ -1,0 +1,23 @@
+/**
+ * No-op unless the user has opted into verbose transcript logging via
+ * `localStorage.setItem('meetily-debug', '1')`. Keeps hot-path
+ * (per-segment / per-partial) console traffic out of normal operation
+ * without deleting the diagnostic value of the logs.
+ */
+export function isDebugLogEnabled(): boolean {
+  try {
+    return localStorage.getItem("meetily-debug") === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function debugLog(...args: unknown[]): void {
+  try {
+    if (isDebugLogEnabled()) {
+      console.log(...args);
+    }
+  } catch {
+    // no-op — never let logging break the hot path
+  }
+}

--- a/frontend/src/lib/transcriptOrder.ts
+++ b/frontend/src/lib/transcriptOrder.ts
@@ -1,0 +1,99 @@
+import { Transcript } from "@/types";
+
+/**
+ * Pure helpers for maintaining a chronologically-sorted transcript array
+ * without re-sorting the whole array on every insert.
+ *
+ * Ordering key: `audio_start_time` (falling back to `chunk_start_time`,
+ * then 0), then `sequence_id` (falling back to 0). audio_start_time is the
+ * true chronological anchor across sources — dual-VAD segments can complete
+ * out of order (e.g. a long system-audio segment force-cut well after a
+ * shorter, later-starting mic segment finishes), so arrival/sequence order
+ * alone is not chronological (issue #37).
+ */
+
+function orderKey(t: Transcript): [number, number] {
+  return [
+    t.audio_start_time ?? t.chunk_start_time ?? 0,
+    t.sequence_id ?? 0,
+  ];
+}
+
+/**
+ * Compares two segments by chronological order key. Returns <0 if `a`
+ * belongs before `b`, >0 if after, 0 if equal.
+ */
+export function compareSegments(a: Transcript, b: Transcript): number {
+  const [aTime, aSeq] = orderKey(a);
+  const [bTime, bSeq] = orderKey(b);
+  if (aTime !== bTime) return aTime - bTime;
+  return aSeq - bSeq;
+}
+
+/**
+ * Inserts `segment` into `sorted` (assumed already sorted per
+ * `compareSegments`) at its correct position via binary search, returning a
+ * NEW array. Does not check for existing entries with the same
+ * `sequence_id` — use `upsertSorted` when duplicates/updates are possible.
+ */
+export function insertSorted(
+  sorted: Transcript[],
+  segment: Transcript,
+): Transcript[] {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (compareSegments(sorted[mid], segment) <= 0) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  const result = sorted.slice();
+  result.splice(lo, 0, segment);
+  return result;
+}
+
+/**
+ * Upserts `segment` into `sorted` (assumed already sorted per
+ * `compareSegments`) by `sequence_id`:
+ *  - If a segment with the same `sequence_id` exists and its order key is
+ *    unchanged, it is replaced in place (no re-sort needed).
+ *  - If the order key changed (or no match existed), the old entry (if any)
+ *    is removed and the new one is binary-search-inserted.
+ *
+ * Returns a NEW array; `sorted` is never mutated.
+ */
+export function upsertSorted(
+  sorted: Transcript[],
+  segment: Transcript,
+): Transcript[] {
+  if (segment.sequence_id === undefined) {
+    return insertSorted(sorted, segment);
+  }
+
+  const existingIndex = sorted.findIndex(
+    (t) => t.sequence_id === segment.sequence_id,
+  );
+
+  if (existingIndex === -1) {
+    return insertSorted(sorted, segment);
+  }
+
+  const existing = sorted[existingIndex];
+  const [existingTime] = orderKey(existing);
+  const [newTime] = orderKey(segment);
+
+  if (existingTime === newTime) {
+    // Same chronological slot - replace in place, no re-sort needed.
+    const result = sorted.slice();
+    result[existingIndex] = segment;
+    return result;
+  }
+
+  // Start time changed - remove old entry, then binary-search-insert.
+  const withoutExisting = sorted.slice();
+  withoutExisting.splice(existingIndex, 1);
+  return insertSorted(withoutExisting, segment);
+}

--- a/frontend/src/services/indexedDBService.ts
+++ b/frontend/src/services/indexedDBService.ts
@@ -303,6 +303,68 @@ class IndexedDBService {
   }
 
   /**
+   * Save a batch of transcript segments for a meeting in a single
+   * transaction. Prefer this over repeated `saveTranscript` calls when
+   * multiple segments are ready to persist at once (e.g. a periodic flush) —
+   * one IndexedDB transaction instead of one per segment.
+   */
+  async saveTranscripts(
+    meetingId: string,
+    transcripts: any[],
+  ): Promise<void> {
+    if (transcripts.length === 0) return;
+
+    try {
+      if (!this.db) await this.init();
+
+      const now = Date.now();
+      const transaction = this.db!.transaction(
+        ["transcripts", "meetings"],
+        "readwrite",
+      );
+      const transcriptsStore = transaction.objectStore("transcripts");
+      const meetingsStore = transaction.objectStore("meetings");
+
+      await Promise.all(
+        transcripts.map(
+          (transcript) =>
+            new Promise<void>((resolve, reject) => {
+              const storedTranscript: StoredTranscript = {
+                ...transcript,
+                meetingId,
+                storedAt: now,
+              };
+              const request = transcriptsStore.add(storedTranscript);
+              request.onsuccess = () => resolve();
+              request.onerror = () => reject(request.error);
+            }),
+        ),
+      );
+
+      const meeting = await new Promise<MeetingMetadata | null>(
+        (resolve, reject) => {
+          const request = meetingsStore.get(meetingId);
+          request.onsuccess = () => resolve(request.result || null);
+          request.onerror = () => reject(request.error);
+        },
+      );
+
+      if (meeting) {
+        meeting.lastUpdated = now;
+        meeting.transcriptCount += transcripts.length;
+        await new Promise<void>((resolve, reject) => {
+          const request = meetingsStore.put(meeting);
+          request.onsuccess = () => resolve();
+          request.onerror = () => reject(request.error);
+        });
+      }
+    } catch (error) {
+      console.warn("Failed to batch-save transcripts to IndexedDB:", error);
+      // Fail silently - don't interrupt recording
+    }
+  }
+
+  /**
    * Get all transcripts for a meeting
    */
   async getTranscripts(meetingId: string): Promise<StoredTranscript[]> {


### PR DESCRIPTION
## Description
Week-one batch from the efficiency/speed/UI review, in the recommended order:

- **Rust runtime**: Whisper model stays resident across recordings (new `unload_model_after_recording` preference, default off; unload on exit); one pooled `WhisperState` per decode purpose instead of `create_state()` per call; discarded transcript-config fetch removed from the stop path; `created_at` index on `meetings`; explicit SQLite pool options (WAL, NORMAL, busy timeout, foreign keys); workspace release profile with thin LTO, one codegen unit and stripped symbols.
- **Transcript persistence**: segments append to `transcripts.ndjson` via a writer task; `transcripts.json` is rebuilt on a 5 s debounce and at stop, then the journal is removed; readers prefer a fresher journal so recovery never misses segments.
- **Frontend**: removed the unconditional 1 Hz recording-state poller; no-op `setState` skipped on the 500 ms sync; startup IndexedDB scans once per session; shared elapsed-time hook; memoised `TranscriptContext` and `SidebarProvider`; partials in their own context; binary insert instead of full re-sort; batched IndexedDB writes; 50 ms typewriter with reduced-motion opt-out; hot-path logging behind a debug flag.
- **Build/CI**: AEC library built from the crate's bundled sources (no system `webrtc-audio-processing-2`); CI installs pipewire/clang/meson/ninja; `NO_STRIP` + `LD_LIBRARY_PATH` set for linuxdeploy; AppImage verified (≥ 50 MB, extracts, contains `libsherpa-onnx-c-api.so`) before upload; AppImage-only bundles; Vulkan SDK steps and the AVX-disabling env removed; ffmpeg download cached; docs cover offline builds and `SHERPA_ONNX_ARCHIVE_DIR`.

## Related Issue
Fixes #47
Fixes #48
Fixes #49
Fixes #50
Fixes #51
Fixes #52
Fixes #53
Fixes #54
Fixes #55

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

Rust: `cargo check` clean with default features (bundled AEC); `cargo test --lib` 271 passed, 0 failed, 3 ignored. Frontend: `tsc --noEmit` clean; whole-tree eslint warning count unchanged from `main` (22, all pre-existing). The CI workflow changes could not be exercised here (manual dispatch only); please run `build-linux` once after merge to confirm the AppImage checks pass.

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A

## Additional Notes
Contributors now need `meson` and `ninja` (plus `libpipewire-0.3-dev`/`libclang-dev`, which were already required but undocumented). New on-disk file during a recording: `transcripts.ndjson` in the meeting folder, removed at stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018unWTJUCyXCL4TnxUFqQwR

---
_Generated by [Claude Code](https://claude.ai/code/session_018unWTJUCyXCL4TnxUFqQwR)_