### PR TITLE
Backend spike crates + Rust-owned recording state and meeting lifecycle (#56 m1, #57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,22 @@ macro_rules! perf_debug {
 
 **Pattern**: Tauri commands update Rust state → Emit events → Frontend listeners update React state → Context propagates to components
 
+**Meeting row ownership** (issue #57 slice 2): Rust owns the `meetings` row's
+whole lifecycle, not just its live-recording phase. `start_recording*`
+inserts the row (status `"recording"`) and mints the `meeting_id` included in
+`recording-started`/`recording-stopped`; the `transcript-update` listener
+upserts each segment to SQLite as it arrives via a batched writer
+(`audio::transcript_db_writer`); `stop_recording` finalises the row
+(`"completed"`, or `"interrupted"` on a fatal-error stop), and a startup
+sweep marks any row still `"recording"` after a crash `"interrupted"`. The
+frontend's post-stop save is now an update to the one field it still owns
+(title, via `api_save_meeting_title`) instead of creating the row —
+`useRecordingStop` falls back to the old create-and-bulk-insert path only if
+`meeting_id` is missing (an older backend). Recovery of an interrupted
+meeting is a database query (`list_interrupted_meetings` /
+`recover_meeting`), not a scan over the IndexedDB cache, which now exists
+only as a per-viewer write-ahead cache for the live transcript list.
+
 ## Common Development Tasks
 
 ### Adding a New Tauri Command

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ members = [
     "frontend/src-tauri",
     "llama-helper",
     "llama-protocol",
-    "meetily-mcp"
+    "meetily-mcp",
+    "whisper-helper",
+    "whisper-protocol",
+    "whisper-core"
 ]
 
 # Shared workspace settings
@@ -47,5 +50,13 @@ opt-level = "s"
 # is startup and footprint, not throughput, so optimise it for size like
 # llama-helper.
 [profile.release.package.meetily-mcp]
+codegen-units = 1
+opt-level = "s"
+
+# whisper-helper (issue #56 spike): same rationale as llama-helper — lazily
+# spawned, short-lived, startup time and AppImage footprint matter more than
+# this crate's own codegen (whisper.cpp/ggml itself always builds at -O3
+# regardless of this profile).
+[profile.release.package.whisper-helper]
 codegen-units = 1
 opt-level = "s"

--- a/docs/transcription-backends.md
+++ b/docs/transcription-backends.md
@@ -1,0 +1,364 @@
+# Runtime whisper backend selection (issue #56 spike)
+
+Engineering spike: can Meetily ship one binary that picks a CPU/Vulkan/CUDA
+whisper backend at runtime, instead of building (and shipping) a separate
+binary per backend at compile time as it does today? This document reports
+what was found, what was prototyped, and what a real implementation would
+cost.
+
+**Bottom line**: `whisper-rs` 0.16 / `whisper-rs-sys` 0.15 give us no
+built-in dynamic-backend mechanism, and upgrading won't help — 0.16.0 is
+already the latest release and its feature set is unchanged from 0.15. The
+sidecar-per-backend pattern already proven by `llama-helper` is the
+practical path, and it works: this spike built a working `whisper-helper`
+CPU sidecar sharing decode logic with the in-process engine, measured its
+overhead, and found it acceptable (see [Measurements](#measurements)).
+Recommendation: proceed with the sidecar architecture, scoped as a
+multi-milestone project (see [Implementation plan](#implementation-plan)) —
+not a small patch.
+
+## 1. Confirmed whisper-rs facts
+
+Read directly from
+`~/.cargo/registry/src/*/whisper-rs-sys-0.15.0/build.rs`:
+
+- **No `GGML_BACKEND_DL` anywhere.** The build script defines
+  `GGML_CUDA`, `GGML_VULKAN`, `GGML_BLAS_VENDOR` (OpenBLAS), etc. as CMake
+  `ON`/link flags gated by `cfg!(feature = "...")`, and links the resulting
+  static libs (`static=ggml-cuda`, `static=ggml-vulkan`, ...) directly into
+  the Rust binary. There is no code path that builds ggml with
+  `GGML_BACKEND_DL=ON` (upstream ggml's actual dynamic-backend-loading
+  option) or that loads a `.so` backend plugin at runtime. Every backend is
+  baked into the binary at compile time, exactly as the CLAUDE.md doc for
+  this repo already describes.
+- **whisper-rs 0.16.0 is the latest version on crates.io** (checked via
+  `cargo info whisper-rs` through the proxy) and its feature list —
+  `cuda`, `vulkan`, `hipblas`, `coreml`, `metal`, `openblas`, `openmp`,
+  `intel-sycl`, `raw-api`, `log_backend` — is the same shape as 0.15's;
+  none of them enable dynamic loading. whisper-rs is a thin wrapper over
+  whisper.cpp/ggml and doesn't add backend-selection logic of its own.
+- Upstream **ggml** (the C library whisper.cpp sits on) does have a real
+  `GGML_BACKEND_DL` CMake option in recent versions, which builds each
+  backend as a separate `.so` loaded via `dlopen` at runtime — this is
+  the mechanism llama.cpp's own release binaries use. But `whisper-rs-sys`
+  0.15's vendored ggml snapshot and build.rs don't wire it up, and there is
+  no whisper-rs release that does. Adopting it would mean forking
+  `whisper-rs-sys`'s build.rs to add `config.define("GGML_BACKEND_DL", "ON")`
+  plus per-backend shared-library CMake targets, and reworking whisper-rs's
+  FFI layer (`raw-api` feature) to `dlopen` the right backend at
+  `WhisperContext` construction instead of linking one in — a substantial,
+  upstream-affecting change with no guarantee of being accepted, and one
+  this repo doesn't control (whisper-rs is a third-party crate, unlike
+  llama-cpp-2 which Meetily doesn't fork either).
+
+**Conclusion**: waiting for or patching in `GGML_BACKEND_DL` support is not
+a near-term option. The sidecar pattern — already shipped for LLM summaries
+via `llama-helper` — is the pragmatic way to get runtime backend selection
+without forking a C++ build system.
+
+## 2. What was built
+
+Three new workspace crates, modelled directly on `llama-helper` +
+`llama-protocol`:
+
+```
+whisper-protocol/   Shared wire-protocol types (Request/Response), like llama-protocol
+whisper-core/       FullParams construction + decoder-confidence scoring,
+                     ported from whisper_engine.rs — usable from both the
+                     in-process engine (future) and any sidecar
+whisper-helper/     The sidecar binary itself (stdio JSON-lines server)
+```
+
+Plus, behind a Cargo feature that is **off by default** and touches nothing
+in the live recording path:
+
+```
+frontend/src-tauri/src/audio/transcription/backend_probe.rs   (feature = "backend_probe")
+```
+
+### whisper-protocol
+
+`Request`: `load_model`, `transcribe` (base64 f32le samples + language +
+context prompt + per-call thread/greedy overrides), `unload`, `ping`,
+`probe` (see below), `shutdown`. `Response`: `loaded`, `transcribed`
+(text + confidence + per-segment breakdown + timing), `unloaded`, `pong`,
+`probe_result`, `goodbye`, `error`. Round-trip and forward-compatibility
+(unknown-field-ignored) unit tests included, same style as
+`llama-protocol`'s.
+
+### whisper-core
+
+Extracted the `FullParams` construction and the decoder-confidence formula
+out of `WhisperEngine::transcribe_audio_with_confidence_opts` into a
+standalone function, `transcribe_pcm16k(ctx, samples, language,
+context_prompt, decode_config, options) -> TranscriptionOutcome`. It takes
+hardware-adaptive knobs (`DecodeConfig { beam_size, max_threads,
+temperature }`) as plain arguments rather than reaching for
+`audio::HardwareProfile` itself, so it has zero dependency on Tokio,
+Tauri, or the app crate — a sidecar binary can use it standalone.
+
+**The in-process `WhisperEngine` is left unmodified for this spike.** The
+extraction is a faithful port (same params, same confidence math, same
+`pad_to_min_whisper_input` floor), not yet a shared call site — see
+[Implementation plan](#implementation-plan) milestone 2 for wiring
+`WhisperEngine` itself to call `whisper-core` and deleting the ~150 lines of
+duplicated logic it currently owns.
+
+### whisper-helper
+
+A stdio JSON-lines server with the same lifecycle as `llama-helper`: read
+one `Request` per line from stdin, write exactly one terminal `Response`
+line to stdout, serve until stdin closes or `Shutdown` arrives, restore
+default `SIGPIPE` disposition at startup so a vanished parent exits cleanly
+instead of panicking. `Probe` is new relative to `llama-helper`'s protocol —
+purpose-built for backend selection (see §3): with no model path it's a
+ping-equivalent; with one, it loads the model and runs a 1s synthetic
+(silent) decode, so a `cuda`-featured binary that can't actually find an
+NVIDIA driver fails the probe instead of reporting false success.
+
+Cargo features mirror the main app's and `llama-helper`'s exactly:
+
+```bash
+cargo build --release -p whisper-helper                    # CPU
+cargo build --release -p whisper-helper --features cuda    # NVIDIA
+cargo build --release -p whisper-helper --features vulkan  # AMD/Intel
+```
+
+Only the CPU variant was built in this container (no CUDA/Vulkan
+toolchains available here — same constraint noted in the task). See
+`whisper-helper/README.md` for the full build matrix and protocol table.
+
+### backend_probe.rs (selection logic prototype)
+
+`audio::transcription::backend_probe`, compiled only under
+`--features backend_probe` (off by default; **not** added to `lib.rs`'s
+`invoke_handler![]`, so it ships inert even if the feature were flipped on).
+It:
+
+1. Enumerates `whisper-helper-{cuda,vulkan,cpu}` next to the running
+   executable (mirrors where `build.sh` stages `llama-helper-<triple>`
+   today, i.e. `frontend/src-tauri/binaries/`).
+2. Spawns each, sends a `Probe` request, reads the terminal response.
+3. Picks the first that reports `decode_ok: Some(true)` in priority order
+   **cuda → vulkan → cpu**.
+4. Returns a `BackendSelection { candidates, recommended, manual_override }`
+   — `manual_override` is a placeholder field for a persisted user choice;
+   actually wiring it to config storage is implementation-phase work (see
+   below), not part of this spike.
+5. `get_transcription_backends()` is the shape a future
+   `#[tauri::command]` for a settings UI would take (currently a plain
+   `pub fn`, not registered as a command).
+
+This module type-checks and its unit tests pass in isolation (verified via
+a scratch crate depending only on `whisper-protocol`, `anyhow`, `serde` —
+see below on why it couldn't be checked in-tree in this container).
+
+## 3. Probe design
+
+Why a real decode instead of just `ping`: a `cuda`-featured
+`whisper-helper` binary links against `libcudart`/`libcuda` and will often
+still **spawn and respond to `ping`** on a machine with no NVIDIA GPU or
+driver (dynamic linking succeeds; only CUDA API calls at runtime fail) —
+whisper.cpp's CUDA init path fails inside `WhisperContext::new_with_params`
+or on the first `full()` call, not at process start. `ping` alone would
+therefore misreport `cuda` as available on non-NVIDIA machines. The `probe`
+request forces an actual `WhisperContext` load + a 1s silent decode through
+that backend, which is the earliest point a real CUDA/Vulkan failure
+surfaces. Cost: ~1.2s wall time per candidate with a model on disk (measured
+below) — acceptable for a one-time startup scan, not for anything
+per-recording.
+
+When no model is available yet (first run, before any model download),
+`probe` degrades to a ping-only check and reports `decode_ok: None` —
+`backend_probe` treats that as "runnable" but not "GPU-confirmed", which is
+the best available signal until a model exists.
+
+## 4. Measurements
+
+All measured in this container: CPU-only sidecar build (`opt-level = "s"`,
+`codegen-units = 1`, matching `llama-helper`'s release profile), model
+`ggml-tiny.bin` (~74MB, fetched through the proxy), 5 runs each unless
+noted, `ping`/`transcribe` measured via a Python harness driving the
+compiled binary directly over stdio.
+
+| Measurement | Result |
+|---|---|
+| Process spawn → `ping` response | **~2.0ms** median (1.87–2.29ms across 5 runs) |
+| `load_model` (tiny, 74MB, cold) | **93ms** |
+| `transcribe` round trip, 5s silence, JSON+base64 | **628–694ms** (3 runs) |
+| ...of which whisper's own `full()` decode | **624ms** (`decode_ms` field) |
+| ⇒ IPC overhead (JSON encode/decode + base64 + pipe) | **~4ms**, <1% of the round trip |
+| `probe` (spawn + load + 1s synthetic decode), cold | **1.20s** |
+| Base64 payload size for 5s @ 16kHz f32 | 426,668 bytes (320,000 bytes raw × 4/3 base64 overhead) |
+| CPU sidecar binary size (release, `opt-level = "s"`) | **2.3MB**, dynamically linked only against libstdc++/libgcc_s/libm/libc (whisper.cpp/ggml statically linked in) |
+
+**Reading these numbers**: sidecar spawn and IPC are cheap relative to
+actual decode time — even on the tiny model, `full()` dominates the round
+trip by ~150×. For `base`/`small`/`medium` models (Meetily's actual
+dev/production tiers per CLAUDE.md), decode time only grows, so the
+JSON+base64 transport is very unlikely to be the bottleneck; a shared-memory
+or tmpfile transport would shave single-digit milliseconds off something
+that already takes hundreds of milliseconds to tens of seconds. **IPC
+transport choice should not drive the architecture decision** — see §5.
+
+**CUDA/Vulkan variants were not built or measured** — this container has no
+CUDA or Vulkan toolchain (confirmed: no `nvcc`, no Vulkan SDK). Their
+startup/decode numbers should track `llama-helper`'s CUDA/Vulkan builds
+closely (same lazy-spawn sidecar shape, same whisper.cpp/ggml compute core)
+but that should be re-measured on real hardware before shipping, not assumed
+from this container's CPU numbers.
+
+### AppImage size delta (estimated, not measured)
+
+The CPU sidecar's 2.3MB is not representative of the other two — whisper.cpp
+built with `GGML_CUDA=ON` statically links CUDA compute kernels for every
+target SM architecture (`build.sh` pins `CUDAARCHS="75;80;86;89;90"`, i.e.
+Turing through Hopper — 5 architectures), and `GGML_VULKAN=ON` embeds
+compiled SPIR-V shaders. Based on published whisper.cpp/llama.cpp CUDA
+build sizes for a comparable multi-arch static link, a reasonable estimate
+is:
+
+| Sidecar | Estimated size |
+|---|---|
+| `whisper-helper-cpu` | ~2–3MB (measured: 2.3MB) |
+| `whisper-helper-vulkan` | ~15–40MB (SPIR-V shader modules, no per-SM duplication) |
+| `whisper-helper-cuda` | ~150–350MB (5 SM architectures' worth of CUDA kernels) |
+
+Shipping all three sidecars in one AppImage would add roughly **170–390MB**
+over today's CPU-only AppImage — dominated almost entirely by the CUDA
+variant. This is the single most important number for the go/no-go decision
+in §5 and **must be measured on real hardware with the actual CUDA/Vulkan
+toolchains** before committing to "ship all three in every release"; the
+range above is wide enough that it could be a non-issue or a real problem
+depending on where it lands.
+
+## 5. Recommended architecture
+
+**Sidecar-per-backend**, following `llama-helper`'s already-proven pattern,
+not a fork of `whisper-rs-sys` to chase `GGML_BACKEND_DL`. Specifics:
+
+- **IPC**: keep JSON-lines over stdio (matching `llama-helper`) for control
+  messages (`load_model`, `ping`, `probe`, `unload`, `shutdown`) and for
+  `transcribe` on typical chunk sizes. The measurements above show IPC
+  overhead is negligible next to decode time even with base64 inflation.
+  **Do not** add shared-memory/tmpfile transport in the first
+  implementation — it's premature optimization for a cost that's currently
+  <1% of the round trip, and it adds real complexity (lifecycle of a shared
+  segment across process crashes, platform differences). Revisit only if
+  profiling on real hardware (larger models, longer chunks, GPU decode
+  being fast enough that IPC becomes a bigger fraction) shows it matters.
+- **Distribution**: do not ship all three sidecars in every release by
+  default given the AppImage size estimate above. Two realistic options,
+  in order of preference:
+  1. **Ship CPU inline** (small, always works) **+ fetch CUDA/Vulkan
+     sidecars on first use**, keyed off `backend_probe`'s hardware
+     detection, the same way whisper models themselves are already
+     downloaded on demand (`WHISPER_MODEL_CATALOG` /
+     `utils::download::DownloadGuard`). This keeps the default AppImage
+     close to today's size and only pays the CUDA/Vulkan cost on machines
+     that can use it.
+  2. **Separate release artifacts** (`meetily-cpu.AppImage`,
+     `meetily-cuda.AppImage`, ...) as today, but each bundling *only* its
+     own sidecar (which is a no-op today since the backend is compiled in)
+     — this is the status quo and doesn't actually solve issue #56's stated
+     problem (official releases shipping CPU-only), so it's listed only as
+     a fallback if on-demand fetch proves impractical.
+- **Selection & override**: `backend_probe::scan_backends` at first-run /
+  settings-open time, in priority order cuda → vulkan → cpu, persisted in
+  the existing transcript config/preferences store (co-located with
+  `WHISPER_MODEL_CATALOG`'s config, not a new subsystem) with a manual
+  override field. Re-probe on app update (a new sidecar build) and on
+  demand from the settings UI (the "test backend" button pattern most audio
+  apps use).
+- **Failure/fallback behavior**:
+  - No sidecar binaries present at all (e.g. mid-migration, or a build that
+    didn't stage them) → fall back to the in-process `WhisperEngine`
+    exactly as it works today. This is why milestone 2 (below) keeps the
+    in-process path alive rather than deleting it.
+  - Chosen backend's sidecar crashes or fails to respond mid-recording →
+    the recording worker should catch the broken pipe / timeout, log it,
+    and fall back one step down the priority list (cuda→vulkan→cpu→
+    in-process), surfacing a toast/notification rather than silently
+    dropping transcription. This mirrors `SidecarManager`'s existing
+    idle/lifecycle handling for `llama-helper` — reuse that manager rather
+    than writing a second one.
+  - `probe` reporting `decode_ok: Some(false)` for the top-priority backend
+    at startup → skip it silently in `recommended`, but still list it in
+    `candidates` with its `detail` string so a settings UI can show *why*
+    (e.g. "cuda: synthetic decode failed: <driver error>") rather than just
+    omitting it.
+
+## 6. Implementation plan
+
+Effort estimates assume one engineer familiar with this codebase; sizes are
+rough (S ≈ 1-2 days, M ≈ 3-5 days, L ≈ 1-2 weeks).
+
+1. **[S] Land the spike crates as-is, wire in CI.** `whisper-protocol`,
+   `whisper-core`, `whisper-helper` already build clean (0 warnings) and
+   have unit tests; add them to whatever CI matrix builds `llama-helper`
+   today. No behavior change to the shipped app (nothing new is wired into
+   `lib.rs`).
+2. **[M] Switch `WhisperEngine` to call `whisper-core`.** Replace
+   `transcribe_audio_with_confidence_opts`'s inline `FullParams`/confidence
+   code with a call to `whisper_core::transcribe_pcm16k`, feeding it
+   `HardwareProfile`-derived `DecodeConfig`. Deletes ~150 duplicated lines,
+   makes the in-process engine and the future sidecar provably identical in
+   behavior (same function, not a hand-kept-in-sync port). Needs care around
+   `whisper-core`'s `set_no_timestamps(false)` (sidecar wants per-segment
+   timestamps; the in-process engine currently forces `true` — reconcile
+   via a `DecodeConfig`/params flag rather than silently changing existing
+   behavior) and the `clean_repetitive_text`/`is_meaningless_output`
+   post-processing the in-process engine does that wasn't ported into
+   `whisper-core` for this spike (needs a decision: move into
+   `whisper-core` too, or keep as an engine-side post-process step callable
+   from both paths).
+3. **[M] `SidecarManager`-style lifecycle for whisper-helper.** Reuse/
+   generalize `summary/summary_engine/sidecar.rs`'s idle-timeout/respawn
+   logic rather than writing a parallel one; wire `backend_probe` results
+   into it as the "which binary to spawn" input.
+4. **[M] Build/staging integration.** Extend `build.sh`/`dev.sh` to build
+   `whisper-helper` alongside `llama-helper` (same `HELPER_FEATURES` pattern
+   already in `build.sh`) and stage it into `binaries/` under Tauri's
+   `externalBin` naming convention. Decide and implement the
+   on-demand-fetch-for-GPU-variants distribution model from §5 — this is
+   the highest-uncertainty item; depends on real AppImage size numbers from
+   milestone 1's CI builds on GPU-capable runners.
+5. **[L] Route the live recording path through the sidecar,** behind the
+   `backend_probe`-selected backend, with the in-process engine as the
+   fallback described in §5. Includes: settings UI consuming
+   `get_transcription_backends` (registering it as an actual
+   `#[tauri::command]`), the manual-override persistence `backend_probe`
+   currently stubs, and end-to-end testing on real CUDA/Vulkan hardware
+   (unavailable in this spike's container).
+6. **[S] Remove compile-time `cuda`/`vulkan`/`hipblas`/`openblas` features
+   from the main app crate** once milestone 5 ships and is validated, since
+   the sidecar makes them redundant — cleans up `frontend/src-tauri/
+   Cargo.toml`'s feature list and the per-backend release build matrix in
+   `build.sh`/CI.
+
+Milestones 1–2 are safe to land independently and incrementally de-risk the
+rest; 3–5 are where the actual runtime-selection payoff (issue #56's ask)
+lands, and 4 in particular needs real GPU hardware to validate the
+distribution-size tradeoff before committing.
+
+## Appendix: build/test status in this environment
+
+- `whisper-protocol`, `whisper-core`, `whisper-helper`: `cargo build
+  --release -p whisper-helper` and `cargo test -p whisper-core -p
+  whisper-protocol --release` both pass with **zero errors and zero
+  warnings** (`CARGO_TARGET_DIR=/home/user/Meetily-Local/target`,
+  `SHERPA_ONNX_ARCHIVE_DIR` set per the task instructions).
+- `backend_probe.rs`: could not run `cargo check` on the full
+  `frontend/src-tauri` crate in this container — it fails **before**
+  reaching this module, in an unrelated pre-existing dependency
+  (`webrtc-audio-processing-sys` needs system lib
+  `webrtc-audio-processing-2` ≥ 2.1 via pkg-config; this container only has
+  `libwebrtc-audio-processing-dev` 0.3.1, the older v1 API/soname). This is
+  an environment gap unrelated to anything touched in this spike — verified
+  by confirming the failure occurs during `webrtc-audio-processing-sys`'s
+  build script, entirely before `audio::transcription` (or any code this
+  spike added) is compiled. To still validate `backend_probe.rs`, it was
+  checked in an isolated scratch crate depending only on `whisper-protocol`,
+  `anyhow`, and `serde` (its actual dependency set under the
+  `backend_probe` feature): `cargo check` and `cargo test` both pass clean,
+  including its two unit tests.

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -41,6 +41,12 @@ hipblas = ["whisper-rs/hipblas"]   # Linux: AMD ROCm HIP
 openblas = ["whisper-rs/openblas"] # Optimized BLAS (Auto-enabled on Windows/Linux)
 openmp = ["whisper-rs/openmp"]     # OpenMP parallel processing
 
+# Issue #56 spike only: compiles audio::transcription::backend_probe, which
+# probes whisper-helper-{cuda,vulkan,cpu} sidecar binaries next to the exe.
+# Off by default — not wired into the live recording path or invoke_handler.
+# See docs/transcription-backends.md.
+backend_probe = ["dep:whisper-protocol"]
+
 [build-dependencies]
 tauri-build = { version = "2.6.0", features = [] }
 reqwest = { version = "0.11", features = ["blocking", "multipart", "json", "stream"] }
@@ -55,6 +61,10 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 # Wire protocol shared with the llama-helper sidecar.
 llama-protocol = { path = "../../llama-protocol" }
+# Wire protocol shared with the whisper-helper sidecar spike (issue #56).
+# Optional: only pulled in by the `backend_probe` feature, which is off by
+# default.
+whisper-protocol = { path = "../../whisper-protocol", optional = true }
 # Used only for `_exit` on shutdown — see the RunEvent::Exit handler in lib.rs.
 libc = "0.2"
 # Encoding per-segment audio clips for playback in the webview.

--- a/frontend/src-tauri/migrations/20260910010000_add_meeting_status.sql
+++ b/frontend/src-tauri/migrations/20260910010000_add_meeting_status.sql
@@ -1,0 +1,18 @@
+-- Issue #57 slice 2: Rust owns the meeting row lifecycle instead of the
+-- frontend creating the row only after a live recording finishes.
+--
+-- status: "recording" (row created when `start_recording*` begins capture),
+-- "completed" (normal stop finalised it), or "interrupted" (a fatal-error
+-- stop, or a row still "recording" when the app starts back up after a
+-- crash — see `MeetingsRepository::mark_stale_recording_meetings_interrupted`).
+--
+-- Existing rows predate lifecycle tracking entirely and are assumed to have
+-- finished normally.
+ALTER TABLE meetings ADD COLUMN status TEXT NOT NULL DEFAULT 'completed';
+ALTER TABLE meetings ADD COLUMN completed_at TEXT;
+ALTER TABLE meetings ADD COLUMN duration_seconds REAL;
+ALTER TABLE meetings ADD COLUMN audio_path TEXT;
+
+-- The recovery dialog lists rows by status; the crash-marker sweep at
+-- startup updates every "recording" row.
+CREATE INDEX IF NOT EXISTS idx_meetings_status ON meetings(status);

--- a/frontend/src-tauri/migrations/20260910020000_add_transcripts_meeting_sequence_unique.sql
+++ b/frontend/src-tauri/migrations/20260910020000_add_transcripts_meeting_sequence_unique.sql
@@ -1,0 +1,13 @@
+-- Issue #57 slice 2: the live-recording path now upserts transcript rows by
+-- (meeting_id, sequence_id) as segments stream in, instead of bulk-inserting
+-- once at the end of the meeting. `ON CONFLICT(meeting_id, sequence_id)`
+-- needs a matching unique index to target.
+--
+-- SQLite treats each NULL as distinct in a UNIQUE index, so this never
+-- collides for the batch/import/retranscription paths (which leave
+-- sequence_id NULL) or for older rows saved before sequence tracking —
+-- only the live-recording path, which always sets sequence_id, upserts
+-- through it. The existing non-unique `idx_transcripts_meeting_sequence`
+-- (added for refinement's read lookups) is left in place.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transcripts_meeting_sequence_unique
+    ON transcripts (meeting_id, sequence_id);

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -21,6 +21,7 @@ pub mod incremental_saver;
 pub mod pipeline;
 pub mod recording_commands;
 pub mod recording_manager;
+pub mod recording_phase;
 pub mod recording_preferences;
 pub mod recording_saver;
 pub mod recording_state;

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -28,6 +28,12 @@ pub mod recording_state;
 pub mod simple_level_monitor;
 pub mod stream;
 
+// Batched SQLite writer for live-recording transcript segments (issue #57
+// slice 2) and the crash-recovery commands (`list_interrupted_meetings`,
+// `recover_meeting`) that read the meeting-row lifecycle it feeds.
+pub mod recovery_commands;
+pub mod transcript_db_writer;
+
 // Transcription module (provider abstraction, engine management, worker pool)
 pub mod transcription;
 

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -12,6 +12,7 @@ use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tokio::task::JoinHandle;
 
 use super::devices::{AudioDevice, DeviceType};
+use super::recording_phase::{self, RecordingPhase};
 use super::RecordingManager;
 
 // Import transcription modules
@@ -64,6 +65,26 @@ impl Drop for PhaseGuard {
 /// True while a stop is still draining / finalising a previous recording.
 pub fn is_stop_in_progress() -> bool {
     STOP_IN_PROGRESS.load(Ordering::SeqCst)
+}
+
+/// Move the canonical recording-state machine (`audio::recording_phase`) to
+/// `phase` and broadcast the resulting snapshot as `recording-state`,
+/// merging in the live duration/queue-depth data this module owns
+/// (`RECORDING_MANAGER`, the transcription queue). This is the single place
+/// every phase transition in this file goes through.
+fn emit_phase<R: Runtime>(app: &AppHandle<R>, phase: RecordingPhase) {
+    let (active_duration_secs, total_pause_secs) = {
+        let guard = RECORDING_MANAGER.lock().unwrap();
+        match guard.as_ref() {
+            Some(m) => (
+                m.get_active_recording_duration(),
+                m.get_total_pause_duration(),
+            ),
+            None => (None, 0.0),
+        }
+    };
+    let chunks_in_queue = transcription::queue_depth();
+    recording_phase::set_phase(app, phase, active_duration_secs, total_pause_secs, chunks_in_queue);
 }
 
 /// Shared entry check for every start path. Refuses while another start is
@@ -130,6 +151,8 @@ fn spawn_fatal_error_stop<R: Runtime>(
         error.user_message()
     );
     let _ = app.emit("recording-error", error.user_message());
+    recording_phase::set_error_message(Some(error.user_message().to_string()));
+    emit_phase(app, RecordingPhase::Error);
 
     let app_for_stop = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -205,6 +228,11 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     // still-finalising stop) and check the live recording flag.
     let _start_phase = begin_start_phase().await?;
 
+    // The canonical state machine's first transition: Idle -> Starting,
+    // before any of the awaits below (model validation, preferences, device
+    // enumeration, PipeWire stream open) that can take a noticeable moment.
+    emit_phase(&app, RecordingPhase::Starting);
+
     // Validate that transcription models are available before starting recording
     info!("🔍 Validating transcription model availability before starting recording...");
     if let Err(validation_error) = transcription::validate_transcription_model_ready(&app).await {
@@ -221,6 +249,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
             }),
         );
 
+        emit_phase(&app, RecordingPhase::Idle);
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
@@ -299,7 +328,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         let now = chrono::Local::now();
         format!("Meeting {}", now.format("%Y-%m-%d_%H-%M-%S"))
     });
-    manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_meeting_name(Some(effective_meeting_name.clone()));
 
     // Set up error callback: on a fatal error (report_error only calls this
     // once per session — see recording_state::report_error) tell the user
@@ -312,10 +341,16 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     });
 
     // Start recording with resolved devices (replaces start_recording_with_defaults_and_auto_save call)
-    let transcription_receiver = manager
+    let transcription_receiver = match manager
         .start_recording(microphone_device, system_device, auto_save, streaming_partials)
         .await
-        .map_err(|e| format!("Failed to start recording: {}", e))?;
+    {
+        Ok(rx) => rx,
+        Err(e) => {
+            emit_phase(&app, RecordingPhase::Idle);
+            return Err(format!("Failed to start recording: {}", e));
+        }
+    };
 
     // Recording itself only needs raw PCM, but finalizing it into a
     // playable file needs ffmpeg — warn (once, non-fatal) rather than
@@ -331,6 +366,14 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     // Claim the streaming-partial receiver before the manager is moved into
     // the global (None when partials are disabled).
     let partial_receiver = manager.take_partial_receiver();
+
+    // Record the meeting name/folder for the canonical snapshot while we
+    // still own `manager` locally (the folder is created inside
+    // `start_recording` above, via the recording saver's accumulation).
+    let folder_path_for_phase = manager
+        .get_meeting_folder()
+        .map(|p| p.to_string_lossy().to_string());
+    recording_phase::set_meeting_info(Some(effective_meeting_name.clone()), folder_path_for_phase);
 
     // Store the manager globally to keep it alive
     {
@@ -426,6 +469,7 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
 
     // Update tray menu to reflect recording state
     crate::tray::update_tray_menu(&app);
+    emit_phase(&app, RecordingPhase::Recording);
 
     info!("✅ Recording started successfully with async-first approach");
 
@@ -457,6 +501,11 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     // still-finalising stop) and check the live recording flag.
     let _start_phase = begin_start_phase().await?;
 
+    // The canonical state machine's first transition: Idle -> Starting,
+    // before any of the awaits below (model validation, preferences, device
+    // enumeration, PipeWire stream open) that can take a noticeable moment.
+    emit_phase(&app, RecordingPhase::Starting);
+
     // Validate that transcription models are available before starting recording
     info!("🔍 Validating transcription model availability before starting recording...");
     if let Err(validation_error) = transcription::validate_transcription_model_ready(&app).await {
@@ -473,6 +522,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
             }),
         );
 
+        emit_phase(&app, RecordingPhase::Idle);
         return Err(validation_error);
     }
     info!("✅ Transcription model validation passed");
@@ -516,7 +566,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
         let now = chrono::Local::now();
         format!("Meeting {}", now.format("%Y-%m-%d_%H-%M-%S"))
     });
-    manager.set_meeting_name(Some(effective_meeting_name));
+    manager.set_meeting_name(Some(effective_meeting_name.clone()));
 
     // Set up error callback: on a fatal error (report_error only calls this
     // once per session — see recording_state::report_error) tell the user
@@ -529,10 +579,16 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     });
 
     // Start recording with specified devices and auto_save setting
-    let transcription_receiver = manager
+    let transcription_receiver = match manager
         .start_recording(mic_device, system_device, auto_save, streaming_partials)
         .await
-        .map_err(|e| format!("Failed to start recording: {}", e))?;
+    {
+        Ok(rx) => rx,
+        Err(e) => {
+            emit_phase(&app, RecordingPhase::Idle);
+            return Err(format!("Failed to start recording: {}", e));
+        }
+    };
 
     // Recording itself only needs raw PCM, but finalizing it into a
     // playable file needs ffmpeg — warn (once, non-fatal) rather than
@@ -548,6 +604,14 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     // Claim the streaming-partial receiver before the manager is moved into
     // the global (None when partials are disabled).
     let partial_receiver = manager.take_partial_receiver();
+
+    // Record the meeting name/folder for the canonical snapshot while we
+    // still own `manager` locally (the folder is created inside
+    // `start_recording` above, via the recording saver's accumulation).
+    let folder_path_for_phase = manager
+        .get_meeting_folder()
+        .map(|p| p.to_string_lossy().to_string());
+    recording_phase::set_meeting_info(Some(effective_meeting_name.clone()), folder_path_for_phase);
 
     // Store the manager globally to keep it alive
     {
@@ -646,6 +710,7 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
 
     // Update tray menu to reflect recording state
     crate::tray::update_tray_menu(&app);
+    emit_phase(&app, RecordingPhase::Recording);
 
     info!("✅ Recording started with custom devices using async-first approach");
 
@@ -682,6 +747,10 @@ pub async fn stop_recording<R: Runtime>(
     // over the manager slot while the drain / save below is still running.
     let _stop_phase = PhaseGuard::try_acquire(&STOP_IN_PROGRESS)
         .ok_or_else(|| "Recording stop already in progress".to_string())?;
+
+    // Canonical state machine: Recording/Paused/Error -> Stopping, as early
+    // as possible in the stop flow.
+    emit_phase(&app, RecordingPhase::Stopping);
 
     // Emit shutdown progress to frontend
     let _ = app.emit(
@@ -735,9 +804,15 @@ pub async fn stop_recording<R: Runtime>(
     match stop_result {
         Ok(_) => {
             info!("✅ Audio streams stopped successfully - no more chunks will be created");
+            // Canonical state machine: Stopping -> Finalising — the force
+            // flush is done, and the drain/save that follows below can take
+            // seconds to minutes.
+            emit_phase(&app, RecordingPhase::Finalising);
         }
         Err(e) => {
             error!("❌ Failed to stop audio streams: {}", e);
+            recording_phase::set_error_message(Some(e.to_string()));
+            emit_phase(&app, RecordingPhase::Error);
             return Err(format!("Failed to stop audio streams: {}", e));
         }
     }
@@ -1008,6 +1083,9 @@ pub async fn stop_recording<R: Runtime>(
 
     // Update tray menu to reflect stopped state
     crate::tray::update_tray_menu(&app);
+    // Canonical state machine: Finalising -> Idle, now that
+    // `recording-stopped` has been emitted.
+    emit_phase(&app, RecordingPhase::Idle);
 
     info!("🎉 Recording stopped successfully with ZERO transcript chunks lost");
     Ok(())
@@ -1044,28 +1122,32 @@ pub async fn pause_recording<R: Runtime>(app: AppHandle<R>) -> Result<(), String
         return Err("No recording is currently active".to_string());
     }
 
-    // Access the recording manager and pause it
-    let manager_guard = RECORDING_MANAGER.lock().unwrap();
-    if let Some(manager) = manager_guard.as_ref() {
-        manager.pause_recording().map_err(|e| e.to_string())?;
-
-        // Emit pause event to frontend
-        app.emit(
-            "recording-paused",
-            serde_json::json!({
-                "message": "Recording paused"
-            }),
-        )
-        .map_err(|e| e.to_string())?;
-
-        // Update tray menu to reflect paused state
-        crate::tray::update_tray_menu(&app);
-
-        info!("Recording paused successfully");
-        Ok(())
-    } else {
-        Err("No recording manager found".to_string())
+    // Access the recording manager and pause it. Scoped so the lock is
+    // dropped before `emit_phase` below re-locks the same (non-reentrant)
+    // static to read live duration data.
+    {
+        let manager_guard = RECORDING_MANAGER.lock().unwrap();
+        match manager_guard.as_ref() {
+            Some(manager) => manager.pause_recording().map_err(|e| e.to_string())?,
+            None => return Err("No recording manager found".to_string()),
+        }
     }
+
+    // Emit pause event to frontend
+    app.emit(
+        "recording-paused",
+        serde_json::json!({
+            "message": "Recording paused"
+        }),
+    )
+    .map_err(|e| e.to_string())?;
+
+    // Update tray menu to reflect paused state
+    crate::tray::update_tray_menu(&app);
+    emit_phase(&app, RecordingPhase::Paused);
+
+    info!("Recording paused successfully");
+    Ok(())
 }
 
 /// Resume the current recording
@@ -1078,28 +1160,32 @@ pub async fn resume_recording<R: Runtime>(app: AppHandle<R>) -> Result<(), Strin
         return Err("No recording is currently active".to_string());
     }
 
-    // Access the recording manager and resume it
-    let manager_guard = RECORDING_MANAGER.lock().unwrap();
-    if let Some(manager) = manager_guard.as_ref() {
-        manager.resume_recording().map_err(|e| e.to_string())?;
-
-        // Emit resume event to frontend
-        app.emit(
-            "recording-resumed",
-            serde_json::json!({
-                "message": "Recording resumed"
-            }),
-        )
-        .map_err(|e| e.to_string())?;
-
-        // Update tray menu to reflect resumed state
-        crate::tray::update_tray_menu(&app);
-
-        info!("Recording resumed successfully");
-        Ok(())
-    } else {
-        Err("No recording manager found".to_string())
+    // Access the recording manager and resume it. Scoped so the lock is
+    // dropped before `emit_phase` below re-locks the same (non-reentrant)
+    // static to read live duration data.
+    {
+        let manager_guard = RECORDING_MANAGER.lock().unwrap();
+        match manager_guard.as_ref() {
+            Some(manager) => manager.resume_recording().map_err(|e| e.to_string())?,
+            None => return Err("No recording manager found".to_string()),
+        }
     }
+
+    // Emit resume event to frontend
+    app.emit(
+        "recording-resumed",
+        serde_json::json!({
+            "message": "Recording resumed"
+        }),
+    )
+    .map_err(|e| e.to_string())?;
+
+    // Update tray menu to reflect resumed state
+    crate::tray::update_tray_menu(&app);
+    emit_phase(&app, RecordingPhase::Recording);
+
+    info!("Recording resumed successfully");
+    Ok(())
 }
 
 /// Check if recording is currently paused
@@ -1116,31 +1202,66 @@ pub async fn is_recording_paused() -> bool {
 /// Get detailed recording state
 #[tauri::command]
 pub async fn get_recording_state() -> serde_json::Value {
-    let manager_guard = RECORDING_MANAGER.lock().unwrap();
+    let (
+        is_recording_flag,
+        is_paused_flag,
+        is_active_flag,
+        recording_duration,
+        active_duration,
+        total_pause_duration,
+        current_pause_duration,
+    ) = {
+        let manager_guard = RECORDING_MANAGER.lock().unwrap();
+        match manager_guard.as_ref() {
+            Some(manager) => (
+                manager.is_recording(),
+                manager.is_paused(),
+                manager.is_active(),
+                manager.get_recording_duration(),
+                manager.get_active_recording_duration(),
+                manager.get_total_pause_duration(),
+                manager.get_current_pause_duration(),
+            ),
+            None => (false, false, false, None, None, 0.0, None),
+        }
+    };
+    let chunks_in_queue = transcription::queue_depth();
 
-    if let Some(manager) = manager_guard.as_ref() {
-        serde_json::json!({
-            "is_recording": manager.is_recording(),
-            "is_finalising": is_stop_in_progress(),
-            "is_paused": manager.is_paused(),
-            "is_active": manager.is_active(),
-            "recording_duration": manager.get_recording_duration(),
-            "active_duration": manager.get_active_recording_duration(),
-            "total_pause_duration": manager.get_total_pause_duration(),
-            "current_pause_duration": manager.get_current_pause_duration()
-        })
-    } else {
-        serde_json::json!({
-            "is_recording": false,
-            "is_finalising": is_stop_in_progress(),
-            "is_paused": false,
-            "is_active": false,
-            "recording_duration": null,
-            "active_duration": null,
-            "total_pause_duration": 0.0,
-            "current_pause_duration": null
-        })
+    // The canonical snapshot (phase, started_at_ms, meeting_name,
+    // folder_path, error, seq) merged with the live duration/queue data
+    // above — the same fields `recording-state` events carry, so a fresh
+    // window/tab that only calls this once on mount gets exactly what it
+    // would have received had it been listening from the start.
+    let snapshot = recording_phase::build_snapshot(active_duration, total_pause_duration, chunks_in_queue);
+
+    let mut value = serde_json::to_value(&snapshot).unwrap_or_else(|_| serde_json::json!({}));
+    if let serde_json::Value::Object(map) = &mut value {
+        // Legacy keys kept for compatibility with existing callers.
+        map.insert("is_recording".to_string(), serde_json::json!(is_recording_flag));
+        map.insert(
+            "is_finalising".to_string(),
+            serde_json::json!(is_stop_in_progress()),
+        );
+        map.insert("is_paused".to_string(), serde_json::json!(is_paused_flag));
+        map.insert("is_active".to_string(), serde_json::json!(is_active_flag));
+        map.insert(
+            "recording_duration".to_string(),
+            serde_json::json!(recording_duration),
+        );
+        map.insert(
+            "active_duration".to_string(),
+            serde_json::json!(active_duration),
+        );
+        map.insert(
+            "total_pause_duration".to_string(),
+            serde_json::json!(total_pause_duration),
+        );
+        map.insert(
+            "current_pause_duration".to_string(),
+            serde_json::json!(current_pause_duration),
+        );
     }
+    value
 }
 
 /// Get the meeting folder path for the current recording

--- a/frontend/src-tauri/src/audio/recording_commands.rs
+++ b/frontend/src-tauri/src/audio/recording_commands.rs
@@ -13,7 +13,10 @@ use tokio::task::JoinHandle;
 
 use super::devices::{AudioDevice, DeviceType};
 use super::recording_phase::{self, RecordingPhase};
+use super::transcript_db_writer::TranscriptDbWriter;
 use super::RecordingManager;
+use crate::database::repositories::meeting::MeetingsRepository;
+use crate::state::AppState;
 
 // Import transcription modules
 use super::transcription::{self, reset_speech_detected_flag};
@@ -28,6 +31,50 @@ pub use super::transcription::TranscriptUpdate;
 // Global recording manager and transcription task to keep them alive during recording
 static RECORDING_MANAGER: Mutex<Option<RecordingManager>> = Mutex::new(None);
 static TRANSCRIPTION_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
+
+/// Batched SQLite writer for the current session's live transcript segments
+/// (issue #57 slice 2), and its task handle. Started once `start_recording*`
+/// has a `meeting_id` and a DB pool; shut down (sender dropped, task
+/// awaited) partway through `stop_recording`, after the transcription drain
+/// has delivered every tail segment to the `transcript-update` listener.
+static TRANSCRIPT_DB_WRITER: Mutex<Option<TranscriptDbWriter>> = Mutex::new(None);
+static TRANSCRIPT_DB_WRITER_TASK: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
+
+/// Fetch the SQLite pool, if `AppState` has been managed yet. `None` early
+/// in startup — e.g. a first-launch cold start racing a start/stop call
+/// before the frontend has created the database. Every call site here
+/// treats a missing pool as "log and continue" rather than failing the
+/// recording (issue #57 slice 2's explicit contract for the meeting-row
+/// writes).
+fn db_pool<R: Runtime>(app: &AppHandle<R>) -> Option<sqlx::SqlitePool> {
+    app.try_state::<AppState>()
+        .map(|s| s.db_manager.pool().clone())
+}
+
+/// Best-effort: mark `meeting_id`'s row "interrupted" (issue #57 slice 2).
+/// Used on every abnormal stop path — a fatal recording error, or the audio
+/// streams themselves failing to stop — so a row never lingers at
+/// "recording" while the app keeps running (only a real crash needs the
+/// startup sweep; this covers every case that doesn't crash the process).
+/// Never fails the caller's own error path: logs and returns either way.
+async fn mark_meeting_interrupted_best_effort<R: Runtime>(
+    app: &AppHandle<R>,
+    meeting_id: &Option<String>,
+) {
+    let Some(mid) = meeting_id else { return };
+    let Some(pool) = db_pool(app) else {
+        warn!(
+            "No DB pool available; meeting {} row was not marked interrupted",
+            mid
+        );
+        return;
+    };
+    match MeetingsRepository::mark_meeting_interrupted(&pool, mid).await {
+        Ok(true) => info!("DB: meeting {} row marked interrupted", mid),
+        Ok(false) => warn!("DB: meeting {} row not found to mark interrupted", mid),
+        Err(e) => warn!("DB: failed to mark meeting {} row interrupted: {}", mid, e),
+    }
+}
 
 /// Held from the first line of a `start_recording*` call until it returns.
 /// `is_recording()` only flips true once the manager is stored — after
@@ -330,6 +377,15 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     });
     manager.set_meeting_name(Some(effective_meeting_name.clone()));
 
+    // Mint the meeting_id up front (issue #57 slice 2): kept for the whole
+    // session so live transcript upserts, `recording-started`/
+    // `recording-stopped`, and the `meetings` row itself all agree on one
+    // id. Minting it doesn't depend on the DB insert below succeeding — a
+    // failed insert still leaves every other use of this id well-defined
+    // (transcript upserts just won't have a row to match against).
+    let meeting_id = uuid::Uuid::new_v4().to_string();
+    manager.set_meeting_id(Some(meeting_id.clone()));
+
     // Set up error callback: on a fatal error (report_error only calls this
     // once per session — see recording_state::report_error) tell the user
     // and run the exact same full stop flow the Stop button runs, so
@@ -373,7 +429,49 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     let folder_path_for_phase = manager
         .get_meeting_folder()
         .map(|p| p.to_string_lossy().to_string());
-    recording_phase::set_meeting_info(Some(effective_meeting_name.clone()), folder_path_for_phase);
+    recording_phase::set_meeting_info(
+        Some(effective_meeting_name.clone()),
+        folder_path_for_phase.clone(),
+        Some(meeting_id.clone()),
+    );
+
+    // Create the `meetings` row now, status "recording" (issue #57 slice 2)
+    // — Rust owns the row's whole lifecycle from here, so a crash mid-
+    // recording leaves a real "recording"-status row for the next startup's
+    // sweep to mark "interrupted" instead of nothing at all. Best-effort:
+    // the recording itself must never fail because this insert did.
+    if let Some(pool) = db_pool(&app) {
+        if let Err(e) = MeetingsRepository::create_recording_meeting(
+            &pool,
+            &meeting_id,
+            &effective_meeting_name,
+            folder_path_for_phase.as_deref(),
+        )
+        .await
+        {
+            warn!(
+                "Failed to create meeting row {} at recording start (continuing without it): {}",
+                meeting_id, e
+            );
+        }
+        // Batched writer for live transcript-segment upserts, regardless of
+        // whether the insert above succeeded — see its own doc comment.
+        let (writer, writer_task) = TranscriptDbWriter::start(pool);
+        *TRANSCRIPT_DB_WRITER.lock().unwrap() = Some(writer);
+        let stale_task = TRANSCRIPT_DB_WRITER_TASK.lock().unwrap().replace(writer_task);
+        if let Some(stale_task) = stale_task {
+            // Same defensive cleanup as the stale transcript-update listener
+            // below: a previous session's task should already be gone, but
+            // never leave two writers racing against the same DB rows.
+            stale_task.abort();
+            warn!("⚠️ Aborted a stale transcript DB writer task from a previous session");
+        }
+    } else {
+        warn!(
+            "No DB pool available yet; meeting {} won't be persisted to SQLite live (transcripts.ndjson on disk is unaffected)",
+            meeting_id
+        );
+    }
 
     // Store the manager globally to keep it alive
     {
@@ -413,6 +511,11 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
     // Store listener ID for cleanup during stop_recording to ensure microphone is released
     {
         use tauri::Listener;
+        // Captured by value into the listener closure below so every
+        // segment it enqueues for SQLite carries this session's meeting_id,
+        // without touching the (frequently swapped) RECORDING_MANAGER lock
+        // to look it up on every event.
+        let meeting_id_for_listener = meeting_id.clone();
         let listener_id = app.listen("transcript-update", move |event: tauri::Event| {
             // Parse the transcript update from the event payload
             if let Ok(update) = serde_json::from_str::<TranscriptUpdate>(event.payload()) {
@@ -431,6 +534,15 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
                     voice_profile_id: update.voice_profile_id.clone(),
                     source: Some(update.source.clone()),
                 };
+
+                // Persist to SQLite via the batched writer (issue #57 slice
+                // 2) — a cheap channel send, non-blocking, independent of
+                // the RecordingSaver copy saved just below.
+                if let Ok(writer_guard) = TRANSCRIPT_DB_WRITER.lock() {
+                    if let Some(writer) = writer_guard.as_ref() {
+                        writer.enqueue(meeting_id_for_listener.clone(), segment.clone());
+                    }
+                }
 
                 // Save to recording manager
                 if let Ok(manager_guard) = RECORDING_MANAGER.lock() {
@@ -462,7 +574,8 @@ pub async fn start_recording_with_meeting_name<R: Runtime>(
         serde_json::json!({
             "message": "Recording started successfully with parallel processing",
             "devices": ["Default Microphone", "Default System Audio"],
-            "workers": 3
+            "workers": 3,
+            "meeting_id": meeting_id
         }),
     )
     .map_err(|e| e.to_string())?;
@@ -568,6 +681,15 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     });
     manager.set_meeting_name(Some(effective_meeting_name.clone()));
 
+    // Mint the meeting_id up front (issue #57 slice 2): kept for the whole
+    // session so live transcript upserts, `recording-started`/
+    // `recording-stopped`, and the `meetings` row itself all agree on one
+    // id. Minting it doesn't depend on the DB insert below succeeding — a
+    // failed insert still leaves every other use of this id well-defined
+    // (transcript upserts just won't have a row to match against).
+    let meeting_id = uuid::Uuid::new_v4().to_string();
+    manager.set_meeting_id(Some(meeting_id.clone()));
+
     // Set up error callback: on a fatal error (report_error only calls this
     // once per session — see recording_state::report_error) tell the user
     // and run the exact same full stop flow the Stop button runs, so
@@ -611,7 +733,49 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     let folder_path_for_phase = manager
         .get_meeting_folder()
         .map(|p| p.to_string_lossy().to_string());
-    recording_phase::set_meeting_info(Some(effective_meeting_name.clone()), folder_path_for_phase);
+    recording_phase::set_meeting_info(
+        Some(effective_meeting_name.clone()),
+        folder_path_for_phase.clone(),
+        Some(meeting_id.clone()),
+    );
+
+    // Create the `meetings` row now, status "recording" (issue #57 slice 2)
+    // — Rust owns the row's whole lifecycle from here, so a crash mid-
+    // recording leaves a real "recording"-status row for the next startup's
+    // sweep to mark "interrupted" instead of nothing at all. Best-effort:
+    // the recording itself must never fail because this insert did.
+    if let Some(pool) = db_pool(&app) {
+        if let Err(e) = MeetingsRepository::create_recording_meeting(
+            &pool,
+            &meeting_id,
+            &effective_meeting_name,
+            folder_path_for_phase.as_deref(),
+        )
+        .await
+        {
+            warn!(
+                "Failed to create meeting row {} at recording start (continuing without it): {}",
+                meeting_id, e
+            );
+        }
+        // Batched writer for live transcript-segment upserts, regardless of
+        // whether the insert above succeeded — see its own doc comment.
+        let (writer, writer_task) = TranscriptDbWriter::start(pool);
+        *TRANSCRIPT_DB_WRITER.lock().unwrap() = Some(writer);
+        let stale_task = TRANSCRIPT_DB_WRITER_TASK.lock().unwrap().replace(writer_task);
+        if let Some(stale_task) = stale_task {
+            // Same defensive cleanup as the stale transcript-update listener
+            // below: a previous session's task should already be gone, but
+            // never leave two writers racing against the same DB rows.
+            stale_task.abort();
+            warn!("⚠️ Aborted a stale transcript DB writer task from a previous session");
+        }
+    } else {
+        warn!(
+            "No DB pool available yet; meeting {} won't be persisted to SQLite live (transcripts.ndjson on disk is unaffected)",
+            meeting_id
+        );
+    }
 
     // Store the manager globally to keep it alive
     {
@@ -651,6 +815,11 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
     // Store listener ID for cleanup during stop_recording to ensure microphone is released
     {
         use tauri::Listener;
+        // Captured by value into the listener closure below so every
+        // segment it enqueues for SQLite carries this session's meeting_id,
+        // without touching the (frequently swapped) RECORDING_MANAGER lock
+        // to look it up on every event.
+        let meeting_id_for_listener = meeting_id.clone();
         let listener_id = app.listen("transcript-update", move |event: tauri::Event| {
             // Parse the transcript update from the event payload
             if let Ok(update) = serde_json::from_str::<TranscriptUpdate>(event.payload()) {
@@ -669,6 +838,15 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
                     voice_profile_id: update.voice_profile_id.clone(),
                     source: Some(update.source.clone()),
                 };
+
+                // Persist to SQLite via the batched writer (issue #57 slice
+                // 2) — a cheap channel send, non-blocking, independent of
+                // the RecordingSaver copy saved just below.
+                if let Ok(writer_guard) = TRANSCRIPT_DB_WRITER.lock() {
+                    if let Some(writer) = writer_guard.as_ref() {
+                        writer.enqueue(meeting_id_for_listener.clone(), segment.clone());
+                    }
+                }
 
                 // Save to recording manager
                 if let Ok(manager_guard) = RECORDING_MANAGER.lock() {
@@ -703,7 +881,8 @@ pub async fn start_recording_with_devices_and_meeting<R: Runtime>(
                 mic_device_name.unwrap_or_else(|| "Default Microphone".to_string()),
                 system_device_name.unwrap_or_else(|| "Default System Audio".to_string())
             ],
-            "workers": 3
+            "workers": 3,
+            "meeting_id": meeting_id
         }),
     )
     .map_err(|e| e.to_string())?;
@@ -747,6 +926,22 @@ pub async fn stop_recording<R: Runtime>(
     // over the manager slot while the drain / save below is still running.
     let _stop_phase = PhaseGuard::try_acquire(&STOP_IN_PROGRESS)
         .ok_or_else(|| "Recording stop already in progress".to_string())?;
+
+    // Captured before the Stopping transition below moves the canonical
+    // phase away from Error — distinguishes a fatal-error-triggered stop
+    // (issue #57 slice 2: the meeting row should end up "interrupted") from
+    // a normal user-initiated stop ("completed"). This function runs
+    // unchanged for both — `spawn_fatal_error_stop` just calls it.
+    let was_fatal_error = recording_phase::current_phase() == RecordingPhase::Error;
+
+    // The meeting_id for this session, if any (issue #57 slice 2) — read
+    // once, up front, while the manager is still definitely present; used at
+    // the end of this function to finalise the `meetings` row.
+    let meeting_id_for_stop: Option<String> = RECORDING_MANAGER
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|m| m.get_meeting_id());
 
     // Canonical state machine: Recording/Paused/Error -> Stopping, as early
     // as possible in the stop flow.
@@ -813,6 +1008,7 @@ pub async fn stop_recording<R: Runtime>(
             error!("❌ Failed to stop audio streams: {}", e);
             recording_phase::set_error_message(Some(e.to_string()));
             emit_phase(&app, RecordingPhase::Error);
+            mark_meeting_interrupted_best_effort(&app, &meeting_id_for_stop).await;
             return Err(format!("Failed to stop audio streams: {}", e));
         }
     }
@@ -926,6 +1122,25 @@ pub async fn stop_recording<R: Runtime>(
         }
     }
 
+    // Shut down the transcript DB writer (issue #57 slice 2): every segment
+    // this session enqueued has been sent by now (the listener above is
+    // gone), so dropping the writer closes its channel — the task then
+    // flushes whatever's left in its current batch and returns, which this
+    // awaits (bounded) before moving on.
+    {
+        let writer = TRANSCRIPT_DB_WRITER.lock().unwrap().take();
+        drop(writer);
+        let task = TRANSCRIPT_DB_WRITER_TASK.lock().unwrap().take();
+        if let Some(task) = task {
+            match tokio::time::timeout(tokio::time::Duration::from_secs(5), task).await {
+                Ok(_) => info!("✅ Transcript DB writer task drained and finished"),
+                Err(_) => warn!(
+                    "⏱️ Transcript DB writer task still running after drain; abandoning wait (transcripts.ndjson on disk is unaffected)"
+                ),
+            }
+        }
+    }
+
     // The streaming-partial task ends on its own once the pipeline drops its
     // sender (it clears the overlay as it exits). Give it a moment, then
     // abort anything still running so a late partial can never re-populate
@@ -1006,59 +1221,96 @@ pub async fn stop_recording<R: Runtime>(
     );
 
     // Perform final cleanup with the manager if available
-    let (meeting_folder, meeting_name) = if let Some(mut manager) = manager_for_cleanup {
-        info!("🧹 Performing final cleanup and saving recording data");
+    let (meeting_folder, meeting_name, final_audio_path, final_duration_seconds) =
+        if let Some(mut manager) = manager_for_cleanup {
+            info!("🧹 Performing final cleanup and saving recording data");
 
-        // Extract meeting info BEFORE async operations
-        let meeting_folder = manager.get_meeting_folder();
-        let meeting_name = manager.get_meeting_name();
+            // Extract meeting info BEFORE async operations
+            let meeting_folder = manager.get_meeting_folder();
+            let meeting_name = manager.get_meeting_name();
 
-        match tokio::time::timeout(
-            tokio::time::Duration::from_secs(300), // 5 minutes max for file I/O
-            manager.save_recording_only(&app),
-        )
-        .await
-        {
-            Ok(Ok(_)) => {
-                info!("✅ Recording data saved successfully during cleanup");
-            }
-            Ok(Err(e)) => {
-                warn!(
-                    "⚠️ Error during recording cleanup (transcripts preserved): {}",
-                    e
-                );
-                // Don't fail shutdown - transcripts are already preserved
-            }
-            Err(_) => {
-                warn!("⏱️ File I/O timeout (5 minutes) reached during save, continuing shutdown");
-                // Don't fail shutdown - transcripts are already preserved
-            }
-        }
+            let (audio_path, duration_seconds) = match tokio::time::timeout(
+                tokio::time::Duration::from_secs(300), // 5 minutes max for file I/O
+                manager.save_recording_only(&app),
+            )
+            .await
+            {
+                Ok(Ok((audio_path, duration_seconds))) => {
+                    info!("✅ Recording data saved successfully during cleanup");
+                    (audio_path, duration_seconds)
+                }
+                Ok(Err(e)) => {
+                    warn!(
+                        "⚠️ Error during recording cleanup (transcripts preserved): {}",
+                        e
+                    );
+                    // Don't fail shutdown - transcripts are already preserved
+                    (None, None)
+                }
+                Err(_) => {
+                    warn!(
+                        "⏱️ File I/O timeout (5 minutes) reached during save, continuing shutdown"
+                    );
+                    // Don't fail shutdown - transcripts are already preserved
+                    (None, None)
+                }
+            };
 
-        (meeting_folder, meeting_name)
-    } else {
-        info!("ℹ️ No recording manager available for cleanup");
-        (None, None)
-    };
+            (meeting_folder, meeting_name, audio_path, duration_seconds)
+        } else {
+            info!("ℹ️ No recording manager available for cleanup");
+            (None, None, None, None)
+        };
 
     // Recording state was already cleared when the manager was taken out of
     // `RECORDING_MANAGER` (and via `RecordingState::cleanup()`/`stop_recording()`
     // internally) earlier in this shutdown sequence — nothing left to flip here.
 
-    // Step 4.5: Prepare metadata for frontend (NO database save)
-    // NOTE: We do NOT save to database here. The frontend will save after all transcripts are displayed.
-    // This ensures the user sees all transcripts streaming in before the database save happens.
+    // Step 4.5: Finalise the meeting row (issue #57 slice 2) and prepare
+    // metadata for the frontend. The row itself — title, transcripts,
+    // status — is entirely Rust's; the frontend's post-stop save now only
+    // ever touches fields it still owns (see `api_save_meeting_title`).
     let (folder_path_str, meeting_name_str) = match (&meeting_folder, &meeting_name) {
         (Some(path), Some(name)) => (Some(path.to_string_lossy().to_string()), Some(name.clone())),
         _ => (None, None),
     };
 
-    info!("📤 Preparing recording metadata for frontend save");
+    info!("📤 Preparing recording metadata for frontend");
     info!("   folder_path: {:?}", folder_path_str);
     info!("   meeting_name: {:?}", meeting_name_str);
+    info!("   meeting_id: {:?}", meeting_id_for_stop);
 
-    // Database save removed - frontend will handle this after receiving all transcripts
-    info!("ℹ️ Skipping database save in Rust - frontend will save after all transcripts received");
+    if let Some(mid) = &meeting_id_for_stop {
+        if let Some(pool) = db_pool(&app) {
+            let result = if was_fatal_error {
+                MeetingsRepository::mark_meeting_interrupted(&pool, mid)
+                    .await
+                    .map(|_| ())
+            } else {
+                MeetingsRepository::mark_meeting_completed(
+                    &pool,
+                    mid,
+                    final_duration_seconds,
+                    final_audio_path.as_deref(),
+                )
+                .await
+                .map(|_| ())
+            };
+            match result {
+                Ok(_) => info!(
+                    "DB: meeting {} row finalised ({})",
+                    mid,
+                    if was_fatal_error { "interrupted" } else { "completed" }
+                ),
+                Err(e) => warn!("DB: failed to finalise meeting {} row: {}", mid, e),
+            }
+        } else {
+            warn!(
+                "No DB pool available; meeting {} row was not finalised",
+                mid
+            );
+        }
+    }
 
     // Step 5: Complete shutdown
     let _ = app.emit(
@@ -1070,13 +1322,16 @@ pub async fn stop_recording<R: Runtime>(
         }),
     );
 
-    // Emit final stop event with folder_path and meeting_name for frontend to save
+    // Emit final stop event with folder_path, meeting_name and meeting_id.
+    // The frontend no longer needs meeting_id to look up *whether* it has a
+    // meeting to update — the row already exists — only to know which row.
     app.emit(
         "recording-stopped",
         serde_json::json!({
-            "message": "Recording stopped - frontend will save after all transcripts received",
+            "message": "Recording stopped",
             "folder_path": folder_path_str,
-            "meeting_name": meeting_name_str
+            "meeting_name": meeting_name_str,
+            "meeting_id": meeting_id_for_stop
         }),
     )
     .map_err(|e| e.to_string())?;

--- a/frontend/src-tauri/src/audio/recording_manager.rs
+++ b/frontend/src-tauri/src/audio/recording_manager.rs
@@ -256,11 +256,15 @@ impl RecordingManager {
         Ok(())
     }
 
-    /// Save recording after transcription is complete
+    /// Save recording after transcription is complete. Returns the final
+    /// audio file path (`None` if auto-save was disabled or saving failed)
+    /// and the active recording duration used to save it, so the caller can
+    /// finalise the meeting's database row (issue #57 slice 2) without
+    /// re-deriving either value.
     pub async fn save_recording_only<R: tauri::Runtime>(
         &mut self,
         app: &tauri::AppHandle<R>,
-    ) -> Result<()> {
+    ) -> Result<(Option<String>, Option<f64>)> {
         debug!("Saving recording with transcript chunks");
 
         // Get actual recording duration from state
@@ -268,25 +272,28 @@ impl RecordingManager {
         info!("Recording duration from state: {:?}s", recording_duration);
 
         // Save the recording with actual duration
-        match self
+        let audio_path = match self
             .recording_saver
             .stop_and_save(app, recording_duration)
             .await
         {
             Ok(Some(file_path)) => {
                 info!("Recording saved successfully to: {}", file_path);
+                Some(file_path)
             }
             Ok(None) => {
                 debug!("Recording not saved (auto-save disabled or no audio data)");
+                None
             }
             Err(e) => {
                 error!("Failed to save recording: {}", e);
                 // Don't fail the stop operation if saving fails
+                None
             }
-        }
+        };
 
         debug!("Recording save operation completed");
-        Ok(())
+        Ok((audio_path, recording_duration))
     }
 
     /// Stop recording and save audio (legacy method)
@@ -413,6 +420,17 @@ impl RecordingManager {
     /// Set the meeting name for this recording session
     pub fn set_meeting_name(&mut self, name: Option<String>) {
         self.recording_saver.set_meeting_name(name);
+    }
+
+    /// Set the `meetings` row id for this recording session (issue #57
+    /// slice 2).
+    pub fn set_meeting_id(&mut self, id: Option<String>) {
+        self.recording_saver.set_meeting_id(id);
+    }
+
+    /// Get the `meetings` row id for this recording session, if set.
+    pub fn get_meeting_id(&self) -> Option<String> {
+        self.recording_saver.get_meeting_id()
     }
 
     /// Add a structured transcript segment to be saved later

--- a/frontend/src-tauri/src/audio/recording_phase.rs
+++ b/frontend/src-tauri/src/audio/recording_phase.rs
@@ -1,0 +1,291 @@
+// audio/recording_phase.rs
+//
+// Canonical recording-state machine (GitHub issue #57, slice 1): a single
+// Rust-owned source of truth for recording lifecycle state, broadcast to the
+// frontend via one `recording-state` event instead of the frontend polling
+// `get_recording_state` every 500ms.
+//
+// This module owns only the *phase* and the handful of fields that are
+// phase-scoped (when the current session started recording, its meeting
+// name/folder, the last fatal error). Live numeric fields (transcription
+// queue depth, active/pause durations) come from the caller —
+// `recording_commands.rs`, which owns `RECORDING_MANAGER` — at the moment a
+// snapshot is built or emitted; this module never reaches for them itself,
+// so it stays independently unit-testable.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Emitter, Runtime};
+
+/// Recording lifecycle phase, owned entirely by the Rust side. The frontend
+/// maps this onto its own `RecordingStatus` enum rather than deriving status
+/// from polled booleans.
+#[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum RecordingPhase {
+    Idle,
+    Starting,
+    Recording,
+    Paused,
+    Stopping,
+    Finalising,
+    Error,
+}
+
+/// Full state snapshot broadcast to the frontend on every phase change (as
+/// the `recording-state` event payload) and returned by the
+/// `get_recording_state` command.
+#[derive(Serialize, Clone, Debug)]
+pub struct RecordingSnapshot {
+    pub phase: RecordingPhase,
+    /// Unix ms the current session entered `Recording` (None once idle).
+    /// The frontend ticks elapsed time client-side from this instead of
+    /// polling a duration.
+    pub started_at_ms: Option<u64>,
+    pub active_duration_secs: Option<f64>,
+    pub total_pause_secs: f64,
+    pub meeting_name: Option<String>,
+    pub folder_path: Option<String>,
+    pub chunks_in_queue: usize,
+    pub error: Option<String>,
+    /// Monotonically increasing with every emitted snapshot, so a listener
+    /// that ends up observing two snapshots out of order (unlikely over a
+    /// single Tauri event channel, but cheap to guard against) can tell
+    /// which one is newer.
+    pub seq: u64,
+}
+
+struct PhaseState {
+    phase: RecordingPhase,
+    started_at_ms: Option<u64>,
+    meeting_name: Option<String>,
+    folder_path: Option<String>,
+    error: Option<String>,
+}
+
+static PHASE_STATE: Mutex<PhaseState> = Mutex::new(PhaseState {
+    phase: RecordingPhase::Idle,
+    started_at_ms: None,
+    meeting_name: None,
+    folder_path: None,
+    error: None,
+});
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Pure transition check: is `current -> target` an allowed move in the
+/// recording lifecycle? Kept separate from `set_phase` so the transition
+/// table is unit-testable without touching the static holder or emitting
+/// anything.
+///
+/// Transition table:
+///
+/// | from        | to                                    |
+/// |-------------|----------------------------------------|
+/// | Idle        | Starting                                |
+/// | Starting    | Recording, Idle (start failed)          |
+/// | Recording   | Paused, Stopping                        |
+/// | Paused      | Recording, Stopping                     |
+/// | Stopping    | Finalising                               |
+/// | Finalising  | Idle                                    |
+/// | Error       | Stopping (auto-stop), Idle              |
+/// | *           | Error (fatal error, any phase)          |
+pub fn next_phase(
+    current: RecordingPhase,
+    target: RecordingPhase,
+) -> Result<RecordingPhase, String> {
+    use RecordingPhase::*;
+
+    let allowed = target == Error
+        || matches!(
+            (current, target),
+            (Idle, Starting)
+                | (Starting, Recording)
+                | (Starting, Idle)
+                | (Recording, Paused)
+                | (Paused, Recording)
+                | (Recording, Stopping)
+                | (Paused, Stopping)
+                | (Stopping, Finalising)
+                | (Finalising, Idle)
+                | (Error, Stopping)
+                | (Error, Idle)
+        );
+
+    if allowed {
+        Ok(target)
+    } else {
+        Err(format!(
+            "invalid recording phase transition: {:?} -> {:?}",
+            current, target
+        ))
+    }
+}
+
+/// Current phase, read without building a full snapshot — cheap and sync,
+/// used by the tray to decide whether a click should start, stop, or be a
+/// no-op.
+pub fn current_phase() -> RecordingPhase {
+    PHASE_STATE.lock().unwrap().phase
+}
+
+/// Move to `phase`, stamping/clearing the phase-scoped fields that follow
+/// from the transition, and bump `seq`.
+fn apply(phase: RecordingPhase) {
+    let mut state = PHASE_STATE.lock().unwrap();
+    if let Err(e) = next_phase(state.phase, phase) {
+        // Never block a real transition on this — the table above documents
+        // the intended lifecycle, but the actual command flow in
+        // recording_commands.rs remains the real source of truth for what's
+        // allowed to happen. Just flag the mismatch for whoever's debugging
+        // the state machine.
+        log::warn!("recording_phase: {} (applying anyway)", e);
+    }
+    match phase {
+        RecordingPhase::Recording if state.started_at_ms.is_none() => {
+            state.started_at_ms = Some(now_ms());
+        }
+        RecordingPhase::Idle => {
+            state.started_at_ms = None;
+            state.meeting_name = None;
+            state.folder_path = None;
+            state.error = None;
+        }
+        _ => {}
+    }
+    state.phase = phase;
+    SEQ.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Record the meeting name / folder path for the in-progress session. Set
+/// once `start_recording` knows them; read back by `get_recording_state` and
+/// included in every subsequent `recording-state` emit until the phase
+/// returns to `Idle`.
+pub fn set_meeting_info(meeting_name: Option<String>, folder_path: Option<String>) {
+    let mut state = PHASE_STATE.lock().unwrap();
+    state.meeting_name = meeting_name;
+    state.folder_path = folder_path;
+}
+
+/// Record the last fatal error's user-facing message. Cleared automatically
+/// on the next transition back to `Idle`.
+pub fn set_error_message(message: Option<String>) {
+    PHASE_STATE.lock().unwrap().error = message;
+}
+
+/// Build the full outward-facing snapshot. `active_duration_secs`,
+/// `total_pause_secs` and `chunks_in_queue` are supplied by the caller
+/// (`recording_commands.rs`, which owns `RECORDING_MANAGER` and the
+/// transcription queue) — this module only tracks the phase-scoped fields.
+pub fn build_snapshot(
+    active_duration_secs: Option<f64>,
+    total_pause_secs: f64,
+    chunks_in_queue: usize,
+) -> RecordingSnapshot {
+    let state = PHASE_STATE.lock().unwrap();
+    RecordingSnapshot {
+        phase: state.phase,
+        started_at_ms: state.started_at_ms,
+        active_duration_secs,
+        total_pause_secs,
+        meeting_name: state.meeting_name.clone(),
+        folder_path: state.folder_path.clone(),
+        chunks_in_queue,
+        error: state.error.clone(),
+        seq: SEQ.load(Ordering::SeqCst),
+    }
+}
+
+/// Move to `phase` and emit the canonical `recording-state` event with the
+/// resulting snapshot, merged with live duration/queue data from the
+/// caller. This is the only place `recording-state` is emitted — every
+/// `RecordingPhase` transition in `recording_commands.rs` goes through it,
+/// so `seq` is a true total order over every transition regardless of which
+/// command triggered it.
+pub fn set_phase<R: Runtime>(
+    app: &AppHandle<R>,
+    phase: RecordingPhase,
+    active_duration_secs: Option<f64>,
+    total_pause_secs: f64,
+    chunks_in_queue: usize,
+) {
+    apply(phase);
+    let snapshot = build_snapshot(active_duration_secs, total_pause_secs, chunks_in_queue);
+    log::debug!(
+        "recording_phase -> {:?} (seq {})",
+        snapshot.phase,
+        snapshot.seq
+    );
+    if let Err(e) = app.emit("recording-state", &snapshot) {
+        log::warn!("Failed to emit recording-state: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use RecordingPhase::*;
+
+    #[test]
+    fn happy_path_transitions_are_allowed() {
+        assert_eq!(next_phase(Idle, Starting), Ok(Starting));
+        assert_eq!(next_phase(Starting, Recording), Ok(Recording));
+        assert_eq!(next_phase(Recording, Paused), Ok(Paused));
+        assert_eq!(next_phase(Paused, Recording), Ok(Recording));
+        assert_eq!(next_phase(Recording, Stopping), Ok(Stopping));
+        assert_eq!(next_phase(Paused, Stopping), Ok(Stopping));
+        assert_eq!(next_phase(Stopping, Finalising), Ok(Finalising));
+        assert_eq!(next_phase(Finalising, Idle), Ok(Idle));
+    }
+
+    #[test]
+    fn a_failed_start_returns_to_idle() {
+        assert_eq!(next_phase(Starting, Idle), Ok(Idle));
+    }
+
+    #[test]
+    fn any_phase_can_go_fatal() {
+        for phase in [Idle, Starting, Recording, Paused, Stopping, Finalising, Error] {
+            assert_eq!(next_phase(phase, Error), Ok(Error));
+        }
+    }
+
+    #[test]
+    fn error_recovers_via_the_stop_flow_or_directly_to_idle() {
+        assert_eq!(next_phase(Error, Stopping), Ok(Stopping));
+        assert_eq!(next_phase(Error, Idle), Ok(Idle));
+    }
+
+    #[test]
+    fn skipping_a_phase_is_rejected() {
+        assert!(next_phase(Idle, Recording).is_err());
+        assert!(next_phase(Recording, Finalising).is_err());
+        assert!(next_phase(Idle, Stopping).is_err());
+        assert!(next_phase(Idle, Finalising).is_err());
+    }
+
+    // The only test that touches the process-global PHASE_STATE — kept to a
+    // single test so parallel test execution can never race it against
+    // another test mutating the same static.
+    #[test]
+    fn apply_stamps_started_at_on_entering_recording_and_clears_on_idle() {
+        apply(Idle);
+        assert!(PHASE_STATE.lock().unwrap().started_at_ms.is_none());
+
+        apply(Starting);
+        apply(Recording);
+        assert!(PHASE_STATE.lock().unwrap().started_at_ms.is_some());
+
+        apply(Idle);
+        assert!(PHASE_STATE.lock().unwrap().started_at_ms.is_none());
+    }
+}

--- a/frontend/src-tauri/src/audio/recording_phase.rs
+++ b/frontend/src-tauri/src/audio/recording_phase.rs
@@ -48,6 +48,11 @@ pub struct RecordingSnapshot {
     pub total_pause_secs: f64,
     pub meeting_name: Option<String>,
     pub folder_path: Option<String>,
+    /// The `meetings` row id for the in-progress session (issue #57 slice
+    /// 2), set as soon as `start_recording*` mints it — before the DB
+    /// insert even completes, since the id is generated first and used
+    /// either way. `None` once idle.
+    pub meeting_id: Option<String>,
     pub chunks_in_queue: usize,
     pub error: Option<String>,
     /// Monotonically increasing with every emitted snapshot, so a listener
@@ -62,6 +67,7 @@ struct PhaseState {
     started_at_ms: Option<u64>,
     meeting_name: Option<String>,
     folder_path: Option<String>,
+    meeting_id: Option<String>,
     error: Option<String>,
 }
 
@@ -70,6 +76,7 @@ static PHASE_STATE: Mutex<PhaseState> = Mutex::new(PhaseState {
     started_at_ms: None,
     meeting_name: None,
     folder_path: None,
+    meeting_id: None,
     error: None,
 });
 
@@ -158,6 +165,7 @@ fn apply(phase: RecordingPhase) {
             state.started_at_ms = None;
             state.meeting_name = None;
             state.folder_path = None;
+            state.meeting_id = None;
             state.error = None;
         }
         _ => {}
@@ -166,14 +174,19 @@ fn apply(phase: RecordingPhase) {
     SEQ.fetch_add(1, Ordering::SeqCst);
 }
 
-/// Record the meeting name / folder path for the in-progress session. Set
-/// once `start_recording` knows them; read back by `get_recording_state` and
-/// included in every subsequent `recording-state` emit until the phase
-/// returns to `Idle`.
-pub fn set_meeting_info(meeting_name: Option<String>, folder_path: Option<String>) {
+/// Record the meeting name / folder path / meeting_id for the in-progress
+/// session. Set once `start_recording` knows them; read back by
+/// `get_recording_state` and included in every subsequent `recording-state`
+/// emit until the phase returns to `Idle`.
+pub fn set_meeting_info(
+    meeting_name: Option<String>,
+    folder_path: Option<String>,
+    meeting_id: Option<String>,
+) {
     let mut state = PHASE_STATE.lock().unwrap();
     state.meeting_name = meeting_name;
     state.folder_path = folder_path;
+    state.meeting_id = meeting_id;
 }
 
 /// Record the last fatal error's user-facing message. Cleared automatically
@@ -199,6 +212,7 @@ pub fn build_snapshot(
         total_pause_secs,
         meeting_name: state.meeting_name.clone(),
         folder_path: state.folder_path.clone(),
+        meeting_id: state.meeting_id.clone(),
         chunks_in_queue,
         error: state.error.clone(),
         seq: SEQ.load(Ordering::SeqCst),

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -26,6 +26,11 @@ pub struct RecordingSaver {
     incremental_saver: Option<Arc<AsyncMutex<IncrementalAudioSaver>>>,
     meeting_folder: Option<PathBuf>,
     meeting_name: Option<String>,
+    /// The `meetings` row id for this session (issue #57 slice 2). Minted
+    /// by `recording_commands::start_recording*` before the manager is
+    /// stored globally, so it's available for the whole session — used to
+    /// key live transcript upserts and to finalise the row at stop.
+    meeting_id: Option<String>,
     metadata: Option<MeetingMetadata>,
     transcript_segments: Arc<Mutex<Vec<TranscriptSegment>>>,
     chunk_receiver: Option<mpsc::UnboundedReceiver<AudioChunk>>,
@@ -53,6 +58,7 @@ impl RecordingSaver {
             incremental_saver: None,
             meeting_folder: None,
             meeting_name: None,
+            meeting_id: None,
             metadata: None,
             transcript_segments: Arc::new(Mutex::new(Vec::new())),
             chunk_receiver: None,
@@ -66,6 +72,18 @@ impl RecordingSaver {
     /// Set the meeting name for this recording session
     pub fn set_meeting_name(&mut self, name: Option<String>) {
         self.meeting_name = name;
+    }
+
+    /// Set the `meetings` row id for this recording session (issue #57
+    /// slice 2). Set once, right after the id is minted in
+    /// `recording_commands::start_recording*`.
+    pub fn set_meeting_id(&mut self, id: Option<String>) {
+        self.meeting_id = id;
+    }
+
+    /// Get the `meetings` row id for this recording session, if set.
+    pub fn get_meeting_id(&self) -> Option<String> {
+        self.meeting_id.clone()
     }
 
     /// Set device information in metadata

--- a/frontend/src-tauri/src/audio/recovery_commands.rs
+++ b/frontend/src-tauri/src/audio/recovery_commands.rs
@@ -1,0 +1,145 @@
+// audio/recovery_commands.rs
+//
+// Issue #57 slice 2: recovery of a meeting an unclean shutdown interrupted
+// mid-recording is now a database query (`meetings.status = 'interrupted'`,
+// set by `mark_stale_recording_meetings_interrupted` at startup and by the
+// fatal-error stop path) instead of the frontend scanning an IndexedDB
+// cache it built up itself. IndexedDB stays only as a per-viewer
+// write-ahead cache for the live transcript list — it has no say in what
+// counts as recoverable any more.
+
+use log::{info, warn};
+use serde::Serialize;
+use tauri::State;
+
+use crate::database::repositories::meeting::{InterruptedMeetingRow, MeetingsRepository};
+use crate::state::AppState;
+
+use super::incremental_saver::{
+    cleanup_checkpoints, has_audio_checkpoints, recover_audio_from_checkpoints,
+    AudioRecoveryStatus,
+};
+
+/// One row of `list_interrupted_meetings`. `has_audio_checkpoints` folds in
+/// a filesystem check (whether `.checkpoints/` still holds unmerged audio)
+/// alongside the DB-only fields from `InterruptedMeetingRow`.
+#[derive(Debug, Clone, Serialize)]
+pub struct InterruptedMeeting {
+    pub meeting_id: String,
+    pub title: String,
+    pub folder_path: Option<String>,
+    pub created_at: String,
+    pub segment_count: i64,
+    pub has_audio_checkpoints: bool,
+}
+
+/// List every meeting an unclean shutdown left in "recording" long enough
+/// for the startup sweep to mark it "interrupted" (or that a fatal
+/// recording error marked interrupted directly). Ordered most-recent
+/// first, matching the old IndexedDB-backed dialog's sort.
+#[tauri::command]
+pub async fn list_interrupted_meetings(
+    state: State<'_, AppState>,
+) -> Result<Vec<InterruptedMeeting>, String> {
+    let pool = state.db_manager.pool();
+    let rows: Vec<InterruptedMeetingRow> = MeetingsRepository::list_interrupted_meetings(pool)
+        .await
+        .map_err(|e| format!("Failed to list interrupted meetings: {}", e))?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let has_audio = match &row.folder_path {
+            Some(folder) => has_audio_checkpoints(folder.clone())
+                .await
+                .unwrap_or(false),
+            None => false,
+        };
+        out.push(InterruptedMeeting {
+            meeting_id: row.meeting_id,
+            title: row.title,
+            folder_path: row.folder_path,
+            created_at: row.created_at.0.to_rfc3339(),
+            segment_count: row.segment_count,
+            has_audio_checkpoints: has_audio,
+        });
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RecoverMeetingResult {
+    pub success: bool,
+    pub meeting_id: String,
+    pub audio_recovery_status: Option<AudioRecoveryStatus>,
+}
+
+/// Recover one interrupted meeting: merge any `.checkpoints/` audio still on
+/// disk into `audio.mp4` (best-effort — a meeting can still be recovered
+/// with transcripts only), then mark the row "completed". The transcript
+/// rows themselves need no recovery work here — they were already upserted
+/// live by `transcript_db_writer` while the meeting recorded, up to
+/// whatever was flushed before the interruption.
+#[tauri::command]
+pub async fn recover_meeting(
+    state: State<'_, AppState>,
+    meeting_id: String,
+) -> Result<RecoverMeetingResult, String> {
+    let pool = state.db_manager.pool();
+
+    let meeting = MeetingsRepository::get_meeting_metadata(pool, &meeting_id)
+        .await
+        .map_err(|e| format!("Failed to look up meeting {}: {}", meeting_id, e))?
+        .ok_or_else(|| format!("Meeting {} not found", meeting_id))?;
+
+    let mut audio_recovery_status: Option<AudioRecoveryStatus> = None;
+    if let Some(folder) = meeting.folder_path.clone() {
+        if has_audio_checkpoints(folder.clone())
+            .await
+            .unwrap_or(false)
+        {
+            match recover_audio_from_checkpoints(folder.clone(), 48000).await {
+                Ok(status) => {
+                    if status.status == "success" {
+                        if let Err(e) = cleanup_checkpoints(folder.clone()).await {
+                            warn!(
+                                "Recovered meeting {} but failed to clean up checkpoints: {}",
+                                meeting_id, e
+                            );
+                        }
+                    }
+                    audio_recovery_status = Some(status);
+                }
+                Err(e) => {
+                    warn!(
+                        "Audio recovery failed for meeting {} (transcripts are recovered regardless): {}",
+                        meeting_id, e
+                    );
+                }
+            }
+        }
+    }
+
+    let duration_seconds = audio_recovery_status
+        .as_ref()
+        .map(|s| s.estimated_duration_seconds);
+    let audio_path = audio_recovery_status
+        .as_ref()
+        .and_then(|s| s.audio_file_path.clone());
+
+    MeetingsRepository::mark_meeting_completed(
+        pool,
+        &meeting_id,
+        duration_seconds,
+        audio_path.as_deref(),
+    )
+    .await
+    .map_err(|e| format!("Failed to finalise recovered meeting {}: {}", meeting_id, e))?;
+
+    info!("✅ Recovered meeting {}", meeting_id);
+
+    Ok(RecoverMeetingResult {
+        success: true,
+        meeting_id,
+        audio_recovery_status,
+    })
+}

--- a/frontend/src-tauri/src/audio/transcript_db_writer.rs
+++ b/frontend/src-tauri/src/audio/transcript_db_writer.rs
@@ -1,0 +1,246 @@
+// audio/transcript_db_writer.rs
+//
+// Issue #57 slice 2: persist live-recording transcript segments to SQLite as
+// they arrive, instead of the frontend bulk-inserting the whole meeting once
+// at the end. The `transcript-update` listener in `recording_commands.rs`
+// already stores every segment in `RecordingSaver` (and, via the journal
+// writer, on disk) synchronously; this module gives it a second, equally
+// cheap, non-blocking place to hand the same segment off to — a channel
+// send — so the listener itself never touches the database directly.
+//
+// A dedicated task owns the actual writes: it batches whatever arrives on
+// the channel and flushes to `TranscriptsRepository::upsert_transcript_segments`
+// either once 20 segments have queued up or every second, whichever comes
+// first. Dropping the `TranscriptDbWriter` (its `Sender`) closes the
+// channel; the task then flushes anything left and returns, which is what
+// `stop_recording` waits on to guarantee every segment from the session is
+// written before it moves on.
+
+use log::{info, warn};
+use sqlx::SqlitePool;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{interval, Duration, MissedTickBehavior};
+
+use crate::audio::common::TranscriptSegment;
+use crate::database::repositories::transcript::TranscriptsRepository;
+
+/// Flush once this many segments have queued up, even if the interval
+/// hasn't ticked yet.
+const BATCH_SIZE: usize = 20;
+/// Otherwise flush at most this often.
+const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Handle held by the command layer for the lifetime of one recording
+/// session. `enqueue` is a plain unbounded-channel send — cheap enough to
+/// call directly from the synchronous `transcript-update` event listener.
+pub struct TranscriptDbWriter {
+    sender: mpsc::UnboundedSender<(String, TranscriptSegment)>,
+}
+
+impl TranscriptDbWriter {
+    /// Spawn the writer task against `pool` and return a handle to enqueue
+    /// segments plus the task's `JoinHandle` (for the caller to await at
+    /// stop, after dropping the handle to close the channel).
+    pub fn start(pool: SqlitePool) -> (Self, JoinHandle<()>) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let task = tokio::spawn(run_writer(pool, receiver));
+        (Self { sender }, task)
+    }
+
+    /// Queue `segment` for `meeting_id` to be written on the next flush.
+    /// Never blocks; silently drops (with a warning) if the writer task has
+    /// already ended — the transcripts.ndjson journal is still the
+    /// authoritative record for the session in that case.
+    pub fn enqueue(&self, meeting_id: String, segment: TranscriptSegment) {
+        if self.sender.send((meeting_id, segment)).is_err() {
+            warn!("Transcript DB writer task is gone; a segment was not queued for SQLite");
+        }
+    }
+}
+
+async fn run_writer(
+    pool: SqlitePool,
+    mut receiver: mpsc::UnboundedReceiver<(String, TranscriptSegment)>,
+) {
+    let mut batch: Vec<(String, TranscriptSegment)> = Vec::with_capacity(BATCH_SIZE);
+    let mut ticker = interval(FLUSH_INTERVAL);
+    // The first tick fires immediately; skip it so an idle recording
+    // doesn't run a pointless empty-batch flush right at startup, and
+    // catch-up ticks after a slow flush don't pile up.
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+            maybe_item = receiver.recv() => {
+                match maybe_item {
+                    Some(item) => {
+                        batch.push(item);
+                        if batch.len() >= BATCH_SIZE {
+                            flush(&pool, &mut batch).await;
+                        }
+                    }
+                    None => {
+                        // Sender dropped (recording stopped): flush whatever
+                        // is left and end the task.
+                        flush(&pool, &mut batch).await;
+                        info!("Transcript DB writer task ending (channel closed)");
+                        return;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                flush(&pool, &mut batch).await;
+            }
+        }
+    }
+}
+
+async fn flush(pool: &SqlitePool, batch: &mut Vec<(String, TranscriptSegment)>) {
+    if batch.is_empty() {
+        return;
+    }
+    let items = std::mem::take(batch);
+    let count = items.len();
+    if let Err(e) = TranscriptsRepository::upsert_transcript_segments(pool, &items).await {
+        warn!(
+            "Failed to write a batch of {} transcript segment(s) to SQLite: {} (transcripts.ndjson on disk is unaffected)",
+            count, e
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::repositories::meeting::MeetingsRepository;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    fn segment(sequence_id: u64, text: &str) -> TranscriptSegment {
+        TranscriptSegment {
+            id: format!("seg_{}", sequence_id),
+            text: text.to_string(),
+            timestamp: None,
+            audio_start_time: Some(sequence_id as f64),
+            audio_end_time: Some(sequence_id as f64 + 1.0),
+            duration: Some(1.0),
+            display_time: None,
+            confidence: None,
+            sequence_id: Some(sequence_id),
+            speaker: None,
+            voice_profile_id: None,
+            source: Some("mic".to_string()),
+        }
+    }
+
+    /// Two segments below `BATCH_SIZE`, sent then the channel closed
+    /// immediately: the writer task must still flush them on shutdown
+    /// rather than dropping whatever hadn't reached a full batch.
+    #[tokio::test]
+    async fn flushes_remaining_segments_when_channel_closes() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "meeting-1", "Test", None)
+            .await
+            .unwrap();
+
+        let (writer, task) = TranscriptDbWriter::start(pool.clone());
+        writer.enqueue("meeting-1".to_string(), segment(1, "hello"));
+        writer.enqueue("meeting-1".to_string(), segment(2, "world"));
+        drop(writer); // closes the channel
+
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("writer task should finish promptly")
+            .expect("writer task should not panic");
+
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT transcript FROM transcripts WHERE meeting_id = ? ORDER BY sequence_id")
+                .bind("meeting-1")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, vec![("hello".to_string(),), ("world".to_string(),)]);
+    }
+
+    /// A later segment with the same `sequence_id` (the transcription
+    /// worker revising a partial into its final text) must update the
+    /// existing row in place, not insert a duplicate.
+    #[tokio::test]
+    async fn upserts_by_sequence_id_instead_of_duplicating() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "meeting-2", "Test", None)
+            .await
+            .unwrap();
+
+        let (writer, task) = TranscriptDbWriter::start(pool.clone());
+        writer.enqueue("meeting-2".to_string(), segment(1, "partial text"));
+        writer.enqueue("meeting-2".to_string(), segment(1, "final text"));
+        drop(writer);
+
+        tokio::time::timeout(Duration::from_secs(5), task)
+            .await
+            .expect("writer task should finish promptly")
+            .expect("writer task should not panic");
+
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT transcript FROM transcripts WHERE meeting_id = ?")
+                .bind("meeting-2")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(rows, vec![("final text".to_string(),)]);
+    }
+
+    /// A batch that reaches `BATCH_SIZE` flushes on its own, without
+    /// waiting for the channel to close or the interval to tick.
+    #[tokio::test]
+    async fn flushes_once_batch_size_is_reached() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "meeting-3", "Test", None)
+            .await
+            .unwrap();
+
+        let (writer, task) = TranscriptDbWriter::start(pool.clone());
+        for i in 0..BATCH_SIZE as u64 {
+            writer.enqueue("meeting-3".to_string(), segment(i, "segment"));
+        }
+
+        // Give the task a moment to process the size-triggered flush without
+        // relying on the 1s interval tick or channel closure.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let count: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM transcripts WHERE meeting_id = ?")
+                    .bind("meeting-3")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+            if count.0 == BATCH_SIZE as i64 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "size-triggered flush did not happen in time"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        drop(writer);
+        let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/backend_probe.rs
+++ b/frontend/src-tauri/src/audio/transcription/backend_probe.rs
@@ -1,0 +1,208 @@
+//! Runtime whisper-backend discovery and selection (issue #56 spike).
+//!
+//! Compiled only under the `backend_probe` Cargo feature, which is **off by
+//! default** — this module is inert unless a build explicitly opts in. It is
+//! not wired into the live recording path: `WhisperEngine` (in-process,
+//! `whisper_engine/whisper_engine.rs`) remains the only transcription path
+//! actually used today. This exists to prototype the selection logic
+//! described in `docs/transcription-backends.md` ahead of that migration.
+//!
+//! # What this does
+//!
+//! Enumerates candidate `whisper-helper-{cuda,vulkan,cpu}` sidecar binaries
+//! next to the running executable, launches each with a `probe` request (see
+//! `whisper-protocol::Request::Probe`), and picks the first that succeeds in
+//! priority order cuda → vulkan → cpu. The result is intended to be
+//! persisted alongside the rest of the transcription config, with a manual
+//! override — see [`BackendChoice`] and [`get_transcription_backends`].
+//!
+//! # What this does not do (yet)
+//!
+//! - No caller in `lib.rs` invokes this at startup or exposes it as a Tauri
+//!   command; registering `get_transcription_backends` in
+//!   `invoke_handler![]` is a follow-up once a settings UI exists for it.
+//! - No sidecar binaries actually ship next to the app yet — `whisper-helper`
+//!   is a standalone workspace crate today (`cargo build -p whisper-helper`).
+//! - Persistence of the manual override piggybacks on
+//!   `WHISPER_MODEL_CATALOG`'s config file conventions in spirit only; the
+//!   actual read/write wiring is left to the implementation phase.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use whisper_protocol::{Request, Response};
+
+/// Priority order for automatic selection: prefer the fastest backend that
+/// actually works on this machine.
+const CANDIDATE_ORDER: [&str; 3] = ["cuda", "vulkan", "cpu"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BackendCandidate {
+    pub backend: String,
+    pub binary_path: String,
+    /// `None` when the binary wasn't found next to the executable at all.
+    pub available: bool,
+    pub probe_ok: Option<bool>,
+    pub detail: String,
+    pub probe_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendSelection {
+    pub candidates: Vec<BackendCandidate>,
+    /// The backend `backend_probe` would pick automatically (first
+    /// `probe_ok: Some(true)` in `CANDIDATE_ORDER`), if any.
+    pub recommended: Option<String>,
+    /// A user's manual override, if one has been persisted. When present,
+    /// callers should prefer this over `recommended`.
+    pub manual_override: Option<String>,
+}
+
+/// Build the expected path for a given backend's sidecar binary, sitting
+/// next to `exe_dir` (mirrors how `llama-helper` is located relative to the
+/// Tauri app's resource/exe directory today).
+fn candidate_path(exe_dir: &Path, backend: &str) -> PathBuf {
+    exe_dir.join(format!("whisper-helper-{backend}"))
+}
+
+/// Run one candidate's `probe` (or, if it can't even be spawned, report
+/// that). `model_path` is forwarded as-is to `Request::Probe` — `None` falls
+/// back to a ping-only check (see `whisper-protocol`'s doc comment on
+/// `Request::Probe`).
+fn probe_one(exe_dir: &Path, backend: &str, model_path: Option<&str>) -> BackendCandidate {
+    let path = candidate_path(exe_dir, backend);
+    if !path.is_file() {
+        return BackendCandidate {
+            backend: backend.to_string(),
+            binary_path: path.display().to_string(),
+            available: false,
+            probe_ok: None,
+            detail: "binary not found".to_string(),
+            probe_ms: None,
+        };
+    }
+
+    let start = Instant::now();
+    let result = (|| -> anyhow::Result<Response> {
+        let mut child = Command::new(&path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let stdin = child.stdin.as_mut().ok_or_else(|| anyhow::anyhow!("no stdin"))?;
+        let request = Request::Probe {
+            model_path: model_path.map(|s| s.to_string()),
+        };
+        let line = serde_json::to_string(&request)?;
+        use std::io::Write;
+        writeln!(stdin, "{line}")?;
+
+        use std::io::{BufRead, BufReader};
+        let stdout = child.stdout.take().ok_or_else(|| anyhow::anyhow!("no stdout"))?;
+        let mut reader = BufReader::new(stdout);
+        let mut resp_line = String::new();
+        reader.read_line(&mut resp_line)?;
+        let response: Response = serde_json::from_str(resp_line.trim())?;
+
+        // Best-effort cleanup; the child exits on its own once stdin closes
+        // (dropping `child` closes the pipe), but don't block indefinitely
+        // waiting on a stuck process during a probe.
+        let _ = child.kill();
+
+        Ok(response)
+    })();
+
+    let probe_ms = start.elapsed();
+    match result {
+        Ok(Response::ProbeResult {
+            decode_ok, detail, ..
+        }) => BackendCandidate {
+            backend: backend.to_string(),
+            binary_path: path.display().to_string(),
+            available: true,
+            probe_ok: decode_ok.or(Some(true)), // ping-only probe still counts as "runnable"
+            detail,
+            probe_ms: Some(probe_ms.as_millis() as u64),
+        },
+        Ok(other) => BackendCandidate {
+            backend: backend.to_string(),
+            binary_path: path.display().to_string(),
+            available: true,
+            probe_ok: Some(false),
+            detail: format!("unexpected response to probe: {other:?}"),
+            probe_ms: Some(probe_ms.as_millis() as u64),
+        },
+        Err(e) => BackendCandidate {
+            backend: backend.to_string(),
+            binary_path: path.display().to_string(),
+            available: true,
+            probe_ok: Some(false),
+            detail: format!("probe failed: {e}"),
+            probe_ms: Some(probe_ms.as_millis() as u64),
+        },
+    }
+}
+
+/// Enumerate and probe all candidate sidecars, returning them alongside the
+/// recommended automatic choice. `timeout` bounds each individual probe
+/// (unused in this prototype — `probe_one` is synchronous and the `Probe`
+/// request itself is meant to complete in ~1s; a production version should
+/// wrap the spawn+read in a thread with a hard timeout so a hung sidecar
+/// can't block the whole scan).
+pub fn scan_backends(exe_dir: &Path, model_path: Option<&str>, _timeout: Duration) -> BackendSelection {
+    let candidates: Vec<BackendCandidate> = CANDIDATE_ORDER
+        .iter()
+        .map(|backend| probe_one(exe_dir, backend, model_path))
+        .collect();
+
+    let recommended = CANDIDATE_ORDER.iter().find_map(|backend| {
+        candidates
+            .iter()
+            .find(|c| c.backend == *backend && c.probe_ok == Some(true))
+            .map(|c| c.backend.clone())
+    });
+
+    BackendSelection {
+        candidates,
+        recommended,
+        manual_override: None,
+    }
+}
+
+/// Tauri-command-shaped entry point for a future settings UI. Not currently
+/// registered in `invoke_handler![]` — see module doc comment.
+///
+/// `model_path` should be the tiny/base model's path if one is downloaded
+/// (gives a real decode_ok signal); `None` degrades to ping-only probing.
+pub fn get_transcription_backends(model_path: Option<&str>) -> anyhow::Result<BackendSelection> {
+    let exe_dir = std::env::current_exe()?
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("executable has no parent directory"))?
+        .to_path_buf();
+    Ok(scan_backends(&exe_dir, model_path, Duration::from_secs(5)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_binary_reports_unavailable() {
+        let dir = std::env::temp_dir();
+        let candidate = probe_one(&dir, "cuda-definitely-not-here", None);
+        assert!(!candidate.available);
+        assert_eq!(candidate.probe_ok, None);
+    }
+
+    #[test]
+    fn candidate_path_matches_expected_naming() {
+        let dir = PathBuf::from("/opt/app");
+        assert_eq!(
+            candidate_path(&dir, "vulkan"),
+            PathBuf::from("/opt/app/whisper-helper-vulkan")
+        );
+    }
+}

--- a/frontend/src-tauri/src/audio/transcription/mod.rs
+++ b/frontend/src-tauri/src/audio/transcription/mod.rs
@@ -4,6 +4,10 @@
 // sole local ASR engine (a prior remote-provider abstraction was removed as
 // dead code — see worker.rs for TranscriptionError).
 
+// Issue #56 spike: runtime sidecar backend probing/selection. Off by
+// default — see backend_probe.rs's module doc comment for scope and status.
+#[cfg(feature = "backend_probe")]
+pub mod backend_probe;
 pub mod echo_dedup;
 pub mod engine;
 pub mod partial_worker;

--- a/frontend/src-tauri/src/database/models.rs
+++ b/frontend/src-tauri/src/database/models.rs
@@ -9,6 +9,19 @@ pub struct MeetingModel {
     pub created_at: DateTimeUtc,
     pub updated_at: DateTimeUtc,
     pub folder_path: Option<String>,
+    /// Lifecycle status: "recording" | "completed" | "interrupted". Rows
+    /// created before this column existed default to "completed" (see the
+    /// migration). Owned entirely by the Rust recording lifecycle (issue
+    /// #57 slice 2) — the frontend never writes it.
+    #[serde(default = "default_meeting_status")]
+    pub status: String,
+    pub completed_at: Option<DateTimeUtc>,
+    pub duration_seconds: Option<f64>,
+    pub audio_path: Option<String>,
+}
+
+fn default_meeting_status() -> String {
+    "completed".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type)]

--- a/frontend/src-tauri/src/database/repositories/meeting.rs
+++ b/frontend/src-tauri/src/database/repositories/meeting.rs
@@ -62,7 +62,7 @@ impl MeetingsRepository {
 
         // Get meeting details
         let meeting: Option<MeetingModel> = sqlx::query_as(
-            "SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?",
+            "SELECT id, title, created_at, updated_at, folder_path, status, completed_at, duration_seconds, audio_path FROM meetings WHERE id = ?",
         )
         .bind(meeting_id)
         .fetch_optional(&mut *transaction)
@@ -124,7 +124,7 @@ impl MeetingsRepository {
         }
 
         let meeting: Option<MeetingModel> = sqlx::query_as(
-            "SELECT id, title, created_at, updated_at, folder_path FROM meetings WHERE id = ?",
+            "SELECT id, title, created_at, updated_at, folder_path, status, completed_at, duration_seconds, audio_path FROM meetings WHERE id = ?",
         )
         .bind(meeting_id)
         .fetch_optional(pool)
@@ -224,6 +224,125 @@ impl MeetingsRepository {
         transaction.commit().await?;
         Ok(true)
     }
+
+    // ------------------------------------------------------------------
+    // Lifecycle (issue #57 slice 2): Rust owns the meeting row from the
+    // moment recording starts, so recovery after a crash is a database
+    // query instead of the frontend reconciling an IndexedDB cache.
+    // ------------------------------------------------------------------
+
+    /// Insert the meeting row at the moment recording starts, status
+    /// "recording". Caller-supplied `meeting_id` (a fresh uuid) is kept for
+    /// the whole recording session so live transcript segments, the
+    /// `recording-stopped` payload, and this row all agree on one id.
+    pub async fn create_recording_meeting(
+        pool: &SqlitePool,
+        meeting_id: &str,
+        title: &str,
+        folder_path: Option<&str>,
+    ) -> Result<(), SqlxError> {
+        let now = Utc::now();
+        sqlx::query(
+            "INSERT INTO meetings (id, title, created_at, updated_at, folder_path, status)
+             VALUES (?, ?, ?, ?, ?, 'recording')",
+        )
+        .bind(meeting_id)
+        .bind(title)
+        .bind(now)
+        .bind(now)
+        .bind(folder_path)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Finalise a meeting row on a normal stop: status -> "completed".
+    pub async fn mark_meeting_completed(
+        pool: &SqlitePool,
+        meeting_id: &str,
+        duration_seconds: Option<f64>,
+        audio_path: Option<&str>,
+    ) -> Result<bool, SqlxError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE meetings
+             SET status = 'completed', completed_at = ?, duration_seconds = ?, audio_path = ?, updated_at = ?
+             WHERE id = ?",
+        )
+        .bind(now)
+        .bind(duration_seconds)
+        .bind(audio_path)
+        .bind(now)
+        .bind(meeting_id)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Mark a meeting row "interrupted" — a fatal-error stop, or the
+    /// crash-marker sweep at startup finding it still "recording".
+    pub async fn mark_meeting_interrupted(
+        pool: &SqlitePool,
+        meeting_id: &str,
+    ) -> Result<bool, SqlxError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE meetings SET status = 'interrupted', updated_at = ? WHERE id = ?",
+        )
+        .bind(now)
+        .bind(meeting_id)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    /// Crash marker: any row still "recording" from a previous run of the
+    /// app (the process ended without `stop_recording` ever finalising it)
+    /// becomes "interrupted". Run once at startup, after the database pool
+    /// is ready. Returns the number of rows updated.
+    pub async fn mark_stale_recording_meetings_interrupted(
+        pool: &SqlitePool,
+    ) -> Result<u64, SqlxError> {
+        let now = Utc::now();
+        let result = sqlx::query(
+            "UPDATE meetings SET status = 'interrupted', updated_at = ? WHERE status = 'recording'",
+        )
+        .bind(now)
+        .execute(pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// List every "interrupted" meeting, most recent first, with its saved
+    /// transcript-segment count — everything the recovery dialog needs
+    /// except whether `.checkpoints` audio still exists on disk, which is a
+    /// filesystem check the caller does per row (see
+    /// `audio::recovery_commands::list_interrupted_meetings`).
+    pub async fn list_interrupted_meetings(
+        pool: &SqlitePool,
+    ) -> Result<Vec<InterruptedMeetingRow>, SqlxError> {
+        let rows = sqlx::query_as::<_, InterruptedMeetingRow>(
+            "SELECT m.id AS meeting_id, m.title AS title, m.folder_path AS folder_path,
+                    m.created_at AS created_at,
+                    COALESCE((SELECT COUNT(*) FROM transcripts t WHERE t.meeting_id = m.id), 0) AS segment_count
+             FROM meetings m
+             WHERE m.status = 'interrupted'
+             ORDER BY m.created_at DESC",
+        )
+        .fetch_all(pool)
+        .await?;
+        Ok(rows)
+    }
+}
+
+/// One row of `MeetingsRepository::list_interrupted_meetings`'s result.
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct InterruptedMeetingRow {
+    pub meeting_id: String,
+    pub title: String,
+    pub folder_path: Option<String>,
+    pub created_at: crate::database::models::DateTimeUtc,
+    pub segment_count: i64,
 }
 
 async fn delete_meeting_with_transaction(
@@ -261,4 +380,154 @@ async fn delete_meeting_with_transaction(
         .await?;
 
     Ok(result.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite pool");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("run migrations");
+        pool
+    }
+
+    async fn status_of(pool: &SqlitePool, meeting_id: &str) -> String {
+        let row: (String,) = sqlx::query_as("SELECT status FROM meetings WHERE id = ?")
+            .bind(meeting_id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        row.0
+    }
+
+    /// A row created at recording start is "recording"; a normal stop moves
+    /// it to "completed" and stamps duration/audio_path/completed_at.
+    #[tokio::test]
+    async fn create_then_complete_transitions_recording_to_completed() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "m1", "Standup", Some("/tmp/m1"))
+            .await
+            .unwrap();
+        assert_eq!(status_of(&pool, "m1").await, "recording");
+
+        let updated =
+            MeetingsRepository::mark_meeting_completed(&pool, "m1", Some(123.5), Some("/tmp/m1/audio.mp4"))
+                .await
+                .unwrap();
+        assert!(updated);
+        assert_eq!(status_of(&pool, "m1").await, "completed");
+
+        let meeting = MeetingsRepository::get_meeting_metadata(&pool, "m1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(meeting.duration_seconds, Some(123.5));
+        assert_eq!(meeting.audio_path.as_deref(), Some("/tmp/m1/audio.mp4"));
+        assert!(meeting.completed_at.is_some());
+    }
+
+    /// A fatal-error stop moves the row to "interrupted" instead.
+    #[tokio::test]
+    async fn mark_interrupted_transitions_recording_to_interrupted() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "m2", "Crashy", None)
+            .await
+            .unwrap();
+
+        let updated = MeetingsRepository::mark_meeting_interrupted(&pool, "m2")
+            .await
+            .unwrap();
+        assert!(updated);
+        assert_eq!(status_of(&pool, "m2").await, "interrupted");
+    }
+
+    /// The startup crash-marker sweep flips every "recording" row to
+    /// "interrupted" and leaves every other status untouched.
+    #[tokio::test]
+    async fn stale_sweep_only_touches_recording_rows() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "still-recording", "A", None)
+            .await
+            .unwrap();
+        MeetingsRepository::create_recording_meeting(&pool, "will-complete", "B", None)
+            .await
+            .unwrap();
+        MeetingsRepository::mark_meeting_completed(&pool, "will-complete", None, None)
+            .await
+            .unwrap();
+
+        let swept = MeetingsRepository::mark_stale_recording_meetings_interrupted(&pool)
+            .await
+            .unwrap();
+        assert_eq!(swept, 1);
+
+        assert_eq!(status_of(&pool, "still-recording").await, "interrupted");
+        assert_eq!(status_of(&pool, "will-complete").await, "completed");
+
+        // Idempotent: nothing left "recording" to sweep a second time.
+        let swept_again = MeetingsRepository::mark_stale_recording_meetings_interrupted(&pool)
+            .await
+            .unwrap();
+        assert_eq!(swept_again, 0);
+    }
+
+    /// `list_interrupted_meetings` returns only "interrupted" rows, most
+    /// recent first, with a correct transcript segment count per row.
+    #[tokio::test]
+    async fn list_interrupted_meetings_reports_segment_counts() {
+        let pool = test_pool().await;
+        MeetingsRepository::create_recording_meeting(&pool, "old", "Old", None)
+            .await
+            .unwrap();
+        MeetingsRepository::mark_meeting_interrupted(&pool, "old")
+            .await
+            .unwrap();
+
+        MeetingsRepository::create_recording_meeting(&pool, "recent", "Recent", None)
+            .await
+            .unwrap();
+        MeetingsRepository::mark_meeting_interrupted(&pool, "recent")
+            .await
+            .unwrap();
+
+        // A completed meeting must never show up here.
+        MeetingsRepository::create_recording_meeting(&pool, "done", "Done", None)
+            .await
+            .unwrap();
+        MeetingsRepository::mark_meeting_completed(&pool, "done", None, None)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, sequence_id)
+             VALUES ('t1', 'recent', 'hello', '2026-01-01T00:00:00Z', 1),
+                    ('t2', 'recent', 'world', '2026-01-01T00:00:01Z', 2)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let rows = MeetingsRepository::list_interrupted_meetings(&pool)
+            .await
+            .unwrap();
+        let ids: Vec<&str> = rows.iter().map(|r| r.meeting_id.as_str()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"old"));
+        assert!(ids.contains(&"recent"));
+        assert!(!ids.contains(&"done"));
+
+        let recent_row = rows.iter().find(|r| r.meeting_id == "recent").unwrap();
+        assert_eq!(recent_row.segment_count, 2);
+        let old_row = rows.iter().find(|r| r.meeting_id == "old").unwrap();
+        assert_eq!(old_row.segment_count, 0);
+    }
 }

--- a/frontend/src-tauri/src/database/repositories/transcript.rs
+++ b/frontend/src-tauri/src/database/repositories/transcript.rs
@@ -96,6 +96,88 @@ impl TranscriptsRepository {
         Ok(meeting_id)
     }
 
+    /// Upsert a batch of live-recording transcript segments, keyed by
+    /// `(meeting_id, sequence_id)` (issue #57 slice 2): a segment whose
+    /// `(meeting_id, sequence_id)` already exists is updated in place
+    /// (covers the transcription worker revising a partial into its final
+    /// text under the same sequence id); anything new is inserted. One
+    /// transaction per batch — called by `transcript_db_writer`'s periodic
+    /// flush, so a batch is typically a handful of segments from one
+    /// in-progress recording.
+    ///
+    /// A segment with `sequence_id: None` is always inserted as a new row
+    /// (SQLite's UNIQUE index treats every NULL as distinct) — the
+    /// live-recording path this writer serves always sets it, so that's
+    /// only reachable from a caller passing raw segments in directly.
+    ///
+    /// Returns `Err` (rolling the whole batch back) on the first failing
+    /// segment rather than skipping it, so a batch is never partially
+    /// applied — the caller logs and drops the batch on error; the
+    /// transcripts.ndjson journal on disk remains the source of truth if a
+    /// batch is ever lost this way.
+    pub async fn upsert_transcript_segments(
+        pool: &SqlitePool,
+        items: &[(String, TranscriptSegment)],
+    ) -> Result<u64, SqlxError> {
+        if items.is_empty() {
+            return Ok(0);
+        }
+
+        let mut conn = pool.acquire().await?;
+        let mut transaction = conn.begin().await?;
+
+        let mut affected = 0u64;
+        for (meeting_id, segment) in items {
+            let transcript_id = format!("transcript-{}", Uuid::new_v4());
+            let result = sqlx::query(
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker, voice_profile_id, sequence_id, source)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ON CONFLICT(meeting_id, sequence_id) DO UPDATE SET
+                     transcript = excluded.transcript,
+                     timestamp = excluded.timestamp,
+                     audio_start_time = excluded.audio_start_time,
+                     audio_end_time = excluded.audio_end_time,
+                     duration = excluded.duration,
+                     speaker = excluded.speaker,
+                     voice_profile_id = excluded.voice_profile_id,
+                     source = excluded.source",
+            )
+            .bind(&transcript_id)
+            .bind(meeting_id)
+            .bind(&segment.text)
+            .bind(
+                segment
+                    .timestamp
+                    .clone()
+                    .unwrap_or_else(|| Utc::now().to_rfc3339()),
+            )
+            .bind(segment.audio_start_time)
+            .bind(segment.audio_end_time)
+            .bind(segment.duration)
+            .bind(&segment.speaker)
+            .bind(&segment.voice_profile_id)
+            .bind(segment.sequence_id.map(|s| s as i64))
+            .bind(&segment.source)
+            .execute(&mut *transaction)
+            .await;
+
+            match result {
+                Ok(r) => affected += r.rows_affected(),
+                Err(e) => {
+                    error!(
+                        "Failed to upsert transcript segment (meeting {}, sequence {:?}): {}",
+                        meeting_id, segment.sequence_id, e
+                    );
+                    transaction.rollback().await?;
+                    return Err(e);
+                }
+            }
+        }
+
+        transaction.commit().await?;
+        Ok(affected)
+    }
+
     /// Re-point every transcript that currently references `from_profile_id`
     /// to `to_profile_id`, also rewriting the displayed `speaker` text to
     /// `to_name`. Used when merging two stored voice profiles into one.

--- a/frontend/src-tauri/src/database/setup.rs
+++ b/frontend/src-tauri/src/database/setup.rs
@@ -1,7 +1,8 @@
-use log::info;
+use log::{info, warn};
 use tauri::{AppHandle, Emitter, Manager};
 
 use super::manager::DatabaseManager;
+use super::repositories::meeting::MeetingsRepository;
 use crate::state::AppState;
 
 /// Initialize database on app startup
@@ -30,8 +31,23 @@ pub async fn initialize_database_on_startup(app: &AppHandle) -> Result<(), Strin
             .await
             .map_err(|e| format!("Failed to initialize database manager: {}", e))?;
 
+        let pool = db_manager.pool().clone();
         app.manage(AppState { db_manager });
         info!("Database initialized successfully");
+
+        // Crash marker (issue #57 slice 2): a meeting row still "recording"
+        // at this point predates this very process — the app that created
+        // it never reached `stop_recording`'s finalisation (a crash, kill,
+        // or forced shutdown). Sweep them to "interrupted" once, here, so
+        // the recovery dialog can find them via a plain status query.
+        match MeetingsRepository::mark_stale_recording_meetings_interrupted(&pool).await {
+            Ok(0) => {}
+            Ok(n) => info!(
+                "Marked {} meeting(s) left 'recording' by a previous run as 'interrupted'",
+                n
+            ),
+            Err(e) => warn!("Failed to sweep stale 'recording' meetings at startup: {}", e),
+        }
     }
 
     Ok(())

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -813,6 +813,10 @@ pub fn run() {
             audio::incremental_saver::recover_audio_from_checkpoints,
             audio::incremental_saver::cleanup_checkpoints,
             audio::incremental_saver::has_audio_checkpoints,
+            // Interrupted-meeting recovery (issue #57 slice 2: DB-driven,
+            // replaces the old IndexedDB scan)
+            audio::recovery_commands::list_interrupted_meetings,
+            audio::recovery_commands::recover_meeting,
             ollama::get_ollama_models,
             ollama::pull_ollama_model,
             ollama::delete_ollama_model,

--- a/frontend/src-tauri/src/tray.rs
+++ b/frontend/src-tauri/src/tray.rs
@@ -55,74 +55,88 @@ fn toggle_recording_handler<R: Runtime>(app: &AppHandle<R>) {
     focus_main_window(app);
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {
-        if crate::is_recording().await {
-            // Immediately show stopping state
-            set_tray_state(&app_clone, RecordingState::Stopping);
+        use crate::audio::recording_phase::RecordingPhase;
 
-            log::info!("Tray toggle: Stopping recording...");
+        // Decide start vs. stop from the canonical recording-state machine
+        // rather than the `is_recording()` boolean: that flips false ~100ms
+        // into a stop while the drain/finalise below still owns the manager
+        // slot for seconds (issue #35), and it's never true during Starting
+        // either. Phase gives every intermediate state its own answer
+        // instead of collapsing them onto "not recording".
+        let phase = crate::audio::recording_phase::current_phase();
+        match phase {
+            RecordingPhase::Recording | RecordingPhase::Paused => {
+                // Immediately show stopping state
+                set_tray_state(&app_clone, RecordingState::Stopping);
 
-            // Generate save path (same as RecordingControls.tsx)
-            let data_dir = match app_clone.path().app_data_dir() {
-                Ok(dir) => dir,
-                Err(e) => {
-                    log::error!("Failed to get app data dir: {}", e);
-                    update_tray_menu_async(&app_clone).await;
-                    return;
-                }
-            };
+                log::info!("Tray toggle: Stopping recording...");
 
-            let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
-            let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
+                // Generate save path (same as RecordingControls.tsx)
+                let data_dir = match app_clone.path().app_data_dir() {
+                    Ok(dir) => dir,
+                    Err(e) => {
+                        log::error!("Failed to get app data dir: {}", e);
+                        update_tray_menu_async(&app_clone).await;
+                        return;
+                    }
+                };
 
-            // Call Rust stop_recording command (like pause/resume pattern)
-            let stop_result = crate::audio::recording_commands::stop_recording(
-                app_clone.clone(),
-                crate::audio::recording_commands::RecordingArgs {
-                    save_path: save_path.to_string_lossy().to_string(),
-                },
-            )
-            .await;
+                let timestamp = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S").to_string();
+                let save_path = data_dir.join(format!("recording-{}.wav", timestamp));
 
-            // Handle result
-            match stop_result {
-                Ok(_) => {
-                    log::info!("Tray toggle: Recording stopped successfully");
+                // Call Rust stop_recording command (like pause/resume pattern)
+                let stop_result = crate::audio::recording_commands::stop_recording(
+                    app_clone.clone(),
+                    crate::audio::recording_commands::RecordingArgs {
+                        save_path: save_path.to_string_lossy().to_string(),
+                    },
+                )
+                .await;
 
-                    // Trigger frontend post-processing via event (works from any page)
-                    // (SQLite save, navigation, analytics)
-                    if let Err(e) = app_clone.emit("recording-stop-complete", true) {
-                        log::error!(
-                            "Tray toggle: Failed to emit recording-stop-complete event: {}",
-                            e
-                        );
+                // Handle result
+                match stop_result {
+                    Ok(_) => {
+                        log::info!("Tray toggle: Recording stopped successfully");
+
+                        // Trigger frontend post-processing via event (works from any page)
+                        // (SQLite save, navigation, analytics)
+                        if let Err(e) = app_clone.emit("recording-stop-complete", true) {
+                            log::error!(
+                                "Tray toggle: Failed to emit recording-stop-complete event: {}",
+                                e
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Tray toggle: Failed to stop recording: {}", e);
+                        // Revert tray state on error
+                        update_tray_menu_async(&app_clone).await;
                     }
                 }
-                Err(e) => {
-                    log::error!("Tray toggle: Failed to stop recording: {}", e);
-                    // Revert tray state on error
-                    update_tray_menu_async(&app_clone).await;
+            }
+            RecordingPhase::Idle => {
+                // Immediately show starting state
+                set_tray_state(&app_clone, RecordingState::Starting);
+
+                log::info!("Emitting start recording event from tray");
+                if let Some(window) = app_clone.get_webview_window("main") {
+                    let _ = window.eval("sessionStorage.setItem('autoStartRecording', 'true')"); // Set the flag to start recording automatically
+                    let _ = window.eval("window.location.assign('/')");
                 }
             }
-        } else if crate::audio::recording_commands::is_stop_in_progress() {
-            // A previous recording is still draining/finalising on the Rust
-            // side (transcription flush, audio merge) even though
-            // `is_recording()` has already gone false. Navigating now would
-            // reload the page mid-save and abort the in-flight SQLite write
-            // (issue #35) - so do nothing and let the user retry once the
-            // finalise completes. `start_recording` itself would refuse this
-            // too, but we want to avoid the destructive `location.assign`
-            // reload entirely, not just fail the start after it.
-            log::info!(
-                "Tray toggle: ignoring start - previous recording still finalising"
-            );
-        } else {
-            // Immediately show starting state
-            set_tray_state(&app_clone, RecordingState::Starting);
-
-            log::info!("Emitting start recording event from tray");
-            if let Some(window) = app_clone.get_webview_window("main") {
-                let _ = window.eval("sessionStorage.setItem('autoStartRecording', 'true')"); // Set the flag to start recording automatically
-                let _ = window.eval("window.location.assign('/')");
+            RecordingPhase::Starting
+            | RecordingPhase::Stopping
+            | RecordingPhase::Finalising
+            | RecordingPhase::Error => {
+                // A start or stop is already in flight (or the session just
+                // ended in error and hasn't reached Idle yet). Navigating
+                // now would reload the page mid-save and abort an in-flight
+                // SQLite write (issue #35) - so do nothing and let the user
+                // retry once the current phase settles.
+                log::info!(
+                    "Tray toggle: ignoring click - recording phase is {:?}",
+                    phase
+                );
             }
         }
     });

--- a/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
+++ b/frontend/src/components/TranscriptRecovery/TranscriptRecovery.tsx
@@ -27,16 +27,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { MeetingMetadata, StoredTranscript } from "@/services/indexedDBService";
+import {
+  RecoverableMeeting,
+  PreviewTranscript,
+} from "@/hooks/useTranscriptRecovery";
 import { cn } from "@/lib/utils";
 
 interface TranscriptRecoveryProps {
   isOpen: boolean;
   onClose: () => void;
-  recoverableMeetings: MeetingMetadata[];
+  recoverableMeetings: RecoverableMeeting[];
   onRecover: (meetingId: string) => Promise<any>;
   onDelete: (meetingId: string) => Promise<void>;
-  onLoadPreview: (meetingId: string) => Promise<StoredTranscript[]>;
+  onLoadPreview: (meetingId: string) => Promise<PreviewTranscript[]>;
 }
 
 export function TranscriptRecovery({
@@ -51,7 +54,7 @@ export function TranscriptRecovery({
     null,
   );
   const [previewTranscripts, setPreviewTranscripts] = useState<
-    StoredTranscript[]
+    PreviewTranscript[]
   >([]);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [isRecovering, setIsRecovering] = useState(false);

--- a/frontend/src/contexts/RecordingStateContext.tsx
+++ b/frontend/src/contexts/RecordingStateContext.tsx
@@ -135,6 +135,7 @@ function snapshotFromBackendState(s: BackendRecordingState): RecordingSnapshot {
     total_pause_secs: s.total_pause_secs ?? 0,
     meeting_name: s.meeting_name ?? null,
     folder_path: s.folder_path ?? null,
+    meeting_id: s.meeting_id ?? null,
     chunks_in_queue: s.chunks_in_queue ?? 0,
     error: s.error ?? null,
     seq: s.seq ?? 0,

--- a/frontend/src/contexts/RecordingStateContext.tsx
+++ b/frontend/src/contexts/RecordingStateContext.tsx
@@ -10,28 +10,38 @@ import React, {
   useMemo,
 } from "react";
 import { toast } from "sonner";
-import { recordingService } from "@/services/recordingService";
+import {
+  recordingService,
+  RecordingPhase,
+  RecordingSnapshot,
+  RecordingState as BackendRecordingState,
+} from "@/services/recordingService";
 import { isPostProcessingRef } from "@/hooks/useRecordingStop";
+import { useElapsedTime } from "@/hooks/useElapsedTime";
 
 // Watchdog (issue #17 gap): if we've been sitting in a stop-flow status
 // (STOPPING / PROCESSING_TRANSCRIPTS / SAVING) for longer than this while
-// the backend confirms it's fully idle (`is_recording=false`,
-// `is_finalising=false`) and no post-processing is actually running
-// locally, assume the frontend missed whatever event was supposed to move
-// it out of that status and force it back to IDLE rather than leaving the
-// Start button hidden forever. Kept long (30s) and gated on
-// `isPostProcessingRef` so it never fires during a legitimate save - the
-// full transcription-wait + DB-save flow can itself take tens of seconds,
-// but keeps that ref true the whole time.
+// the backend's canonical state machine (audio::recording_phase) reports
+// Idle and no post-processing is actually running locally, assume the
+// frontend missed whatever event was supposed to move it out of that
+// status and force it back to IDLE rather than leaving the Start button
+// hidden forever. Kept long (30s) and gated on `isPostProcessingRef` so it
+// never fires during a legitimate save - the full transcription-wait +
+// DB-save flow can itself take tens of seconds, but keeps that ref true
+// the whole time.
 const WATCHDOG_STUCK_TIMEOUT_MS = 30000;
 
 /**
- * Recording state synchronized with backend
- * This context provides a single source of truth for recording state
- * that automatically syncs with the Rust backend, solving:
- * 1. Page refresh desync (backend recording but UI shows stopped)
- * 2. Pause state visibility across components
- * 3. Comprehensive state for future features (reconnection, etc.)
+ * Recording state synchronized with the Rust backend's canonical state
+ * machine (`audio::recording_phase::RecordingPhase`, issue #57 slice 1).
+ *
+ * This context is now event-driven rather than polled: it subscribes to
+ * the single `recording-state` event Rust emits on every phase transition
+ * (start/stop/pause/resume/error), plus a one-shot `get_recording_state`
+ * fetch on mount and on window focus/visibility change to resync a window
+ * that missed events while backgrounded or was opened mid-session. There is
+ * no periodic poll any more - durations tick client-side from the
+ * snapshot's `started_at_ms` via `useElapsedTime`.
  */
 
 // Recording lifecycle status enum
@@ -58,7 +68,7 @@ interface RecordingState {
   statusMessage?: string; // Optional message for current status
 
   // True while the Rust side reports a previous stop is still draining /
-  // finalising (recording_commands::is_stop_in_progress()), independent of
+  // finalising (recording phase is Stopping or Finalising), independent of
   // this window's own local `status`. Lets a fresh window/tab, or a tray
   // stop that this window never locally transitioned for, still see the
   // stop-in-progress window.
@@ -77,8 +87,8 @@ interface RecordingStateContextType extends RecordingState {
   // Single source of truth for "a stop is in flight and must not be
   // interrupted by a new start": true whenever local status is in the
   // STOPPING/PROCESSING_TRANSCRIPTS/SAVING lifecycle, OR the backend reports
-  // `is_finalising`. Every start entry point (sidebar toggle, tray toggle,
-  // auto-start effect, page.tsx) must honour this (issue #35).
+  // `isBackendFinalising`. Every start entry point (sidebar toggle, tray
+  // toggle, auto-start effect, page.tsx) must honour this (issue #35).
   isStopFlowActive: boolean;
 }
 
@@ -96,340 +106,328 @@ export const useRecordingState = () => {
   return context;
 };
 
+/** Ordering over the local stop-flow lifecycle, used so a phase-derived
+ *  status update never regresses past whatever local post-processing has
+ *  already reached (e.g. the backend reporting Idle - which happens right
+ *  after `recording-stopped`, seconds before local post-processing actually
+ *  finishes saving - must not snap the UI back to IDLE mid-save). 0 covers
+ *  every status outside the stop flow (IDLE/STARTING/RECORDING/ERROR). */
+const STOP_FLOW_RANK: Partial<Record<RecordingStatus, number>> = {
+  [RecordingStatus.STOPPING]: 1,
+  [RecordingStatus.PROCESSING_TRANSCRIPTS]: 2,
+  [RecordingStatus.SAVING]: 3,
+  [RecordingStatus.COMPLETED]: 4,
+};
+function stopFlowRank(status: RecordingStatus): number {
+  return STOP_FLOW_RANK[status] ?? 0;
+}
+
+/** Builds a full snapshot shape out of `get_recording_state`'s response for
+ *  the initial/resync fetch, so it can go through the same `applySnapshot`
+ *  path as a live `recording-state` event. `get_recording_state` always
+ *  includes the snapshot fields now, but this stays defensive about a
+ *  missing field rather than assuming it. */
+function snapshotFromBackendState(s: BackendRecordingState): RecordingSnapshot {
+  return {
+    phase: s.phase ?? (s.is_recording ? (s.is_paused ? "paused" : "recording") : "idle"),
+    started_at_ms: s.started_at_ms ?? null,
+    active_duration_secs: s.active_duration_secs ?? s.active_duration ?? null,
+    total_pause_secs: s.total_pause_secs ?? 0,
+    meeting_name: s.meeting_name ?? null,
+    folder_path: s.folder_path ?? null,
+    chunks_in_queue: s.chunks_in_queue ?? 0,
+    error: s.error ?? null,
+    seq: s.seq ?? 0,
+  };
+}
+
 export function RecordingStateProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [state, setState] = useState<RecordingState>({
-    isRecording: false,
-    isPaused: false,
-    isActive: false,
-    recordingDuration: null,
-    activeDuration: null,
-    status: RecordingStatus.IDLE, // NEW: Initialize with IDLE status
-    statusMessage: undefined, // NEW: No message initially
-    isBackendFinalising: false,
-  });
+  // Canonical fields mirrored straight from the backend's RecordingPhase
+  // snapshot.
+  const [phase, setPhase] = useState<RecordingPhase>("idle");
+  const [startedAtMs, setStartedAtMs] = useState<number | null>(null);
+  const [totalPauseSecs, setTotalPauseSecs] = useState(0);
 
-  const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  // Indirection to break the startPolling <-> syncWithBackend declaration
-  // cycle below without forward-referencing either useCallback before it's
-  // declared (startPolling schedules ticks by calling through this ref
-  // rather than closing over syncWithBackend directly).
-  const syncWithBackendRef = useRef<() => Promise<void>>(async () => {});
-
-  // Mirrors state.status for syncWithBackend's watchdog check below, which
-  // needs the latest status without taking a `state` dependency (that would
-  // recreate syncWithBackend, and therefore the polling interval, on every
-  // status change).
-  const statusRef = useRef(state.status);
-  useEffect(() => {
-    statusRef.current = state.status;
-  }, [state.status]);
-
-  // Timestamp of when the watchdog condition (stuck in a stop-flow status
-  // while the backend reports fully idle) was first observed; null while
-  // not currently stuck. Reset whenever the condition stops holding.
-  const watchdogStuckSinceRef = useRef<number | null>(null);
-
-  // NEW: Status setter with logging
-  const setStatus = useCallback(
-    (status: RecordingStatus, message?: string) => {
-      console.log(
-        `[RecordingState] Status: ${state.status} → ${status}`,
-        message || "",
-      );
-
-      setState((prev) => ({
-        ...prev,
-        status,
-        statusMessage: message,
-      }));
-    },
-    [state.status],
+  // Local lifecycle status - richer than `phase` (it also tracks
+  // PROCESSING_TRANSCRIPTS/SAVING/COMPLETED, which are driven by
+  // useRecordingStop's own post-processing, not by the Rust phase machine).
+  const [status, setStatusState] = useState<RecordingStatus>(
+    RecordingStatus.IDLE,
+  );
+  const [statusMessage, setStatusMessage] = useState<string | undefined>(
+    undefined,
   );
 
-  /**
-   * Stop polling backend state (called when recording stops)
-   */
-  const stopPolling = useCallback(() => {
-    if (pollingIntervalRef.current) {
-      console.log("[RecordingStateContext] Stopping state polling");
-      clearInterval(pollingIntervalRef.current);
-      pollingIntervalRef.current = null;
-    }
-  }, []);
+  // Mirrors `status` for use inside callbacks/timers that must read the
+  // latest value without becoming a dependency (which would tear down and
+  // re-arm the watchdog timer below on every status change).
+  const statusRef = useRef(status);
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
-  /**
-   * Start polling backend state (called when recording starts)
-   */
-  const startPolling = useCallback(() => {
-    if (pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current);
-    }
+  // Discards a `recording-state` event or resync fetch that is older than
+  // one already applied (e.g. the initial `get_recording_state` resolving
+  // after a live event already moved the snapshot forward).
+  const lastSeqRef = useRef(-1);
 
+  const watchdogTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Displayed active-recording duration while paused: frozen at the value
+  // the backend computed at the instant of pausing (its own
+  // `get_active_recording_duration` stops growing the moment a pause
+  // starts) rather than continuing to tick. Set directly inside
+  // `applySnapshot` below (an event-driven update, not a render-time ref
+  // mutation) whenever a `Paused` snapshot arrives, and cleared on any other
+  // phase.
+  const [frozenActiveDuration, setFrozenActiveDuration] = useState<
+    number | null
+  >(null);
+
+  // NEW: Status setter with logging
+  const setStatus = useCallback((next: RecordingStatus, message?: string) => {
     console.log(
-      "[RecordingStateContext] Starting state polling (500ms interval)",
+      `[RecordingState] Status: ${statusRef.current} → ${next}`,
+      message || "",
     );
-    pollingIntervalRef.current = setInterval(() => {
-      syncWithBackendRef.current();
-    }, 500);
+    setStatusState(next);
+    setStatusMessage(message);
   }, []);
 
   /**
-   * Sync recording state with backend
-   * Called on mount (fixes refresh desync) and periodically while recording
+   * Apply a `RecordingSnapshot` (from a live `recording-state` event or a
+   * `get_recording_state` resync) to local state. This is the only place
+   * `phase`/`startedAtMs`/`totalPauseSecs`/`status` are derived from the
+   * backend.
    */
-  const syncWithBackend = useCallback(async () => {
-    try {
-      const backendState = await recordingService.getRecordingState();
-      const isFinalising = backendState.is_finalising ?? false;
-
-      // Skip the setState when nothing the backend reports has actually
-      // changed - `syncWithBackend` runs every 500ms while a recording/stop
-      // is in flight, and re-creating the state object on every tick forces
-      // every consumer (page.tsx, the sidebar, the top bar, ...) to
-      // re-render for no reason (issue #51).
-      setState((prev) => {
-        if (
-          prev.isRecording === backendState.is_recording &&
-          prev.isPaused === backendState.is_paused &&
-          prev.isActive === backendState.is_active &&
-          prev.recordingDuration === backendState.recording_duration &&
-          prev.activeDuration === backendState.active_duration &&
-          prev.isBackendFinalising === isFinalising
-        ) {
-          return prev;
-        }
-        return {
-          ...prev,
-          isRecording: backendState.is_recording,
-          isPaused: backendState.is_paused,
-          isActive: backendState.is_active,
-          recordingDuration: backendState.recording_duration,
-          activeDuration: backendState.active_duration,
-          isBackendFinalising: isFinalising,
-        };
-      });
-
-      const inStopFlow = [
-        RecordingStatus.STOPPING,
-        RecordingStatus.PROCESSING_TRANSCRIPTS,
-        RecordingStatus.SAVING,
-      ].includes(statusRef.current);
-
-      // Keep polling alive through the finalising window even after
-      // `recording-stopped` has already fired (backend is_recording flips
-      // false ~100ms into a stop, well before the multi-second finalise
-      // completes) - and stop it once the backend confirms both recording
-      // and finalising have cleared. This is what lets a fresh window/tab
-      // that mounts mid-finalise, or this window if it missed the
-      // recording-stopped event's stopPolling() race, still observe the
-      // window (issue #35). Also keep polling while `status` itself is
-      // still in the stop-flow lifecycle even after the backend goes fully
-      // idle, so the watchdog below gets the repeated ticks it needs to
-      // measure how long it's been stuck (issue #17 gap) - it stops polling
-      // itself once it fires.
-      if (backendState.is_recording || isFinalising || inStopFlow) {
-        if (!pollingIntervalRef.current) {
-          startPolling();
-        }
-      } else {
-        stopPolling();
-      }
-
-      // Watchdog: the frontend is sitting in a stop-flow status but the
-      // backend says recording+finalising are both done, and no
-      // post-processing is actually running locally to move it the rest of
-      // the way to COMPLETED/IDLE. If that holds for longer than the
-      // timeout, assume whatever event was supposed to drive that
-      // transition (recording-stop-complete, its fallback, ...) was lost
-      // and force IDLE ourselves rather than leaving the Start button
-      // hidden forever.
-      if (inStopFlow && !backendState.is_recording && !isFinalising && !isPostProcessingRef.current) {
-        if (watchdogStuckSinceRef.current === null) {
-          watchdogStuckSinceRef.current = Date.now();
-        } else if (
-          Date.now() - watchdogStuckSinceRef.current >
-          WATCHDOG_STUCK_TIMEOUT_MS
-        ) {
-          console.warn(
-            "[RecordingStateContext] Watchdog: stuck in",
-            statusRef.current,
-            "for over",
-            WATCHDOG_STUCK_TIMEOUT_MS,
-            "ms while backend reports idle and no post-processing is running - forcing IDLE",
-          );
-          watchdogStuckSinceRef.current = null;
-          setState((prev) => ({
-            ...prev,
-            status: RecordingStatus.IDLE,
-            statusMessage: undefined,
-          }));
-          toast.error(
-            "Recording finished; the transcript may need recovery from the Recoverable meetings dialog",
-          );
-          stopPolling();
-        }
-      } else {
-        watchdogStuckSinceRef.current = null;
-      }
-
-      console.log("[RecordingStateContext] Synced with backend:", backendState);
-    } catch (error) {
-      console.error(
-        "[RecordingStateContext] Failed to sync with backend:",
-        error,
+  const applySnapshot = useCallback((snapshot: RecordingSnapshot) => {
+    if (snapshot.seq < lastSeqRef.current) {
+      console.log(
+        "[RecordingStateContext] Ignoring stale recording-state snapshot (seq",
+        snapshot.seq,
+        "< last applied",
+        lastSeqRef.current,
+        ")",
       );
-      // Don't update state on error - keep current state
+      return;
     }
-  }, [startPolling, stopPolling]);
+    lastSeqRef.current = snapshot.seq;
 
-  useEffect(() => {
-    syncWithBackendRef.current = syncWithBackend;
-  }, [syncWithBackend]);
+    console.log("[RecordingStateContext] Applying snapshot:", snapshot);
+
+    setPhase(snapshot.phase);
+    setStartedAtMs(snapshot.started_at_ms);
+    setTotalPauseSecs(snapshot.total_pause_secs);
+    setFrozenActiveDuration(
+      snapshot.phase === "paused" ? snapshot.active_duration_secs : null,
+    );
+
+    setStatusState((prevStatus) => {
+      switch (snapshot.phase) {
+        case "error":
+          return RecordingStatus.ERROR;
+        case "starting":
+          return RecordingStatus.STARTING;
+        case "recording":
+        case "paused":
+          return RecordingStatus.RECORDING;
+        case "stopping":
+          return stopFlowRank(prevStatus) < 1
+            ? RecordingStatus.STOPPING
+            : prevStatus;
+        case "finalising":
+          // "unless the local post-processing has already moved to SAVING"
+          return stopFlowRank(prevStatus) < 2
+            ? RecordingStatus.PROCESSING_TRANSCRIPTS
+            : prevStatus;
+        case "idle":
+        default:
+          // Only force IDLE when local post-processing hasn't already moved
+          // past STOPPING - see the STOP_FLOW_RANK comment above.
+          return stopFlowRank(prevStatus) < 1
+            ? RecordingStatus.IDLE
+            : prevStatus;
+      }
+    });
+
+    if (snapshot.phase === "error") {
+      setStatusMessage(snapshot.error ?? undefined);
+    }
+  }, []);
+
+  // Ticks elapsed wall time since the session started recording (including
+  // any time spent paused) - client-side, from the backend's `started_at_ms`,
+  // instead of polling a duration.
+  const elapsedMs = useElapsedTime(startedAtMs);
+  const recordingDuration = startedAtMs !== null ? elapsedMs / 1000 : null;
+
+  // Active duration excludes pause time; see `frozenActiveDuration` above for
+  // the paused case.
+  const activeDuration =
+    recordingDuration === null
+      ? null
+      : phase === "paused"
+        ? frozenActiveDuration
+        : Math.max(0, recordingDuration - totalPauseSecs);
+
+  const isRecording = phase === "recording" || phase === "paused";
+  const isPaused = phase === "paused";
+  const isActive = phase === "recording";
+  const isBackendFinalising = phase === "stopping" || phase === "finalising";
 
   /**
-   * Set up event listeners for backend state changes
+   * Subscribe to `recording-state`, and resync once on mount plus on every
+   * window focus / tab-visible transition (covers a window that was
+   * backgrounded through a whole recording, or opened mid-session).
    */
   useEffect(() => {
-    console.log("[RecordingStateContext] Setting up event listeners");
-    const unsubscribers: (() => void)[] = [];
+    let unlistenState: (() => void) | undefined;
+    let cancelled = false;
 
-    const setupListeners = async () => {
+    const resync = async () => {
       try {
-        // Recording started
-        const unlistenStarted = await recordingService.onRecordingStarted(
-          () => {
-            console.log("[RecordingStateContext] Recording started event");
-            setState((prev) => ({
-              ...prev,
-              isRecording: true,
-              isPaused: false,
-              isActive: true,
-              status: RecordingStatus.RECORDING, // NEW: Set status to RECORDING
-            }));
-            startPolling();
-          },
-        );
-        unsubscribers.push(unlistenStarted);
-
-        // Recording stopped
-        const unlistenStopped = await recordingService.onRecordingStopped(
-          (payload) => {
-            console.log(
-              "[RecordingStateContext] Recording stopped event:",
-              payload,
-            );
-            setState((prev) => {
-              // Set status to STOPPING if not already in stop flow
-              // This ensures smooth UI transition for tray/keyboard stops
-              const newStatus = [
-                RecordingStatus.STOPPING,
-                RecordingStatus.PROCESSING_TRANSCRIPTS,
-                RecordingStatus.SAVING,
-              ].includes(prev.status)
-                ? prev.status // Already in stop flow
-                : RecordingStatus.STOPPING; // New stop, transition smoothly
-
-              return {
-                ...prev,
-                status: newStatus,
-                statusMessage:
-                  newStatus === RecordingStatus.STOPPING
-                    ? "Stopping recording..."
-                    : prev.statusMessage,
-                isRecording: false,
-                isPaused: false,
-                isActive: false,
-                recordingDuration: null,
-                activeDuration: null,
-              };
-            });
-            // Deliberately do NOT stop polling here: the backend keeps
-            // draining/finalising (transcription flush, audio merge) for
-            // seconds after `is_recording` flips false, and `is_finalising`
-            // must keep being observed through that window (issue #35).
-            // `syncWithBackend`'s own polling tick stops the interval once
-            // the backend confirms both recording and finalising are done.
-          },
-        );
-        unsubscribers.push(unlistenStopped);
-
-        // Recording paused
-        const unlistenPaused = await recordingService.onRecordingPaused(() => {
-          console.log("[RecordingStateContext] Recording paused event");
-          setState((prev) => ({
-            ...prev,
-            isPaused: true,
-            isActive: false,
-          }));
-        });
-        unsubscribers.push(unlistenPaused);
-
-        // Recording resumed
-        const unlistenResumed = await recordingService.onRecordingResumed(
-          () => {
-            console.log("[RecordingStateContext] Recording resumed event");
-            setState((prev) => ({
-              ...prev,
-              isPaused: false,
-              isActive: true,
-            }));
-          },
-        );
-        unsubscribers.push(unlistenResumed);
-
-        console.log(
-          "[RecordingStateContext] Event listeners set up successfully",
-        );
+        const backendState = await recordingService.getRecordingState();
+        if (!cancelled) {
+          applySnapshot(snapshotFromBackendState(backendState));
+        }
       } catch (error) {
         console.error(
-          "[RecordingStateContext] Failed to set up event listeners:",
+          "[RecordingStateContext] Failed to resync recording state:",
           error,
         );
       }
     };
 
-    setupListeners();
+    const setup = async () => {
+      try {
+        unlistenState = await recordingService.onRecordingState((snapshot) => {
+          applySnapshot(snapshot);
+        });
+        console.log(
+          "[RecordingStateContext] Subscribed to recording-state events",
+        );
+      } catch (error) {
+        console.error(
+          "[RecordingStateContext] Failed to subscribe to recording-state:",
+          error,
+        );
+      }
+
+      // Initial sync on mount - fixes refresh/new-window desync (backend
+      // recording but this window's default state is idle).
+      await resync();
+    };
+
+    setup();
+
+    const onFocus = () => {
+      resync();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        resync();
+      }
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
 
     return () => {
-      console.log("[RecordingStateContext] Cleaning up event listeners");
-      unsubscribers.forEach((unsub) => unsub());
-      stopPolling();
+      cancelled = true;
+      unlistenState?.();
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [startPolling, stopPolling]);
+  }, [applySnapshot]);
 
   /**
-   * Initial sync on mount - CRITICAL for fixing refresh desync bug
-   * If backend is recording but UI state is false, this will correct it.
-   * setState happens after await inside syncWithBackend.
+   * Watchdog (issue #17 gap): arm a one-shot timer whenever local `status`
+   * is stuck in the stop flow while the backend's phase is already Idle.
+   * Re-checks both conditions (plus `isPostProcessingRef`) when it fires,
+   * so a status change or a post-processing run that starts in the
+   * meantime disarms it without needing its own effect dependency.
    */
   useEffect(() => {
-    console.log("[RecordingStateContext] Initial mount - syncing with backend");
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    syncWithBackend();
-  }, [syncWithBackend]);
+    const rank = stopFlowRank(status);
+    const inStopFlow = rank >= 1 && rank <= 3; // STOPPING/PROCESSING/SAVING, not COMPLETED
+    const backendIdle = phase === "idle";
+
+    if (inStopFlow && backendIdle && !isPostProcessingRef.current) {
+      if (!watchdogTimerRef.current) {
+        watchdogTimerRef.current = setTimeout(() => {
+          watchdogTimerRef.current = null;
+          const stillRank = stopFlowRank(statusRef.current);
+          const stillStuck =
+            stillRank >= 1 && stillRank <= 3 && !isPostProcessingRef.current;
+          if (stillStuck) {
+            console.warn(
+              "[RecordingStateContext] Watchdog: stuck in",
+              statusRef.current,
+              "for over",
+              WATCHDOG_STUCK_TIMEOUT_MS,
+              "ms while backend reports idle and no post-processing is running - forcing IDLE",
+            );
+            setStatusState(RecordingStatus.IDLE);
+            setStatusMessage(undefined);
+            toast.error(
+              "Recording finished; the transcript may need recovery from the Recoverable meetings dialog",
+            );
+          }
+        }, WATCHDOG_STUCK_TIMEOUT_MS);
+      }
+    } else if (watchdogTimerRef.current) {
+      clearTimeout(watchdogTimerRef.current);
+      watchdogTimerRef.current = null;
+    }
+  }, [status, phase]);
+
+  // Clear any still-armed watchdog timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (watchdogTimerRef.current) {
+        clearTimeout(watchdogTimerRef.current);
+      }
+    };
+  }, []);
 
   // NEW: Computed helpers from status
   const contextValue = useMemo(() => {
-    const isStopping = state.status === RecordingStatus.STOPPING;
-    const isProcessing = state.status === RecordingStatus.PROCESSING_TRANSCRIPTS;
-    const isSaving = state.status === RecordingStatus.SAVING;
+    const isStopping = status === RecordingStatus.STOPPING;
+    const isProcessing = status === RecordingStatus.PROCESSING_TRANSCRIPTS;
+    const isSaving = status === RecordingStatus.SAVING;
     return {
-      ...state,
+      isRecording,
+      isPaused,
+      isActive,
+      recordingDuration,
+      activeDuration,
+      status,
+      statusMessage,
+      isBackendFinalising,
       setStatus,
       isStopping,
       isProcessing,
       isSaving,
       // Single source of truth (issue #35): local stop-flow status OR the
-      // backend's own `is_finalising` flag, so every start entry point can
-      // gate on one value regardless of which window/tab drove the stop.
+      // backend's own finalising phase, so every start entry point can gate
+      // on one value regardless of which window/tab drove the stop.
       isStopFlowActive:
-        isStopping || isProcessing || isSaving || state.isBackendFinalising,
+        isStopping || isProcessing || isSaving || isBackendFinalising,
     };
-  }, [state, setStatus]);
+  }, [
+    isRecording,
+    isPaused,
+    isActive,
+    recordingDuration,
+    activeDuration,
+    status,
+    statusMessage,
+    isBackendFinalising,
+    setStatus,
+  ]);
 
   return (
     <RecordingStateContext.Provider value={contextValue}>

--- a/frontend/src/contexts/TranscriptContext.tsx
+++ b/frontend/src/contexts/TranscriptContext.tsx
@@ -131,20 +131,24 @@ function TranscriptProviderInner({ children }: { children: ReactNode }) {
         // Initialize IndexedDB
         await indexedDBService.init();
 
-        // Listen for recording-started event
+        // Listen for recording-started event. Rust now creates the
+        // `meetings` row itself at recording start (issue #57 slice 2) and
+        // hands back its id in the payload — use that directly as the key
+        // for the IndexedDB write-ahead cache below instead of minting a
+        // separate IndexedDB-only id and duplicating meeting metadata
+        // (title/folder_path/status) that SQLite already owns.
         unlistenRecordingStarted = await recordingService.onRecordingStarted(
-          async () => {
+          async (payload) => {
             try {
-              // Generate unique meeting ID
-              const meetingId = `meeting-${Date.now()}`;
+              // Talking to an older backend build with no meeting_id in the
+              // payload falls back to a local-only cache key so the
+              // write-ahead cache below still works, just unkeyed to a real
+              // meeting row.
+              const meetingId = payload.meeting_id ?? `meeting-${Date.now()}`;
               setCurrentMeetingId(meetingId);
-
-              // Store in sessionStorage as fallback for markMeetingAsSaved
+              // Fallback for markMeetingAsSaved if this provider instance
+              // unmounts/remounts mid-recording.
               sessionStorage.setItem("indexeddb_current_meeting_id", meetingId);
-              console.log(
-                "[Recording Started] 💾 IndexedDB meeting ID stored:",
-                meetingId,
-              );
 
               // Get meeting name
               const meetingName =
@@ -155,7 +159,16 @@ function TranscriptProviderInner({ children }: { children: ReactNode }) {
                 meetingName ||
                 `Meeting ${new Date().toISOString().slice(0, 19).replace("T", "_").replace(/:/g, "-")}`;
 
-              // Initialize meeting metadata in IndexedDB
+              // Synchronize meeting title to state (fixes tray stop title issue)
+              setMeetingTitle(effectiveTitle);
+
+              // A slim metadata row, kept only so the periodic janitors
+              // below (deleteOldMeetings/deleteSavedMeetings) have
+              // something to key their pruning off of — SQLite (via
+              // `payload.meeting_id`'s row) is the source of truth for
+              // everything else about this meeting now, so this no longer
+              // round-trips to fetch/store folder_path or track
+              // savedToSQLite for recovery purposes.
               await indexedDBService.saveMeetingMetadata({
                 meetingId,
                 title: effectiveTitle,
@@ -163,33 +176,10 @@ function TranscriptProviderInner({ children }: { children: ReactNode }) {
                 lastUpdated: Date.now(),
                 transcriptCount: 0,
                 savedToSQLite: false,
-                folderPath: undefined, // Will update shortly
               });
-
-              // Synchronize meeting title to state (fixes tray stop title issue)
-              setMeetingTitle(effectiveTitle);
-
-              // Fetch folder path from backend and update metadata
-              // This ensures folder path is persisted even if app crashes
-              try {
-                const { invoke } = await import("@tauri-apps/api/core");
-                const folderPath = await invoke<string>(
-                  "get_meeting_folder_path",
-                );
-                if (folderPath) {
-                  const metadata =
-                    await indexedDBService.getMeetingMetadata(meetingId);
-                  if (metadata) {
-                    metadata.folderPath = folderPath;
-                    await indexedDBService.saveMeetingMetadata(metadata);
-                  }
-                }
-              } catch (error) {
-                // Non-fatal - will be set on stop if recording completes normally
-              }
             } catch (error) {
               console.error(
-                "Failed to initialize meeting in IndexedDB:",
+                "Failed to initialize meeting state on recording-started:",
                 error,
               );
             }
@@ -198,32 +188,17 @@ function TranscriptProviderInner({ children }: { children: ReactNode }) {
 
         // Listen for recording-stopped event
         unlistenRecordingStopped = await recordingService.onRecordingStopped(
-          async (payload) => {
+          async () => {
             // Recording has ended - there is no "finishing" utterance left
             // to preview, so drop any in-flight partial previews.
             clearPartials();
 
             // Nothing left to accumulate - flush anything still queued so
-            // it isn't lost before the meeting gets marked saved.
+            // it isn't lost before the meeting gets marked saved. Rust
+            // already owns folder_path/status on the meeting row itself
+            // (issue #57 slice 2), so there's no IndexedDB metadata to
+            // reconcile here any more.
             flushSaveQueueRef.current?.();
-
-            try {
-              if (currentMeetingId) {
-                // Update folder path in IndexedDB
-                const metadata =
-                  await indexedDBService.getMeetingMetadata(currentMeetingId);
-
-                if (metadata && payload.folder_path) {
-                  metadata.folderPath = payload.folder_path;
-                  await indexedDBService.saveMeetingMetadata(metadata);
-                }
-              }
-            } catch (error) {
-              console.error(
-                "Failed to update meeting metadata on stop:",
-                error,
-              );
-            }
           },
         );
       } catch (error) {

--- a/frontend/src/hooks/useRecordingStateSync.ts
+++ b/frontend/src/hooks/useRecordingStateSync.ts
@@ -9,10 +9,11 @@ interface UseRecordingStateSyncReturn {
 
 /**
  * Thin adapter between page.tsx's page-local `isRecording` mirror and
- * RecordingStateContext's `isRecording` (the single source of truth, kept
- * in sync with the backend via Tauri event listeners plus a 500ms poll
- * while a recording/stop is in flight - see
- * `contexts/RecordingStateContext.tsx`).
+ * RecordingStateContext's `isRecording` (the single source of truth, kept in
+ * sync with the backend's canonical recording-state machine via the
+ * `recording-state` event plus a one-shot resync on mount/focus - see
+ * `contexts/RecordingStateContext.tsx`. Issue #57 slice 1 removed the
+ * previous 500ms poll entirely).
  *
  * Previously this hook ran its own unconditional 1-second backend poll for
  * the entire lifetime of the home page, duplicating the context's polling

--- a/frontend/src/hooks/useRecordingStop.ts
+++ b/frontend/src/hooks/useRecordingStop.ts
@@ -122,12 +122,14 @@ export function useRecordingStop(
           message: string;
           folder_path?: string;
           meeting_name?: string;
+          meeting_id?: string;
         }>("recording-stopped", async (event) => {
           // Create promise that resolves when sessionStorage is set (prevents race condition)
           recordingStoppedDataRef.current = (async () => {
-            const { folder_path, meeting_name } = event.payload;
+            const { folder_path, meeting_name, meeting_id } = event.payload;
 
-            // Store folder_path and meeting_name for later use in handleRecordingStop
+            // Store folder_path, meeting_name and meeting_id for later use
+            // in handleRecordingStop
             if (folder_path) {
               sessionStorage.setItem("last_recording_folder_path", folder_path);
             }
@@ -136,6 +138,15 @@ export function useRecordingStop(
                 "last_recording_meeting_name",
                 meeting_name,
               );
+            }
+            // meeting_id is the `meetings` row Rust already created and
+            // finalised for this session (issue #57 slice 2). Its absence
+            // means an older backend build — handleRecordingStop falls back
+            // to the pre-#57 create-and-bulk-insert path in that case.
+            if (meeting_id) {
+              sessionStorage.setItem("last_recording_meeting_id", meeting_id);
+            } else {
+              sessionStorage.removeItem("last_recording_meeting_id");
             }
           })();
         });
@@ -348,23 +359,64 @@ export function useRecordingStop(
                 : "none",
           });
 
+          // Rust already created and finalised the meeting row (status,
+          // transcripts, folder_path, audio) by the time `recording-stopped`
+          // fired (issue #57 slice 2) — its id came along in that payload.
+          // The frontend's post-stop save is now an update to the one field
+          // it still owns (the title, which the live-recording view may
+          // have let the user edit to something other than what recording
+          // started with), not a create-and-bulk-insert. A missing
+          // meeting_id means an older backend build without slice 2 — fall
+          // back to the original create-and-bulk-insert path so nothing
+          // breaks mid-migration.
+          const meetingIdFromStop = sessionStorage.getItem(
+            "last_recording_meeting_id",
+          );
+
           try {
-            const responseData = await storageService.saveMeeting(
-              savedMeetingName || meetingTitle || "New Meeting", // PREFER savedMeetingName (backend source)
-              freshTranscripts,
-              folderPath,
-            );
+            const finalTitle =
+              savedMeetingName || meetingTitle || "New Meeting";
+            let meetingId: string;
 
-            const meetingId = responseData.meeting_id;
-            if (!meetingId) {
-              console.error("No meeting_id in response:", responseData);
-              throw new Error("No meeting ID received from save operation");
+            if (meetingIdFromStop) {
+              meetingId = meetingIdFromStop;
+              try {
+                await storageService.finalizeMeetingTitle(
+                  meetingId,
+                  finalTitle,
+                );
+              } catch (titleError) {
+                // Non-fatal: the meeting row already exists with whatever
+                // title Rust set at recording start; worst case the user
+                // re-titles it from the meeting detail page.
+                console.warn(
+                  "Failed to finalize meeting title (meeting is still saved):",
+                  titleError,
+                );
+              }
+              console.log(
+                "✅ Meeting already saved by the backend; finalized title for ID:",
+                meetingId,
+              );
+            } else {
+              console.log(
+                "No meeting_id in recording-stopped payload (older backend) — falling back to bulk transcript save",
+              );
+              const responseData = await storageService.saveMeeting(
+                finalTitle,
+                freshTranscripts,
+                folderPath,
+              );
+              if (!responseData.meeting_id) {
+                console.error("No meeting_id in response:", responseData);
+                throw new Error("No meeting ID received from save operation");
+              }
+              meetingId = responseData.meeting_id;
+              console.log(
+                "✅ Successfully saved COMPLETE meeting with ID:",
+                meetingId,
+              );
             }
-
-            console.log(
-              "✅ Successfully saved COMPLETE meeting with ID:",
-              meetingId,
-            );
             console.log("   Transcripts:", freshTranscripts.length);
             console.log("   folder_path:", folderPath);
 
@@ -410,6 +462,7 @@ export function useRecordingStop(
             // Clean up session storage
             sessionStorage.removeItem("last_recording_folder_path");
             sessionStorage.removeItem("last_recording_meeting_name");
+            sessionStorage.removeItem("last_recording_meeting_id");
             // Clean up IndexedDB meeting ID (redundant with markMeetingAsSaved cleanup, but ensures cleanup)
             sessionStorage.removeItem("indexeddb_current_meeting_id");
 

--- a/frontend/src/hooks/useTranscriptRecovery.ts
+++ b/frontend/src/hooks/useTranscriptRecovery.ts
@@ -1,99 +1,98 @@
 /**
  * useTranscriptRecovery Hook
  *
- * Orchestrates transcript recovery operations for interrupted meetings.
- * Provides functionality to detect, preview, and recover meetings from IndexedDB.
+ * Orchestrates recovery of meetings an unclean shutdown interrupted
+ * mid-recording. Issue #57 slice 2: "recoverable" is now a database fact
+ * (`meetings.status = 'interrupted'`, set by the Rust startup sweep or a
+ * fatal-error stop) instead of a scan over an IndexedDB cache the frontend
+ * built up itself — recovery is a Rust command, not a client-side
+ * reconstruction. IndexedDB remains only a per-viewer write-ahead cache for
+ * the live transcript list; it has no say in what's recoverable any more.
  */
 
 import { useState, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import {
-  indexedDBService,
-  MeetingMetadata,
-  StoredTranscript,
-} from "@/services/indexedDBService";
-import { storageService } from "@/services/storageService";
+  storageService,
+  InterruptedMeeting,
+  AudioRecoveryStatus,
+} from "@/services/storageService";
 import { getErrorMessage } from "@/lib/utils";
 
-interface AudioRecoveryStatus {
-  status: string; // "success" | "partial" | "failed" | "none"
-  chunk_count: number;
-  estimated_duration_seconds: number;
-  audio_file_path?: string;
-  message: string;
+/** One row from `list_interrupted_meetings`, shaped to match the fields the
+ *  recovery dialog UI already renders (mirrors the old IndexedDB
+ *  `MeetingMetadata` shape it replaces, so the dialog component didn't need
+ *  to change). */
+export interface RecoverableMeeting {
+  meetingId: string;
+  title: string;
+  startTime: number;
+  lastUpdated: number;
+  transcriptCount: number;
+  /** Set only when `.checkpoints/` audio still exists on disk for this
+   *  meeting — mirrors the old "folderPath present = audio available"
+   *  contract the dialog's UI already checks for. */
+  folderPath?: string;
+}
+
+/** One transcript segment for the dialog's preview panel — the fields of
+ *  `MeetingTranscript` (from `api_get_meeting`) the preview UI reads. */
+export interface PreviewTranscript {
+  id: string;
+  text: string;
+  timestamp: string;
+  audio_start_time?: number;
+  audio_end_time?: number;
+  duration?: number;
 }
 
 export interface UseTranscriptRecoveryReturn {
-  recoverableMeetings: MeetingMetadata[];
+  recoverableMeetings: RecoverableMeeting[];
   isLoading: boolean;
   isRecovering: boolean;
-  checkForRecoverableTranscripts: () => Promise<MeetingMetadata[]>;
-  recoverMeeting: (
-    meetingId: string,
-  ) => Promise<{
+  checkForRecoverableTranscripts: () => Promise<RecoverableMeeting[]>;
+  recoverMeeting: (meetingId: string) => Promise<{
     success: boolean;
     audioRecoveryStatus?: AudioRecoveryStatus | null;
     meetingId?: string;
   }>;
-  loadMeetingTranscripts: (meetingId: string) => Promise<StoredTranscript[]>;
+  loadMeetingTranscripts: (meetingId: string) => Promise<PreviewTranscript[]>;
   deleteRecoverableMeeting: (meetingId: string) => Promise<void>;
+}
+
+function toRecoverableMeeting(row: InterruptedMeeting): RecoverableMeeting {
+  const createdMs = Date.parse(row.created_at);
+  return {
+    meetingId: row.meeting_id,
+    title: row.title,
+    startTime: Number.isNaN(createdMs) ? Date.now() : createdMs,
+    lastUpdated: Number.isNaN(createdMs) ? Date.now() : createdMs,
+    transcriptCount: row.segment_count,
+    folderPath:
+      row.has_audio_checkpoints && row.folder_path
+        ? row.folder_path
+        : undefined,
+  };
 }
 
 export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
   const [recoverableMeetings, setRecoverableMeetings] = useState<
-    MeetingMetadata[]
+    RecoverableMeeting[]
   >([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isRecovering, setIsRecovering] = useState(false);
 
   /**
-   * Check for recoverable meetings in IndexedDB
+   * List meetings the backend considers interrupted.
    */
   const checkForRecoverableTranscripts = useCallback(async () => {
     setIsLoading(true);
     try {
-      const meetings = await indexedDBService.getAllMeetings();
-
-      // Filter out meetings older than 7 days and newer than 15 seconds
-      // The 15 seconds threshold prevents showing meetings from the current session(jus in case)
-      // where recording just stopped but hasn't been fully saved yet
-      const cutoffTime = Date.now() - 7 * 24 * 60 * 60 * 1000;
-      const secondsAgo = Date.now() - 15 * 1000;
-
-      const recentMeetings = meetings.filter((m) => {
-        const isWithinRetention = m.lastUpdated > cutoffTime; // Not older than 7 days
-        const isOldEnough = m.lastUpdated < secondsAgo; // Older than 15 seconds
-        return isWithinRetention && isOldEnough;
-      });
-
-      // Verify audio checkpoint availability for each meeting
-      const meetingsWithAudioStatus = await Promise.all(
-        recentMeetings.map(async (meeting) => {
-          if (meeting.folderPath) {
-            try {
-              const hasAudio = await invoke<boolean>("has_audio_checkpoints", {
-                meetingFolder: meeting.folderPath,
-              });
-
-              // If no audio files, clear folderPath to show "No audio" in UI
-              return {
-                ...meeting,
-                folderPath: hasAudio ? meeting.folderPath : undefined,
-              };
-            } catch (error) {
-              console.warn("Failed to check audio for meeting:", error);
-              // On error, assume no audio to be safe
-              return { ...meeting, folderPath: undefined };
-            }
-          }
-          return meeting;
-        }),
-      );
-
-      setRecoverableMeetings(meetingsWithAudioStatus);
-      return meetingsWithAudioStatus;
+      const rows = await storageService.listInterruptedMeetings();
+      const meetings = rows.map(toRecoverableMeeting);
+      setRecoverableMeetings(meetings);
+      return meetings;
     } catch (error) {
-      console.error("Failed to check for recoverable transcripts:", error);
+      console.error("Failed to list interrupted meetings:", error);
       setRecoverableMeetings([]);
       return [];
     } finally {
@@ -102,15 +101,20 @@ export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
   }, []);
 
   /**
-   * Load transcripts for preview
+   * Load transcripts for preview. Interrupted meetings already have their
+   * transcript segments in SQLite — they were upserted live, up to
+   * whatever was flushed before the interruption (issue #57 slice 2) — so
+   * this reads the same way a saved meeting's transcripts do, rather than
+   * reading back out of IndexedDB.
    */
   const loadMeetingTranscripts = useCallback(
-    async (meetingId: string): Promise<StoredTranscript[]> => {
+    async (meetingId: string): Promise<PreviewTranscript[]> => {
       try {
-        const transcripts = await indexedDBService.getTranscripts(meetingId);
-        // Sort by sequence ID
-        transcripts.sort((a, b) => (a.sequenceId || 0) - (b.sequenceId || 0));
-        return transcripts;
+        const meeting = await storageService.getMeeting(meetingId);
+        const transcripts = (meeting.transcripts ?? []) as PreviewTranscript[];
+        return [...transcripts].sort(
+          (a, b) => (a.audio_start_time ?? 0) - (b.audio_start_time ?? 0),
+        );
       } catch (error) {
         console.error("Failed to load meeting transcripts:", error);
         return [];
@@ -120,131 +124,41 @@ export function useTranscriptRecovery(): UseTranscriptRecoveryReturn {
   );
 
   /**
-   * Recover a meeting from IndexedDB
+   * Recover a meeting: the Rust command merges any `.checkpoints` audio
+   * still on disk and marks the row "completed".
    */
-  const recoverMeeting = useCallback(
-    async (
-      meetingId: string,
-    ): Promise<{
-      success: boolean;
-      audioRecoveryStatus?: AudioRecoveryStatus | null;
-      meetingId?: string;
-    }> => {
-      setIsRecovering(true);
-      try {
-        // 1. Load meeting metadata
-        const metadata = await indexedDBService.getMeetingMetadata(meetingId);
-        if (!metadata) {
-          throw new Error("Meeting metadata not found");
-        }
+  const recoverMeeting = useCallback(async (meetingId: string) => {
+    setIsRecovering(true);
+    try {
+      const result = await storageService.recoverMeeting(meetingId);
 
-        // 2. Load all transcripts
-        const transcripts = await loadMeetingTranscripts(meetingId);
-        if (transcripts.length === 0) {
-          throw new Error("No transcripts found for this meeting");
-        }
+      setRecoverableMeetings((prev) =>
+        prev.filter((m) => m.meetingId !== meetingId),
+      );
 
-        // 3. Check for folder path
-        let folderPath = metadata.folderPath;
-
-        if (!folderPath) {
-          // Try to get from backend (might exist if only app crashed, not system)
-          try {
-            folderPath = await invoke<string>("get_meeting_folder_path");
-          } catch (error) {
-            folderPath = undefined;
-          }
-        }
-
-        // 4. Attempt audio recovery if folder path exists
-        let audioRecoveryStatus: AudioRecoveryStatus | null = null;
-        if (folderPath) {
-          try {
-            audioRecoveryStatus = await invoke<AudioRecoveryStatus>(
-              "recover_audio_from_checkpoints",
-              { meetingFolder: folderPath, sampleRate: 48000 },
-            );
-          } catch (error) {
-            console.error("Audio recovery failed:", error);
-            audioRecoveryStatus = {
-              status: "failed",
-              chunk_count: 0,
-              estimated_duration_seconds: 0,
-              message: getErrorMessage(error),
-            };
-          }
-        } else {
-          audioRecoveryStatus = {
-            status: "none",
-            chunk_count: 0,
-            estimated_duration_seconds: 0,
-            message: "No folder path available",
-          };
-        }
-
-        // 5. Convert StoredTranscripts to the format expected by storageService
-        const formattedTranscripts = transcripts.map((t, index) => ({
-          id: t.id?.toString() || `${Date.now()}-${index}`,
-          text: t.text,
-          timestamp: t.timestamp,
-          sequence_id: t.sequenceId || index,
-          chunk_start_time: (t as any).chunk_start_time,
-          is_partial: (t as any).is_partial || false,
-          confidence: t.confidence,
-          audio_start_time: (t as any).audio_start_time,
-          audio_end_time: (t as any).audio_end_time,
-          duration: (t as any).duration,
-        }));
-
-        // 6. Save to backend database using existing save utilities
-        const saveResponse = await storageService.saveMeeting(
-          metadata.title,
-          formattedTranscripts,
-          folderPath ?? null,
-        );
-
-        const savedMeetingId = saveResponse.meeting_id;
-
-        // 7. Mark as saved in IndexedDB
-        await indexedDBService.markMeetingSaved(meetingId);
-
-        // 8. Clean up checkpoint files
-        if (folderPath) {
-          try {
-            await invoke("cleanup_checkpoints", { meetingFolder: folderPath });
-          } catch (error) {
-            // Non-fatal - don't fail recovery if cleanup fails
-            console.warn("Checkpoint cleanup failed (non-fatal):", error);
-          }
-        }
-
-        // 9. Remove from recoverable list
-        setRecoverableMeetings((prev) =>
-          prev.filter((m) => m.meetingId !== meetingId),
-        );
-
-        return {
-          success: true,
-          audioRecoveryStatus,
-          meetingId: savedMeetingId,
-        };
-      } catch (error) {
-        console.error("Failed to recover meeting:", error);
-        throw error;
-      } finally {
-        setIsRecovering(false);
-      }
-    },
-    [loadMeetingTranscripts],
-  );
+      return {
+        success: result.success,
+        audioRecoveryStatus: result.audio_recovery_status,
+        meetingId: result.meeting_id,
+      };
+    } catch (error) {
+      console.error("Failed to recover meeting:", error);
+      throw new Error(getErrorMessage(error));
+    } finally {
+      setIsRecovering(false);
+    }
+  }, []);
 
   /**
-   * Delete a recoverable meeting
+   * Delete an interrupted meeting outright (the user chose to discard it
+   * rather than recover it) — the same command every other "delete a
+   * meeting" affordance in the app uses.
    */
   const deleteRecoverableMeeting = useCallback(
     async (meetingId: string): Promise<void> => {
       try {
-        await indexedDBService.deleteMeeting(meetingId);
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("api_delete_meeting", { meetingId });
         setRecoverableMeetings((prev) =>
           prev.filter((m) => m.meetingId !== meetingId),
         );

--- a/frontend/src/lib/dev/tauri-mock.ts
+++ b/frontend/src/lib/dev/tauri-mock.ts
@@ -97,6 +97,14 @@ const COMMAND_DEFAULTS: Record<string, Default> = {
   get_transcription_status: null,
   has_audio_checkpoints: false,
 
+  // --- Interrupted-meeting recovery (issue #57 slice 2) --------------------
+  list_interrupted_meetings: () => [],
+  recover_meeting: () => ({
+    success: false,
+    meeting_id: "",
+    audio_recovery_status: null,
+  }),
+
   // --- Onboarding gate ------------------------------------------------------
   // AppShell shows a full-screen OnboardingFlow (hiding the whole app) unless
   // this resolves to a non-null object with `completed: true`. That is the one

--- a/frontend/src/services/recordingService.ts
+++ b/frontend/src/services/recordingService.ts
@@ -34,6 +34,10 @@ export interface RecordingSnapshot {
   total_pause_secs: number;
   meeting_name: string | null;
   folder_path: string | null;
+  /** The `meetings` row id for the in-progress session (issue #57 slice 2),
+   *  null once idle. Rust owns creating/finalising this row — the frontend
+   *  only ever updates fields it still owns (see `api_save_meeting_title`). */
+  meeting_id: string | null;
   chunks_in_queue: number;
   error: string | null;
   /** Monotonically increasing per emitted snapshot. */
@@ -56,6 +60,21 @@ export interface RecordingStoppedPayload {
   message: string;
   folder_path?: string;
   meeting_name?: string;
+  /** The `meetings` row id Rust created for this session at start and has
+   *  already finalised (status "completed"/"interrupted") by the time this
+   *  fires (issue #57 slice 2). Absent only when talking to an older
+   *  backend build — callers should fall back to the pre-#57 save flow. */
+  meeting_id?: string;
+}
+
+export interface RecordingStartedPayload {
+  message: string;
+  devices?: string[];
+  workers?: number;
+  /** The `meetings` row id Rust just created (status "recording") for this
+   *  session (issue #57 slice 2). Absent only when talking to an older
+   *  backend build. */
+  meeting_id?: string;
 }
 
 /**
@@ -128,11 +147,15 @@ class RecordingService {
 
   /**
    * Listen for recording-started event
-   * @param callback - Function to call when recording starts
+   * @param callback - Function to call when recording starts, with its payload
    * @returns Promise that resolves to unlisten function
    */
-  async onRecordingStarted(callback: () => void): Promise<UnlistenFn> {
-    return listen("recording-started", callback);
+  async onRecordingStarted(
+    callback: (payload: RecordingStartedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<RecordingStartedPayload>("recording-started", (event) => {
+      callback(event.payload);
+    });
   }
 
   /**

--- a/frontend/src/services/recordingService.ts
+++ b/frontend/src/services/recordingService.ts
@@ -8,7 +8,39 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, UnlistenFn } from "@tauri-apps/api/event";
 
-export interface RecordingState {
+/**
+ * Canonical recording lifecycle phase, owned entirely by the Rust side
+ * (`audio::recording_phase::RecordingPhase`). Mirrors its `serde`
+ * `snake_case` representation exactly.
+ */
+export type RecordingPhase =
+  | "idle"
+  | "starting"
+  | "recording"
+  | "paused"
+  | "stopping"
+  | "finalising"
+  | "error";
+
+/**
+ * Payload of the `recording-state` event, and the shape `get_recording_state`
+ * now returns alongside its legacy keys. See `audio::recording_phase::RecordingSnapshot`.
+ */
+export interface RecordingSnapshot {
+  phase: RecordingPhase;
+  /** Unix ms the current session started recording (null once idle). */
+  started_at_ms: number | null;
+  active_duration_secs: number | null;
+  total_pause_secs: number;
+  meeting_name: string | null;
+  folder_path: string | null;
+  chunks_in_queue: number;
+  error: string | null;
+  /** Monotonically increasing per emitted snapshot. */
+  seq: number;
+}
+
+export interface RecordingState extends Partial<RecordingSnapshot> {
   is_recording: boolean;
   is_paused: boolean;
   is_active: boolean;
@@ -77,6 +109,22 @@ class RecordingService {
   }
 
   // Event Listeners
+
+  /**
+   * Listen for the canonical `recording-state` event, emitted by the Rust
+   * state machine (`audio::recording_phase`) on every phase transition
+   * (start/stop/pause/resume/error) — the single source of truth this
+   * context syncs from instead of polling `get_recording_state`.
+   * @param callback - Function to call with the new snapshot
+   * @returns Promise that resolves to unlisten function
+   */
+  async onRecordingState(
+    callback: (snapshot: RecordingSnapshot) => void,
+  ): Promise<UnlistenFn> {
+    return listen<RecordingSnapshot>("recording-state", (event) => {
+      callback(event.payload);
+    });
+  }
 
   /**
    * Listen for recording-started event

--- a/frontend/src/services/storageService.ts
+++ b/frontend/src/services/storageService.ts
@@ -50,6 +50,60 @@ class StorageService {
   async getMeeting(meetingId: string): Promise<Meeting> {
     return invoke<Meeting>("api_get_meeting", { meetingId });
   }
+
+  /**
+   * Update the title of a meeting Rust already created and finalised
+   * (issue #57 slice 2 — the meeting row and its transcripts are Rust's;
+   * this is the one field the frontend still owns post-stop, e.g. a title
+   * the user edited live that differs from the name recording started
+   * with).
+   * @param meetingId - ID of the already-existing meeting row
+   * @param title - The final title to set
+   */
+  async finalizeMeetingTitle(meetingId: string, title: string): Promise<void> {
+    await invoke("api_save_meeting_title", { meetingId, title });
+  }
+
+  /**
+   * List meetings an unclean shutdown left "interrupted" (issue #57 slice
+   * 2), most recent first.
+   */
+  async listInterruptedMeetings(): Promise<InterruptedMeeting[]> {
+    return invoke<InterruptedMeeting[]>("list_interrupted_meetings");
+  }
+
+  /**
+   * Recover one interrupted meeting: merges any `.checkpoints` audio still
+   * on disk and marks the row "completed". Its transcripts need no recovery
+   * work — they were already persisted live, up to whatever was flushed
+   * before the interruption.
+   */
+  async recoverMeeting(meetingId: string): Promise<RecoverMeetingResult> {
+    return invoke<RecoverMeetingResult>("recover_meeting", { meetingId });
+  }
+}
+
+export interface InterruptedMeeting {
+  meeting_id: string;
+  title: string;
+  folder_path?: string | null;
+  created_at: string;
+  segment_count: number;
+  has_audio_checkpoints: boolean;
+}
+
+export interface AudioRecoveryStatus {
+  status: string; // "success" | "partial" | "failed" | "none"
+  chunk_count: number;
+  estimated_duration_seconds: number;
+  audio_file_path?: string | null;
+  message: string;
+}
+
+export interface RecoverMeetingResult {
+  success: boolean;
+  meeting_id: string;
+  audio_recovery_status?: AudioRecoveryStatus | null;
 }
 
 // Export singleton instance

--- a/whisper-core/Cargo.toml
+++ b/whisper-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "whisper-core"
+version = "0.1.0"
+edition.workspace = true
+description = "Shared whisper.cpp params-building and confidence-scoring logic, used by both the in-process WhisperEngine and the whisper-helper sidecar."
+
+[dependencies]
+anyhow = { workspace = true }
+whisper-rs = { version = "0.16.0", features = ["raw-api", "log_backend"] }
+
+[features]
+default = []
+cuda = ["whisper-rs/cuda"]
+vulkan = ["whisper-rs/vulkan"]
+openblas = ["whisper-rs/openblas"]
+openmp = ["whisper-rs/openmp"]

--- a/whisper-core/src/lib.rs
+++ b/whisper-core/src/lib.rs
@@ -1,0 +1,264 @@
+//! Shared whisper.cpp transcription logic: `FullParams` construction and
+//! decoder-confidence scoring.
+//!
+//! Ported out of `frontend/src-tauri/src/whisper_engine/whisper_engine.rs`
+//! (`transcribe_audio_with_confidence_opts`) for the issue #56 sidecar spike.
+//! The in-process engine is left unmodified for this spike (see
+//! `docs/transcription-backends.md` for the follow-up that would switch it
+//! to call this crate too, removing the duplication); this crate mirrors its
+//! parameter choices and confidence formula exactly so the two paths behave
+//! identically once wired together.
+//!
+//! Deliberately has no knowledge of Tokio, Tauri, or hardware detection —
+//! callers (the in-process engine, or `whisper-helper`) supply thread count
+//! and beam size via [`DecodeConfig`] rather than this crate reaching for
+//! `audio::HardwareProfile` itself, so it stays usable from a plain sidecar
+//! binary with no async runtime.
+
+use anyhow::{anyhow, Result};
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext};
+
+/// Whisper decodes nothing useful under 1s of audio ("input is too short")
+/// and silently returns zero segments instead of erroring — callers must pad
+/// short chunks before calling [`transcribe_pcm16k`].
+pub const WHISPER_MIN_INPUT_SAMPLES: usize = 16_000; // 1s @ 16kHz
+
+/// Zero-pad `audio` up to [`WHISPER_MIN_INPUT_SAMPLES`] if it's shorter.
+pub fn pad_to_min_whisper_input(mut audio: Vec<f32>) -> Vec<f32> {
+    if audio.len() < WHISPER_MIN_INPUT_SAMPLES {
+        audio.resize(WHISPER_MIN_INPUT_SAMPLES, 0.0);
+    }
+    audio
+}
+
+/// Hardware-adaptive decode knobs. The in-process engine derives these from
+/// `audio::HardwareProfile::detect().get_whisper_config()`; a sidecar with no
+/// access to that module can supply its own estimate (e.g. `num_cpus` or a
+/// fixed conservative default) via [`DecodeConfig::default`].
+#[derive(Debug, Clone, Copy)]
+pub struct DecodeConfig {
+    pub beam_size: u32,
+    pub max_threads: i32,
+    pub temperature: f32,
+}
+
+impl Default for DecodeConfig {
+    fn default() -> Self {
+        // Matches HardwareProfile's conservative fallback tier.
+        Self {
+            beam_size: 5,
+            max_threads: 4,
+            temperature: 0.0,
+        }
+    }
+}
+
+/// Per-call overrides — mirrors `whisper_engine::TranscribeOptions`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TranscribeOptions {
+    pub max_threads: Option<i32>,
+    pub greedy: bool,
+}
+
+/// Cap `default` at `requested`, if given, flooring at 1. Identical to
+/// `whisper_engine::effective_threads` — kept in sync manually since this
+/// crate doesn't depend on the app crate.
+fn effective_threads(default: i32, requested: Option<i32>) -> i32 {
+    let capped = match requested {
+        Some(requested) => default.min(requested),
+        None => default,
+    };
+    capped.max(1)
+}
+
+#[derive(Debug, Clone)]
+pub struct SegmentOutcome {
+    pub text: String,
+    pub confidence: f32,
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptionOutcome {
+    pub text: String,
+    pub confidence: f32,
+    pub is_partial: bool,
+    pub segments: Vec<SegmentOutcome>,
+}
+
+/// Transcribe one chunk of 16kHz mono f32 PCM against an already-loaded
+/// `WhisperContext`. Synchronous and CPU-bound — callers on an async runtime
+/// should run this via `spawn_blocking`, exactly as
+/// `WhisperEngine::transcribe_audio_with_confidence_opts` does.
+///
+/// Confidence formula matches the in-process engine: mean token probability
+/// per segment (specials excluded), discounted by the segment's no-speech
+/// probability, weighted by token count when averaging across segments.
+pub fn transcribe_pcm16k(
+    ctx: &WhisperContext,
+    audio_data: Vec<f32>,
+    language: Option<&str>,
+    context_prompt: Option<&str>,
+    decode_config: DecodeConfig,
+    options: TranscribeOptions,
+) -> Result<TranscriptionOutcome> {
+    let duration_seconds = audio_data.len() as f64 / 16000.0;
+    let is_partial = duration_seconds < 15.0;
+
+    let mut params = if options.greedy {
+        FullParams::new(SamplingStrategy::Greedy { best_of: 1 })
+    } else {
+        FullParams::new(SamplingStrategy::BeamSearch {
+            beam_size: decode_config.beam_size as i32,
+            patience: 1.0,
+        })
+    };
+
+    params.set_n_threads(effective_threads(
+        decode_config.max_threads,
+        options.max_threads,
+    ));
+
+    let (language_code, should_translate) = match language {
+        Some("auto") | None => (None, false),
+        Some("auto-translate") => (None, true),
+        Some(lang) => (Some(lang), false),
+    };
+    params.set_language(language_code);
+    params.set_translate(should_translate);
+
+    params.set_no_timestamps(false); // sidecar reports per-segment timestamps
+    params.set_token_timestamps(true);
+
+    params.set_print_special(false);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+
+    params.set_suppress_blank(true);
+    params.set_suppress_nst(true);
+    params.set_temperature(decode_config.temperature);
+    params.set_max_initial_ts(1.0);
+    params.set_entropy_thold(2.4);
+    params.set_logprob_thold(-1.0);
+    params.set_no_speech_thold(0.55);
+    params.set_max_len(200);
+    params.set_single_segment(false);
+
+    let sanitized_prompt = context_prompt
+        .map(|p| p.replace('\0', " "))
+        .filter(|p| !p.trim().is_empty());
+    if let Some(ref prompt) = sanitized_prompt {
+        params.set_initial_prompt(prompt);
+    }
+
+    let audio_data = pad_to_min_whisper_input(audio_data);
+
+    let mut state = ctx
+        .create_state()
+        .map_err(|e| anyhow!("failed to create whisper state: {e}"))?;
+    state
+        .full(params, &audio_data)
+        .map_err(|e| anyhow!("whisper full() failed: {e}"))?;
+    let num_segments = state.full_n_segments();
+
+    let mut segments = Vec::with_capacity(num_segments.max(0) as usize);
+    let mut result = String::new();
+    let mut weighted_confidence = 0.0f32;
+    let mut total_tokens = 0u32;
+
+    for i in 0..num_segments {
+        let Some(segment) = state.get_segment(i) else {
+            continue;
+        };
+        let segment_text = match segment.to_str_lossy() {
+            Ok(text) => text.into_owned(),
+            Err(_) => continue,
+        };
+
+        let mut prob_sum = 0.0f32;
+        let mut token_count = 0u32;
+        for t in 0..segment.n_tokens() {
+            let Some(token) = segment.get_token(t) else {
+                continue;
+            };
+            let is_special = token
+                .to_str()
+                .map(|s| s.starts_with("<|") || s.starts_with("[_"))
+                .unwrap_or(true);
+            if is_special {
+                continue;
+            }
+            prob_sum += token.token_probability();
+            token_count += 1;
+        }
+
+        let no_speech = segment.no_speech_probability().clamp(0.0, 1.0);
+        let segment_confidence = if token_count > 0 {
+            let avg_p = prob_sum / token_count as f32;
+            let c = avg_p * (1.0 - no_speech);
+            weighted_confidence += c * token_count as f32;
+            total_tokens += token_count;
+            c
+        } else {
+            0.0
+        };
+
+        let cleaned_text = segment_text.trim();
+        if !cleaned_text.is_empty() {
+            if !result.is_empty() {
+                result.push(' ');
+            }
+            result.push_str(cleaned_text);
+        }
+
+        segments.push(SegmentOutcome {
+            text: cleaned_text.to_string(),
+            confidence: segment_confidence.clamp(0.0, 1.0),
+            start_ms: segment.start_timestamp() * 10,
+            end_ms: segment.end_timestamp() * 10,
+        });
+    }
+
+    let avg_confidence = if total_tokens > 0 {
+        (weighted_confidence / total_tokens as f32).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+
+    Ok(TranscriptionOutcome {
+        text: result.trim().to_string(),
+        confidence: avg_confidence,
+        is_partial,
+        segments,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pads_short_input_to_floor() {
+        let out = pad_to_min_whisper_input(vec![0.5; 4_000]);
+        assert_eq!(out.len(), WHISPER_MIN_INPUT_SAMPLES);
+        assert_eq!(out[3_999], 0.5);
+        assert_eq!(out[4_000], 0.0);
+    }
+
+    #[test]
+    fn leaves_long_input_untouched() {
+        let input = vec![0.1; 32_000];
+        let out = pad_to_min_whisper_input(input.clone());
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn effective_threads_caps_and_floors() {
+        assert_eq!(effective_threads(8, Some(2)), 2);
+        assert_eq!(effective_threads(8, None), 8);
+        assert_eq!(effective_threads(8, Some(0)), 1);
+        assert_eq!(effective_threads(1, Some(99)), 1);
+    }
+}

--- a/whisper-helper/Cargo.toml
+++ b/whisper-helper/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "whisper-helper"
+version = "0.1.0"
+edition.workspace = true
+description = "Stdio JSON-lines whisper.cpp transcription sidecar (issue #56 spike). One binary per compiled backend — see README.md for the build matrix."
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+whisper-protocol = { path = "../whisper-protocol" }
+whisper-core = { path = "../whisper-core" }
+whisper-rs = { version = "0.16.0", features = ["raw-api", "log_backend"] }
+base64 = "0.22"
+# Restore default SIGPIPE disposition at startup — see llama-helper's
+# main.rs for why (a vanished parent must not turn a stdout write into an
+# EPIPE panic).
+libc = "0.2"
+
+[features]
+default = []
+cpu = []
+cuda = ["whisper-rs/cuda", "whisper-core/cuda"]
+vulkan = ["whisper-rs/vulkan", "whisper-core/vulkan"]
+
+# Release profile lives at the workspace root (see top-level Cargo.toml) —
+# sized like llama-helper/meetily-mcp since this is also a short-lived,
+# lazily-spawned sidecar where startup time and disk footprint matter more
+# than raw decode throughput (whisper.cpp itself is unaffected by this
+# crate's own codegen settings).

--- a/whisper-helper/README.md
+++ b/whisper-helper/README.md
@@ -1,0 +1,76 @@
+# whisper-helper
+
+Stdio JSON-lines whisper.cpp transcription sidecar — prototype for
+[issue #56](../docs/transcription-backends.md) (runtime backend selection).
+Modelled directly on `../llama-helper` (see that crate + `llama-protocol`
+for the pattern this follows).
+
+**Status**: standalone spike crate. Not yet staged into
+`frontend/src-tauri/binaries/` by `build.sh`/`dev.sh`, and not spawned by the
+running app. See `docs/transcription-backends.md` for the design and
+implementation plan to get from here to a shipped sidecar.
+
+## Build matrix
+
+Same shape as `llama-helper`: one binary per backend, selected via Cargo
+features, built exactly the way `build.sh` builds `llama-helper` today.
+
+```bash
+# CPU (default features, no GPU feature flag)
+cargo build --release -p whisper-helper
+
+# NVIDIA CUDA
+cargo build --release -p whisper-helper --features cuda
+
+# AMD/Intel Vulkan
+cargo build --release -p whisper-helper --features vulkan
+```
+
+Each feature forwards to the matching `whisper-rs` (and `whisper-core`)
+feature, so the same `whisper-rs-sys` build.rs / cmake logic that builds the
+main app's whisper.cpp runs here — no separate GPU toolchain setup beyond
+what `docs/building_in_linux.md` already documents for CUDA/Vulkan builds of
+the main app.
+
+Staging into `frontend/src-tauri/binaries/whisper-helper-<target-triple>`
+(Tauri's `externalBin` convention, same as `llama-helper-<target-triple>`)
+is a follow-up for `build.sh`/`dev.sh` once the sidecar is wired into the
+live path — see the design doc's implementation plan.
+
+## Protocol
+
+Newline-delimited JSON over stdin/stdout, shared with the app via the
+`whisper-protocol` crate (`Request`/`Response`) so the two ends can't drift
+apart silently:
+
+| Request | Response | Purpose |
+|---|---|---|
+| `load_model { path }` | `loaded { error, load_ms }` | Load/switch the GGML/GGUF model |
+| `transcribe { samples_b64, language, context_prompt, max_threads, greedy }` | `transcribed { text, confidence, is_partial, segments, error, decode_ms }` | Transcribe one 16kHz mono f32 PCM chunk (base64 little-endian samples) |
+| `unload` | `unloaded` | Free the loaded model/context without exiting |
+| `ping` | `pong` | Liveness check |
+| `probe { model_path }` | `probe_result { backend, decode_ok, detail }` | Self-report compiled backend; with a model, run a 1s synthetic decode to confirm the backend actually initializes on this machine |
+| `shutdown` | `goodbye` | Clean exit |
+
+## What's shared with the in-process engine
+
+`whisper-core` (sibling crate) holds the `FullParams` construction and
+decoder-confidence formula, ported from
+`frontend/src-tauri/src/whisper_engine/whisper_engine.rs`'s
+`transcribe_audio_with_confidence_opts`. The in-process engine itself is
+**unchanged** by this spike — see `whisper-core`'s doc comment for the
+follow-up that would switch it to call the shared crate too and delete the
+duplication.
+
+## Measurements (this spike, CPU build, `ggml-tiny.bin`, this container)
+
+See `docs/transcription-backends.md` for the full write-up. Headline
+numbers:
+
+- Spawn → `ping`: ~2ms median
+- `load_model` (tiny, 75MB): ~93ms
+- 5s-silence `transcribe` round trip: ~630ms (of which ~624ms is whisper's
+  own `full()` decode — JSON+base64 IPC overhead is ~4ms, <1% of the total)
+- Release (`opt-level = "s"`) CPU binary size: **2.3MB** (dynamically linked
+  against libstdc++/libgcc_s/libm/libc only; whisper.cpp/ggml are statically
+  linked in)

--- a/whisper-helper/src/main.rs
+++ b/whisper-helper/src/main.rs
@@ -1,0 +1,281 @@
+//! `whisper-helper`: a stdio JSON-lines whisper.cpp transcription sidecar.
+//!
+//! Prototype for issue #56 (runtime backend selection). Modelled directly on
+//! `llama-helper/src/main.rs`'s request loop and lifecycle: read one
+//! [`whisper_protocol::Request`] per line from stdin, reply with exactly one
+//! terminal [`whisper_protocol::Response`] line on stdout, serve until stdin
+//! closes or `Shutdown` arrives. Params-building and confidence scoring are
+//! shared with the in-process engine via the `whisper-core` crate rather
+//! than duplicated here — see that crate's doc comment.
+//!
+//! Not wired into the live recording path yet (see
+//! `docs/transcription-backends.md`); this binary is a standalone
+//! measurement + design vehicle.
+
+use std::io::{self, BufRead, Write};
+use std::time::Instant;
+
+use anyhow::{anyhow, Result};
+use base64::Engine;
+use whisper_core::{DecodeConfig, TranscribeOptions};
+use whisper_protocol::{Request, Response, Segment};
+use whisper_rs::{WhisperContext, WhisperContextParameters};
+
+/// Which backend this binary was compiled for — self-reported in `Probe`
+/// responses and used by `backend_probe` (the future selection logic) to
+/// label results without having to parse the binary's filename.
+fn compiled_backend() -> &'static str {
+    if cfg!(feature = "cuda") {
+        "cuda"
+    } else if cfg!(feature = "vulkan") {
+        "vulkan"
+    } else {
+        "cpu"
+    }
+}
+
+struct State {
+    ctx: Option<WhisperContext>,
+    decode_config: DecodeConfig,
+}
+
+impl State {
+    fn new() -> Self {
+        Self {
+            ctx: None,
+            decode_config: DecodeConfig::default(),
+        }
+    }
+
+    fn load_model(&mut self, path: &str) -> Result<()> {
+        let context_param = WhisperContextParameters {
+            use_gpu: cfg!(any(feature = "cuda", feature = "vulkan")),
+            gpu_device: 0,
+            ..Default::default()
+        };
+        let ctx = WhisperContext::new_with_params(path, context_param)
+            .map_err(|e| anyhow!("failed to load model {path}: {e}"))?;
+        self.ctx = Some(ctx);
+        Ok(())
+    }
+
+    fn transcribe(
+        &self,
+        samples: Vec<f32>,
+        language: Option<&str>,
+        context_prompt: Option<&str>,
+        max_threads: Option<i32>,
+        greedy: bool,
+    ) -> Result<whisper_core::TranscriptionOutcome> {
+        let ctx = self
+            .ctx
+            .as_ref()
+            .ok_or_else(|| anyhow!("no model loaded"))?;
+        whisper_core::transcribe_pcm16k(
+            ctx,
+            samples,
+            language,
+            context_prompt,
+            self.decode_config,
+            TranscribeOptions {
+                max_threads,
+                greedy,
+            },
+        )
+    }
+}
+
+fn send_response(response: &Response) -> Result<()> {
+    let json = serde_json::to_string(response)?;
+    println!("{json}");
+    io::stdout().flush()?;
+    Ok(())
+}
+
+/// A short burst of near-silent samples (1s @ 16kHz) used by `Probe` when no
+/// real model/audio is available — enough to exercise `full()` end-to-end
+/// (model load + a decode pass) without needing a recorded clip on disk.
+fn synthetic_probe_samples() -> Vec<f32> {
+    vec![0.0f32; whisper_core::WHISPER_MIN_INPUT_SAMPLES]
+}
+
+fn handle_request(state: &mut State, request: Request) -> Result<Response> {
+    match request {
+        Request::LoadModel { path } => {
+            let start = Instant::now();
+            match state.load_model(&path) {
+                Ok(()) => Ok(Response::Loaded {
+                    error: None,
+                    load_ms: start.elapsed().as_millis() as u64,
+                }),
+                Err(e) => Ok(Response::Loaded {
+                    error: Some(e.to_string()),
+                    load_ms: start.elapsed().as_millis() as u64,
+                }),
+            }
+        }
+        Request::Transcribe {
+            samples_b64,
+            language,
+            context_prompt,
+            max_threads,
+            greedy,
+        } => {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(samples_b64)
+                .map_err(|e| anyhow!("invalid base64 samples: {e}"))?;
+            if bytes.len() % 4 != 0 {
+                return Ok(Response::Transcribed {
+                    text: String::new(),
+                    confidence: 0.0,
+                    is_partial: false,
+                    segments: vec![],
+                    error: Some("sample buffer length is not a multiple of 4 bytes (f32le)".into()),
+                    decode_ms: 0,
+                });
+            }
+            let samples: Vec<f32> = bytes
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+
+            let start = Instant::now();
+            match state.transcribe(
+                samples,
+                language.as_deref(),
+                context_prompt.as_deref(),
+                max_threads,
+                greedy.unwrap_or(false),
+            ) {
+                Ok(outcome) => Ok(Response::Transcribed {
+                    text: outcome.text,
+                    confidence: outcome.confidence,
+                    is_partial: outcome.is_partial,
+                    segments: outcome
+                        .segments
+                        .into_iter()
+                        .map(|s| Segment {
+                            text: s.text,
+                            confidence: s.confidence,
+                            start_ms: s.start_ms,
+                            end_ms: s.end_ms,
+                        })
+                        .collect(),
+                    error: None,
+                    decode_ms: start.elapsed().as_millis() as u64,
+                }),
+                Err(e) => Ok(Response::Transcribed {
+                    text: String::new(),
+                    confidence: 0.0,
+                    is_partial: false,
+                    segments: vec![],
+                    error: Some(e.to_string()),
+                    decode_ms: start.elapsed().as_millis() as u64,
+                }),
+            }
+        }
+        Request::Unload => {
+            state.ctx = None;
+            Ok(Response::Unloaded)
+        }
+        Request::Ping => Ok(Response::Pong),
+        Request::Probe { model_path } => {
+            let backend = compiled_backend().to_string();
+            match model_path {
+                None => Ok(Response::ProbeResult {
+                    backend,
+                    decode_ok: None,
+                    detail: "no model available; probe verified process spawn + ping only".into(),
+                }),
+                Some(path) => {
+                    let mut probe_state = State::new();
+                    let load_result = probe_state.load_model(&path);
+                    if let Err(e) = load_result {
+                        return Ok(Response::ProbeResult {
+                            backend,
+                            decode_ok: Some(false),
+                            detail: format!("model load failed: {e}"),
+                        });
+                    }
+                    match probe_state.transcribe(synthetic_probe_samples(), None, None, None, true)
+                    {
+                        Ok(_) => Ok(Response::ProbeResult {
+                            backend,
+                            decode_ok: Some(true),
+                            detail: "1s synthetic decode succeeded".into(),
+                        }),
+                        Err(e) => Ok(Response::ProbeResult {
+                            backend,
+                            decode_ok: Some(false),
+                            detail: format!("synthetic decode failed: {e}"),
+                        }),
+                    }
+                }
+            }
+        }
+        Request::Shutdown => Ok(Response::Goodbye),
+    }
+}
+
+fn main() -> Result<()> {
+    // See llama-helper's main.rs: writing to a stdout whose reader has gone
+    // away must not panic on EPIPE.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
+    eprintln!(
+        "whisper-helper ({}) starting",
+        compiled_backend()
+    );
+
+    let mut state = State::new();
+    let stdin = io::stdin();
+    let mut stdin_lock = stdin.lock();
+    let mut buffer = String::new();
+
+    loop {
+        buffer.clear();
+        match stdin_lock.read_line(&mut buffer) {
+            Ok(0) => {
+                eprintln!("EOF received, shutting down");
+                break;
+            }
+            Ok(_) => {
+                let line = buffer.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let is_shutdown;
+                match serde_json::from_str::<Request>(line) {
+                    Ok(request) => {
+                        is_shutdown = matches!(request, Request::Shutdown);
+                        match handle_request(&mut state, request) {
+                            Ok(response) => send_response(&response)?,
+                            Err(e) => send_response(&Response::Error {
+                                message: e.to_string(),
+                            })?,
+                        }
+                    }
+                    Err(e) => {
+                        is_shutdown = false;
+                        eprintln!("failed to parse request: {e}");
+                        send_response(&Response::Error {
+                            message: format!("invalid request: {e}"),
+                        })?;
+                    }
+                }
+                if is_shutdown {
+                    break;
+                }
+            }
+            Err(e) => {
+                eprintln!("error reading stdin: {e}");
+                break;
+            }
+        }
+    }
+
+    eprintln!("whisper-helper exiting");
+    Ok(())
+}

--- a/whisper-protocol/Cargo.toml
+++ b/whisper-protocol/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "whisper-protocol"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/whisper-protocol/src/lib.rs
+++ b/whisper-protocol/src/lib.rs
@@ -1,0 +1,158 @@
+//! Wire protocol between the Tauri app and a `whisper-helper` sidecar.
+//!
+//! Modelled on `llama-protocol`: newline-delimited JSON over the child
+//! process's stdin/stdout. The app writes one [`Request`] per line, the
+//! helper answers with exactly one terminal line per request
+//! ([`Response::Loaded`], [`Response::Transcribed`], [`Response::Pong`],
+//! [`Response::ProbeResult`], [`Response::Goodbye`], or [`Response::Error`]).
+//!
+//! Both sides depend on this crate so the two ends of the pipe can't drift
+//! apart silently — serde ignores unknown fields on deserialize, so a field
+//! added to only one side is dropped rather than erroring.
+
+use serde::{Deserialize, Serialize};
+
+/// App → helper.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Request {
+    /// Load (or switch to) a GGML/GGUF whisper model. Mirrors
+    /// `WhisperEngine::load_model` in the in-process engine.
+    LoadModel { path: String },
+    /// Transcribe one chunk of 16 kHz mono f32 PCM audio.
+    ///
+    /// `samples_b64` is little-endian f32 samples, base64-encoded (the
+    /// baseline IPC transport measured by this spike; see
+    /// `docs/transcription-backends.md` for the shared-memory/tmpfile
+    /// alternative considered for larger chunks).
+    Transcribe {
+        samples_b64: String,
+        language: Option<String>,
+        context_prompt: Option<String>,
+        /// Per-call overrides — mirrors
+        /// `whisper_engine::TranscribeOptions`.
+        max_threads: Option<i32>,
+        greedy: Option<bool>,
+    },
+    /// Release the loaded model and its context (frees VRAM/RAM without
+    /// exiting the process).
+    Unload,
+    /// Liveness check; also used by `backend_probe` as the cheapest possible
+    /// "is this sidecar binary runnable at all" test.
+    Ping,
+    /// Run a short synthetic decode (silence, ~1s) to confirm the compiled
+    /// backend (cuda/vulkan/cpu) actually initializes on this machine — a
+    /// `cuda` build can load and `Ping` fine on a machine with no NVIDIA
+    /// driver, but will fail here. `model_path` is optional: with no model
+    /// on disk the probe falls back to backend self-report only (see
+    /// `Response::ProbeResult::decode_ok`).
+    Probe { model_path: Option<String> },
+    Shutdown,
+}
+
+/// Helper → app.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Response {
+    Loaded {
+        error: Option<String>,
+        load_ms: u64,
+    },
+    /// One transcribed chunk. Segment-level detail is intentionally kept
+    /// (rather than one flat string) so a future UI can render per-segment
+    /// confidence the way the in-process engine's timestamp-aware paths do.
+    Transcribed {
+        text: String,
+        confidence: f32,
+        is_partial: bool,
+        segments: Vec<Segment>,
+        error: Option<String>,
+        /// Wall-clock time spent inside whisper's `full()` call, for
+        /// per-segment round-trip overhead measurements.
+        decode_ms: u64,
+    },
+    Unloaded,
+    Pong,
+    ProbeResult {
+        backend: String,
+        /// `None` when no model was available to attempt a decode with —
+        /// the probe only confirmed the process starts and responds.
+        decode_ok: Option<bool>,
+        detail: String,
+    },
+    Goodbye,
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Segment {
+    pub text: String,
+    pub confidence: f32,
+    pub start_ms: i64,
+    pub end_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcribe_request_round_trips() {
+        let req = Request::Transcribe {
+            samples_b64: "AAAA".to_string(),
+            language: Some("en".to_string()),
+            context_prompt: None,
+            max_threads: Some(4),
+            greedy: Some(false),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"type\":\"transcribe\""));
+        let back: Request = serde_json::from_str(&json).unwrap();
+        match back {
+            Request::Transcribe { language, max_threads, .. } => {
+                assert_eq!(language.as_deref(), Some("en"));
+                assert_eq!(max_threads, Some(4));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn probe_result_round_trips_with_no_model() {
+        let resp = Response::ProbeResult {
+            backend: "cuda".to_string(),
+            decode_ok: None,
+            detail: "no model available, ping only".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        match serde_json::from_str::<Response>(&json).unwrap() {
+            Response::ProbeResult { backend, decode_ok, .. } => {
+                assert_eq!(backend, "cuda");
+                assert_eq!(decode_ok, None);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn error_response_round_trips() {
+        let json = r#"{"type":"error","message":"boom"}"#;
+        match serde_json::from_str::<Response>(json).unwrap() {
+            Response::Error { message } => assert_eq!(message, "boom"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn unknown_field_is_ignored_not_an_error() {
+        // Forward-compat: a field only one side knows about must not break
+        // deserialization on the other side.
+        let json = r#"{"type":"ping","future_field":123}"#;
+        assert!(matches!(
+            serde_json::from_str::<Request>(json).unwrap(),
+            Request::Ping
+        ));
+    }
+}


### PR DESCRIPTION
## Description
Three commits:

**#56 milestone 1 (spike output, inert)**
- `whisper-protocol/`, `whisper-core/`, `whisper-helper/` (cpu built and tested; cuda/vulkan features wired like `llama-helper`), `backend_probe.rs` behind the off-by-default `backend_probe` feature, and `docs/transcription-backends.md` with measurements and the recommended sidecar-per-backend architecture.

**#57 slice 1 (canonical recording state)**
- `audio/recording_phase.rs`: `RecordingPhase` state machine + `RecordingSnapshot`, one `recording-state` event at every transition; `get_recording_state` returns the snapshot plus legacy keys; tray gated on phase.
- Frontend `RecordingStateContext` is event-driven (resync on mount/focus/visibility, client-side duration ticking); the 500 ms poll is gone.

**#57 slice 2 (Rust-owned meeting lifecycle)**
- The meetings row is created at recording start (`status = recording`) and `meeting_id` flows through the saver, snapshot and `recording-started` / `recording-stopped` events.
- Transcript segments are upserted into SQLite as they arrive by a batched writer (20 segments or 1 s), flushed at stop; the ndjson journal stays.
- The row is finalised at stop (`completed` with duration/audio path, or `interrupted` on a fatal stop); rows still `recording` at startup are marked `interrupted`.
- Frontend post-stop save is now a title update by `meeting_id` (fallback to the old bulk path if the id is missing); recovery uses new `list_interrupted_meetings` / `recover_meeting` commands, and IndexedDB is only a write-ahead cache.
- Migrations: `20260910010000_add_meeting_status.sql`, `20260910020000_add_transcripts_meeting_sequence_unique.sql`. CLAUDE.md updated.

## Related Issue
Part of #56 (milestone 1). Fixes #57.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe)

## Testing
- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] All tests pass

`cargo check` clean; `cargo test --lib` 284 passed, 0 failed, 3 ignored (new lifecycle, writer, phase-transition and sidecar tests); `tsc --noEmit` clean; eslint unchanged from `main` (22 warnings, 0 errors). Not exercised against a live PipeWire recording; the new stop/recovery flow deserves one manual run (record, stop, check the meeting row; kill the app mid-recording, relaunch, check the recovery dialog).

## Documentation
- [x] Documentation updated
- [ ] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A

## Additional Notes
Two schema migrations run on first launch after this merge. Decision still open on #56 milestone 5 (on-demand GPU sidecar download vs per-backend AppImages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018unWTJUCyXCL4TnxUFqQwR