### PR TITLE
GPUI parity: close remaining gaps; fix transcript-wiping VAD bug and toast crash

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -46,9 +46,12 @@ setup_common_env() {
     #   - app_lib at info  → our own logs visible
     #   - whisper_rs at warn → drop the per-decoder beam-search trace noise
     #                          (whisper.cpp emits these at INFO, very chatty)
+    #   - zbus / tracing / wgpu / naga at warn → D-Bus (tray, portals) and
+    #                          GPU-backend chatter the GPUI shell would
+    #                          otherwise log at INFO on every tray poll
     #   - everything else at info
     # Override by exporting RUST_LOG before invoking dev.sh.
-    export RUST_LOG="${RUST_LOG:-info,whisper_rs=warn}"
+    export RUST_LOG="${RUST_LOG:-info,whisper_rs=warn,zbus=warn,tracing=warn,wgpu_hal=warn,wgpu_core=warn,naga=warn}"
 
     if command -v sccache >/dev/null 2>&1; then
         export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
@@ -158,18 +161,21 @@ run_gpui_dev() {
 
     setup_dev_cuda_env "$mode"
 
-    # llama-helper sidecar: meetily-core falls back to
-    # target/{release,debug}/llama-helper in dev builds (via
-    # CARGO_MANIFEST_DIR), so build it once up front with the matching GPU
-    # feature if it's missing or stale isn't worth detecting here — just
-    # make sure a debug build exists.
+    # llama-helper sidecar, built in *release* even for dev: a debug
+    # llama.cpp is far too slow for real summaries, and this reuses the same
+    # cached build `./build.sh` produces. Its CUDA objects must be
+    # position-independent or rust-lld refuses to link them (same export as
+    # build.sh). Note llama-cpp-sys doesn't rebuild when this env var
+    # changes, so a stale non-PIC build needs `cargo clean -p llama-cpp-sys-2`.
+    export CMAKE_POSITION_INDEPENDENT_CODE="${CMAKE_POSITION_INDEPENDENT_CODE:-ON}"
     local helper_features=()
     case "$mode" in
         cuda)   helper_features=(--features cuda) ;;
         vulkan) helper_features=(--features vulkan) ;;
     esac
-    echo "==> Building llama-helper sidecar (${mode}, debug)"
-    ( cd "$ROOT/llama-helper" && cargo build "${helper_features[@]}" )
+    echo "==> Building llama-helper sidecar (${mode}, release)"
+    ( cd "$ROOT/llama-helper" && cargo build --release "${helper_features[@]}" )
+    export MEETILY_LLAMA_HELPER="${MEETILY_LLAMA_HELPER:-$ROOT/target/release/llama-helper}"
 
     local gpui_features=()
     case "$mode" in

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -597,6 +597,7 @@ pub async fn api_get_meeting_transcripts<R: Runtime>(
                     speaker: t.speaker,
                     voice_profile_id: t.voice_profile_id,
                     source: t.source,
+                    confidence: t.confidence,
                 })
                 .collect::<Vec<_>>();
 

--- a/meetily-core/migrations/20260911000000_add_confidence_to_transcripts.sql
+++ b/meetily-core/migrations/20260911000000_add_confidence_to_transcripts.sql
@@ -1,0 +1,6 @@
+-- Persist the live-recording Whisper confidence score alongside each
+-- transcript segment so it survives a save/reload, not just the in-memory
+-- `transcript-update` event. Nullable: older rows, imports, and
+-- retranscription leave it NULL (matches the frontend's "no dot when
+-- confidence is undefined" behaviour in VirtualizedTranscriptView.tsx).
+ALTER TABLE transcripts ADD COLUMN confidence REAL;

--- a/meetily-core/src/audio/retranscription.rs
+++ b/meetily-core/src/audio/retranscription.rs
@@ -405,6 +405,16 @@ async fn run_retranscription(
     // Create transcript segments with proper timestamps from VAD
     let segments = create_transcript_segments(&all_transcripts);
 
+    // Never replace a meeting's transcript with nothing. If the batch pass
+    // produced no text (VAD found no speech, or Whisper returned only
+    // silence/hallucination-filtered output), the existing transcript — often
+    // the live one, for auto-refine — is strictly better than an empty one.
+    if segments.is_empty() {
+        return Err(anyhow!(
+            "Retranscription produced no transcript text; the existing transcript was kept"
+        ));
+    }
+
     // Save to database
     let pool = pool.ok_or_else(|| anyhow!("App state not available"))?;
 

--- a/meetily-core/src/audio/vad.rs
+++ b/meetily-core/src/audio/vad.rs
@@ -18,8 +18,9 @@
 //! - The "redemption_time_ms" parameter now maps to sherpa's
 //!   `min_silence_duration` (the trailing silence gap that terminates a
 //!   speech segment). Same intent, slightly different name.
-//! - Sherpa accepts arbitrary chunk sizes (no 30 ms windowing here);
-//!   internal windowing is fixed at 512 samples per silero-vad's spec.
+//! - Audio is handed to sherpa one 512-sample silero window per call:
+//!   sherpa updates its speech/silence state once per `accept_waveform`
+//!   call, so larger calls blur or lose segment boundaries (see `feed_16k`).
 
 use anyhow::{anyhow, Result};
 use log::{debug, info, warn};
@@ -68,6 +69,10 @@ pub struct ContinuousVadProcessor {
 const MAX_PARTIAL_SAMPLES: usize = 30 * 16_000;
 
 const VAD_SAMPLE_RATE: i32 = 16_000;
+
+/// silero-vad's window: 512 samples = 32 ms at 16 kHz. Also the most audio
+/// handed to sherpa per `accept_waveform` call (see `feed_16k`).
+const VAD_WINDOW_SIZE: usize = 512;
 
 impl ContinuousVadProcessor {
     /// Create a VAD processor with no specific source tag (defaults to Mic for
@@ -137,7 +142,7 @@ impl ContinuousVadProcessor {
                 threshold: 0.45,
                 min_silence_duration,           // From caller (typically 400ms live, 800ms batch).
                 min_speech_duration: 0.25,      // Reject segments shorter than 250ms.
-                window_size: 512,               // 32 ms at 16 kHz, silero-vad's expected window.
+                window_size: VAD_WINDOW_SIZE as i32, // 32 ms at 16 kHz, silero-vad's expected window.
                 max_speech_duration,
             },
             ten_vad: Default::default(),
@@ -230,7 +235,16 @@ impl ContinuousVadProcessor {
         if samples_16k.is_empty() {
             return;
         }
-        self.detector.accept_waveform(samples_16k);
+        // Feed sherpa one model window at a time. Its `AcceptWaveform` runs
+        // silero on every window in the call but updates the speech/silence
+        // state machine only once per call (OR of all windows) — so a large
+        // call collapses to one decision: a whole-file batch call yields a
+        // single bogus segment, 1 s calls merge utterances across pauses,
+        // 10 s calls drop entire utterances. sherpa keeps any sub-window
+        // remainder internally, so arbitrary slice boundaries are fine.
+        for window in samples_16k.chunks(VAD_WINDOW_SIZE) {
+            self.detector.accept_waveform(window);
+        }
         self.processed_samples_16k += samples_16k.len() as u64;
 
         // Accumulate the in-progress utterance for streaming partial decodes,

--- a/meetily-core/src/database/models.rs
+++ b/meetily-core/src/database/models.rs
@@ -54,6 +54,9 @@ pub struct Transcript {
     /// rows and imports; used to play the matching channel of the stereo
     /// recording (mic = left, system = right).
     pub source: Option<String>,
+    /// Whisper confidence score (0.0-1.0) from the live-recording path. Null
+    /// for older rows, imports, and retranscription.
+    pub confidence: Option<f32>,
 }
 
 /// Stored speaker voice profile used to recognize returning speakers across meetings.
@@ -246,4 +249,10 @@ pub struct MeetingTranscript {
     /// per-segment playback. Null for older rows / imports.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Whisper confidence score (0.0-1.0), when persisted from the
+    /// live-recording path. Null for older rows, imports, and
+    /// retranscription — the frontend's `ConfidenceIndicator` renders
+    /// nothing in that case, and the GPUI mirror does the same.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
 }

--- a/meetily-core/src/database/repositories/meeting.rs
+++ b/meetily-core/src/database/repositories/meeting.rs
@@ -96,6 +96,7 @@ impl MeetingsRepository {
                     speaker: t.speaker,
                     voice_profile_id: t.voice_profile_id,
                     source: t.source,
+                    confidence: t.confidence,
                 })
                 .collect::<Vec<_>>();
 

--- a/meetily-core/src/database/repositories/transcript.rs
+++ b/meetily-core/src/database/repositories/transcript.rs
@@ -53,8 +53,8 @@ impl TranscriptsRepository {
         for segment in transcripts {
             let transcript_id = format!("transcript-{}", Uuid::new_v4());
             let result = sqlx::query(
-                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker, voice_profile_id, sequence_id, source)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker, voice_profile_id, sequence_id, source, confidence)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(&transcript_id)
             .bind(&meeting_id)
@@ -72,6 +72,7 @@ impl TranscriptsRepository {
             .bind(&segment.voice_profile_id)
             .bind(segment.sequence_id.map(|s| s as i64))
             .bind(&segment.source)
+            .bind(segment.confidence)
             .execute(&mut *transaction)
             .await;
 
@@ -131,8 +132,8 @@ impl TranscriptsRepository {
         for (meeting_id, segment) in items {
             let transcript_id = format!("transcript-{}", Uuid::new_v4());
             let result = sqlx::query(
-                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker, voice_profile_id, sequence_id, source)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration, speaker, voice_profile_id, sequence_id, source, confidence)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT(meeting_id, sequence_id) DO UPDATE SET
                      transcript = excluded.transcript,
                      timestamp = excluded.timestamp,
@@ -141,7 +142,8 @@ impl TranscriptsRepository {
                      duration = excluded.duration,
                      speaker = excluded.speaker,
                      voice_profile_id = excluded.voice_profile_id,
-                     source = excluded.source",
+                     source = excluded.source,
+                     confidence = excluded.confidence",
             )
             .bind(&transcript_id)
             .bind(meeting_id)
@@ -159,6 +161,7 @@ impl TranscriptsRepository {
             .bind(&segment.voice_profile_id)
             .bind(segment.sequence_id.map(|s| s as i64))
             .bind(&segment.source)
+            .bind(segment.confidence)
             .execute(&mut *transaction)
             .await;
 

--- a/meetily-core/src/ollama/client.rs
+++ b/meetily-core/src/ollama/client.rs
@@ -43,7 +43,7 @@ impl std::fmt::Display for OllamaError {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OllamaModel {
     pub name: String,
     pub id: String,

--- a/meetily-core/src/summary/summary_engine/sidecar.rs
+++ b/meetily-core/src/summary/summary_engine/sidecar.rs
@@ -240,23 +240,18 @@ impl SidecarManager {
             log::warn!("RESOURCE_DIR environment variable not set");
         }
 
-        // 3. Fallback for dev: try relative paths from workspace (no target triple in dev builds)
+        // 3. Fallback for dev: the workspace target dir (no target triple in
+        //    dev builds). Walk up from the running crate's manifest dir, since
+        //    the app crate may sit one level below the workspace root
+        //    (meetily-gpui/) or two (frontend/src-tauri/).
         if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
-            let project_root = PathBuf::from(&manifest_dir)
-                .parent()
-                .and_then(|p| p.parent())
-                .ok_or_else(|| anyhow!("Failed to determine project root"))?
-                .to_path_buf();
-
-            let candidates = vec![
-                project_root.join("target/release/llama-helper"),
-                project_root.join("target/debug/llama-helper"),
-            ];
-
-            for candidate in candidates {
-                if candidate.exists() {
-                    log::info!("Using dev llama-helper: {}", candidate.display());
-                    return Ok(candidate);
+            for dir in PathBuf::from(&manifest_dir).ancestors() {
+                for profile in ["release", "debug"] {
+                    let candidate = dir.join("target").join(profile).join("llama-helper");
+                    if candidate.exists() {
+                        log::info!("Using dev llama-helper: {}", candidate.display());
+                        return Ok(candidate);
+                    }
                 }
             }
         }

--- a/meetily-gpui/Cargo.toml
+++ b/meetily-gpui/Cargo.toml
@@ -52,3 +52,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "chrono"] }
 chrono = { version = "0.4.31", features = ["serde"] }
 # `_exit` on shutdown, same as the Tauri shell.
 libc = "0.2"
+# GitHub releases update check (same major line as meetily-core's own
+# reqwest dep, so Cargo unifies the two into one build).
+reqwest = { version = "0.11", features = ["json"] }
+semver = "1"

--- a/meetily-gpui/src/app_state.rs
+++ b/meetily-gpui/src/app_state.rs
@@ -6,6 +6,7 @@ use gpui_kit::{App, Entity, Global};
 use meetily_core::audio::recording_service::RecordingContext;
 use meetily_core::database::manager::DatabaseManager;
 use meetily_core::events::SharedEventSink;
+use meetily_core::summary::summary_engine::ModelManagerState;
 
 use crate::core_events::CoreEvents;
 use crate::runtime::Io;
@@ -25,6 +26,10 @@ pub struct AppServices {
     pub core_events: Entity<CoreEvents>,
     /// `None` on a first launch until onboarding creates the database.
     pub db: DbSlot,
+    /// Shared slot for the built-in-AI (summary) model manager — the same
+    /// `ModelManagerState` the Tauri shell manages via `tauri::State`.
+    /// Lazily initialized on first use by `service::ensure_manager`.
+    pub builtin_manager: ModelManagerState,
 }
 
 impl Global for AppServices {}
@@ -49,6 +54,16 @@ impl AppServices {
     /// restart. Called once, at the end of onboarding's setup step.
     pub fn set_db(&self, db: DatabaseManager) {
         *self.db.write().unwrap() = Some(db);
+    }
+
+    /// Clone of the shared slot backing the built-in-AI model manager, for
+    /// passing into `summary_engine::service` calls off the main thread.
+    pub fn builtin_manager_slot(
+        &self,
+    ) -> std::sync::Arc<
+        tokio::sync::Mutex<Option<std::sync::Arc<meetily_core::summary::summary_engine::model_manager::ModelManager>>>,
+    > {
+        self.builtin_manager.0.clone()
     }
 
     /// Context for `meetily_core::audio::recording_service` calls.

--- a/meetily-gpui/src/main.rs
+++ b/meetily-gpui/src/main.rs
@@ -117,6 +117,7 @@ fn main() {
                         e
                     );
                 }
+                notifications::start_meeting_reminder_loop(cx);
             });
         })
         .detach();

--- a/meetily-gpui/src/main.rs
+++ b/meetily-gpui/src/main.rs
@@ -10,6 +10,7 @@ mod root;
 mod runtime;
 mod shell;
 mod tray;
+mod ui;
 mod views;
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/meetily-gpui/src/main.rs
+++ b/meetily-gpui/src/main.rs
@@ -60,9 +60,14 @@ fn main() {
         bootstrap::spawn_background_init(
             sink.clone(),
             db.as_ref().map(|db| db.pool().clone()),
-            model_manager,
+            model_manager.clone(),
         );
     }
+    // Same slot `spawn_background_init` pre-warms above — the Settings
+    // page's built-in-AI model manager (`views/settings/summary.rs`) reads
+    // and writes through this, exactly like the Tauri shell's
+    // `tauri::State<ModelManagerState>`.
+    let builtin_manager = meetily_core::summary::summary_engine::ModelManagerState(model_manager);
     // `AppServices::set_db` fills this in later, without a restart, once
     // first-launch onboarding creates the database (see `root.rs` /
     // `views/onboarding`). Wrapped in a lock (rather than moved into
@@ -87,6 +92,7 @@ fn main() {
             sink: sink.clone(),
             core_events,
             db,
+            builtin_manager,
         });
 
         let mut window_options = TitleBar::window_options();

--- a/meetily-gpui/src/notifications.rs
+++ b/meetily-gpui/src/notifications.rs
@@ -1,4 +1,5 @@
-//! Desktop notifications for recording start/stop, gated by the same
+//! Desktop notifications for the recording lifecycle, transcription
+//! completion, system errors and meeting reminders, gated by the same
 //! notification settings the Tauri app stores (`notification_settings` in
 //! SQLite, via `SettingsRepository`/`KEY_NOTIFICATION_SETTINGS` —
 //! Tauri-free, already in `meetily-core`).
@@ -11,20 +12,35 @@
 //! same row without moving that module into core. If no row exists yet
 //! (nobody has ever opened the Tauri app's notification settings), this
 //! defaults to on, per the phase 1 tray spec.
+//!
+//! Also owns the meeting-reminder background loop and the GitHub-releases
+//! update check — both dead code paths in the Tauri app (see module docs
+//! on [`start_meeting_reminder_loop`] and [`check_for_updates`]).
 
+use std::collections::HashSet;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
 use gpui_kit::App;
 use serde::Deserialize;
 
+use meetily_core::calendar::repository::CalendarRepository;
 use meetily_core::database::repositories::setting::{
     SettingsRepository, KEY_NOTIFICATION_SETTINGS,
 };
 
 use crate::app_state::AppServices;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum Kind {
     Started,
     Stopped,
+    Paused,
+    Resumed,
+    TranscriptionComplete,
+    SystemError(String),
+    MeetingReminder { minutes: u64, title: Option<String> },
+    Test,
 }
 
 #[derive(Debug, Deserialize)]
@@ -45,6 +61,18 @@ struct PreferencesMini {
     show_recording_started: bool,
     #[serde(default)]
     show_recording_stopped: bool,
+    #[serde(default = "default_true")]
+    show_recording_paused: bool,
+    #[serde(default = "default_true")]
+    show_recording_resumed: bool,
+    #[serde(default = "default_true")]
+    show_transcription_complete: bool,
+    #[serde(default = "default_true")]
+    show_meeting_reminders: bool,
+    #[serde(default = "default_true")]
+    show_system_errors: bool,
+    #[serde(default = "default_reminder_minutes")]
+    meeting_reminder_minutes: Vec<u64>,
 }
 
 impl Default for PreferencesMini {
@@ -53,6 +81,12 @@ impl Default for PreferencesMini {
         Self {
             show_recording_started: false,
             show_recording_stopped: false,
+            show_recording_paused: true,
+            show_recording_resumed: true,
+            show_transcription_complete: true,
+            show_meeting_reminders: true,
+            show_system_errors: true,
+            meeting_reminder_minutes: default_reminder_minutes(),
         }
     }
 }
@@ -61,17 +95,78 @@ fn default_true() -> bool {
     true
 }
 
+fn default_reminder_minutes() -> Vec<u64> {
+    vec![15, 5]
+}
+
 impl Default for SettingsMini {
     fn default() -> Self {
         Self {
             consent_given: true,
             system_permission_granted: true,
             manual_dnd_mode: false,
-            notification_preferences: PreferencesMini {
-                show_recording_started: true,
-                show_recording_stopped: true,
-            },
+            notification_preferences: PreferencesMini::default(),
         }
+    }
+}
+
+// ============================================================================
+// Pure gating logic (unit-tested)
+// ============================================================================
+
+/// Whether `kind` should be shown given `settings` — consent, system
+/// permission, manual DND, and the per-event-type toggle, mirroring
+/// `NotificationManager::should_show_notification` (minus the system DND
+/// check, which needs a live D-Bus query and stays in [`maybe_notify`]).
+/// `Kind::Test` always shows, matching the Tauri manager.
+fn should_notify(settings: &SettingsMini, kind: &Kind) -> bool {
+    if matches!(kind, Kind::Test) {
+        return true;
+    }
+    if !settings.consent_given || !settings.system_permission_granted || settings.manual_dnd_mode {
+        return false;
+    }
+    let p = &settings.notification_preferences;
+    match kind {
+        Kind::Started => p.show_recording_started,
+        Kind::Stopped => p.show_recording_stopped,
+        Kind::Paused => p.show_recording_paused,
+        Kind::Resumed => p.show_recording_resumed,
+        Kind::TranscriptionComplete => p.show_transcription_complete,
+        Kind::SystemError(_) => p.show_system_errors,
+        Kind::MeetingReminder { .. } => p.show_meeting_reminders,
+        Kind::Test => true,
+    }
+}
+
+/// Title/body pair for a notification kind, mirroring
+/// `frontend/src-tauri/src/notifications/types.rs`'s `Notification::*`
+/// constructors.
+fn notification_text(kind: &Kind) -> (&'static str, String) {
+    match kind {
+        Kind::Started => (
+            "Parley",
+            "Recording has started. Please inform others in the meeting that you are recording."
+                .to_string(),
+        ),
+        Kind::Stopped => ("Parley", "Recording has been stopped and saved".to_string()),
+        Kind::Paused => ("Parley", "Recording has been paused".to_string()),
+        Kind::Resumed => ("Parley", "Recording has been resumed".to_string()),
+        Kind::TranscriptionComplete => {
+            ("Parley", "Transcription has been completed".to_string())
+        }
+        Kind::SystemError(message) => ("Parley Error", message.clone()),
+        Kind::MeetingReminder { minutes, title } => (
+            "Parley",
+            match title {
+                Some(t) => format!("Meeting '{}' starts in {} minutes", t, minutes),
+                None => format!("Meeting starts in {} minutes", minutes),
+            },
+        ),
+        Kind::Test => (
+            "Parley",
+            "This is a test notification to verify the system is working correctly".to_string(),
+        ),
     }
 }
 
@@ -84,61 +179,388 @@ pub fn maybe_notify(cx: &mut App, kind: Kind) {
     let pool = services.pool();
 
     io.spawn(async move {
-        let settings = match pool {
-            Some(pool) => {
-                match SettingsRepository::get_setting::<SettingsMini>(
-                    &pool,
-                    KEY_NOTIFICATION_SETTINGS,
-                )
-                .await
-                {
-                    Ok(Some(settings)) => settings,
-                    Ok(None) => {
-                        log::debug!("no stored notification settings; defaulting to on");
-                        SettingsMini::default()
-                    }
-                    Err(e) => {
-                        log::warn!("failed to read notification settings, defaulting to on: {}", e);
-                        SettingsMini::default()
-                    }
-                }
-            }
-            None => SettingsMini::default(),
-        };
-
-        if !settings.consent_given || !settings.system_permission_granted || settings.manual_dnd_mode {
+        let settings = load_settings(pool).await;
+        if !should_notify(&settings, &kind) {
             return;
         }
-
-        let (enabled, title, body) = match kind {
-            Kind::Started => (
-                settings.notification_preferences.show_recording_started,
-                "Parley",
-                "Recording started",
-            ),
-            Kind::Stopped => (
-                settings.notification_preferences.show_recording_stopped,
-                "Parley",
-                "Recording stopped",
-            ),
-        };
-        if !enabled {
-            return;
-        }
-
+        let (title, body) = notification_text(&kind);
         show(title, body).await;
     });
 }
 
+/// "Send test notification" button target (Notifications settings page).
+/// Bypasses every gate except showing the notification itself — matches
+/// `NotificationManager::show_test_notification`.
+pub fn send_test_notification(cx: &mut App) {
+    maybe_notify(cx, Kind::Test);
+}
+
+async fn load_settings(pool: Option<sqlx::SqlitePool>) -> SettingsMini {
+    match pool {
+        Some(pool) => {
+            match SettingsRepository::get_setting::<SettingsMini>(&pool, KEY_NOTIFICATION_SETTINGS)
+                .await
+            {
+                Ok(Some(settings)) => settings,
+                Ok(None) => {
+                    log::debug!("no stored notification settings; defaulting to on");
+                    SettingsMini::default()
+                }
+                Err(e) => {
+                    log::warn!("failed to read notification settings, defaulting to on: {}", e);
+                    SettingsMini::default()
+                }
+            }
+        }
+        None => SettingsMini::default(),
+    }
+}
+
 /// Show a system notification via D-Bus, off the calling task (notify-rust
 /// makes a blocking D-Bus call).
-async fn show(title: &'static str, body: &'static str) {
-    let result =
-        tokio::task::spawn_blocking(move || notify_rust::Notification::new().summary(title).body(body).show())
-            .await;
+async fn show(title: &'static str, body: String) {
+    let result = tokio::task::spawn_blocking(move || {
+        notify_rust::Notification::new().summary(title).body(&body).show()
+    })
+    .await;
     match result {
         Ok(Ok(_)) => {}
         Ok(Err(e)) => log::warn!("failed to show desktop notification: {}", e),
         Err(e) => log::warn!("notification task panicked: {}", e),
+    }
+}
+
+// ============================================================================
+// Meeting reminders
+// ============================================================================
+
+/// One upcoming calendar event, trimmed to what the reminder loop needs.
+#[derive(Debug, Clone, PartialEq)]
+struct UpcomingEvent {
+    id: String,
+    title: Option<String>,
+    start_at: DateTime<Utc>,
+}
+
+/// Which of `events` are due a reminder right now, given the configured
+/// `reminder_minutes` thresholds (e.g. `[15, 5]`) and the set of event ids
+/// already reminded this session. An event fires **once** per session: the
+/// largest configured threshold that the event has reached (i.e.
+/// `minutes_until <= threshold`) is used, and the event id is then
+/// considered done — it won't fire again for a smaller threshold later.
+/// Pure, unit-tested; the caller is responsible for inserting the returned
+/// ids into `already_notified` afterward.
+fn due_reminders(
+    events: &[UpcomingEvent],
+    now: DateTime<Utc>,
+    reminder_minutes: &[u64],
+    already_notified: &HashSet<String>,
+) -> Vec<(String, u64, Option<String>)> {
+    if reminder_minutes.is_empty() {
+        return Vec::new();
+    }
+    let mut thresholds: Vec<u64> = reminder_minutes.to_vec();
+    thresholds.sort_unstable_by(|a, b| b.cmp(a)); // descending
+
+    let mut due = Vec::new();
+    for event in events {
+        if already_notified.contains(&event.id) {
+            continue;
+        }
+        let minutes_until = (event.start_at - now).num_seconds() as f64 / 60.0;
+        if minutes_until < 0.0 {
+            continue; // already started
+        }
+        if let Some(&threshold) = thresholds.iter().find(|&&t| minutes_until <= t as f64) {
+            due.push((event.id.clone(), threshold, event.title.clone()));
+        }
+    }
+    due
+}
+
+/// Background loop that reads upcoming calendar events every ~45s and fires
+/// one reminder per event, `meeting_reminder_minutes` before its start,
+/// de-duplicated per event id for the process lifetime. Dead in the Tauri
+/// app (`show_meeting_reminder` is a command nothing ever calls) — this is
+/// the real implementation. Call once, after the main window opens.
+pub fn start_meeting_reminder_loop(cx: &mut App) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let db = services.db.clone();
+
+    io.spawn(async move {
+        let mut already_notified: HashSet<String> = HashSet::new();
+        loop {
+            let pool = db.read().unwrap().as_ref().map(|db| db.pool().clone());
+            if let Some(pool) = pool {
+                reminder_tick(pool, &mut already_notified).await;
+            }
+            tokio::time::sleep(Duration::from_secs(45)).await;
+        }
+    });
+}
+
+/// Real body of the reminder tick, taking the pool directly (used by
+/// [`start_meeting_reminder_loop`], separated out so it's callable/testable
+/// without a live `App`/`Io`).
+async fn reminder_tick(pool: sqlx::SqlitePool, already_notified: &mut HashSet<String>) {
+    let settings = load_settings(Some(pool.clone())).await;
+    if !settings.notification_preferences.show_meeting_reminders {
+        return;
+    }
+    let reminder_minutes = &settings.notification_preferences.meeting_reminder_minutes;
+    if reminder_minutes.is_empty() {
+        return;
+    }
+    let max_minutes = *reminder_minutes.iter().max().unwrap_or(&0);
+
+    let now = Utc::now();
+    let horizon = now + chrono::Duration::minutes(max_minutes as i64 + 1);
+    let events = match CalendarRepository::list_events_in_range(&pool, now, horizon).await {
+        Ok(events) => events,
+        Err(e) => {
+            log::warn!("meeting reminder loop: failed to list upcoming events: {}", e);
+            return;
+        }
+    };
+    let upcoming: Vec<UpcomingEvent> = events
+        .into_iter()
+        .filter(|e| !e.is_all_day && e.start_at > now)
+        .map(|e| UpcomingEvent {
+            id: e.id,
+            title: e.summary,
+            start_at: e.start_at,
+        })
+        .collect();
+
+    let due = due_reminders(&upcoming, now, reminder_minutes, already_notified);
+    for (id, minutes, title) in due {
+        already_notified.insert(id);
+        let (event_title, body) = notification_text(&Kind::MeetingReminder { minutes, title });
+        show(event_title, body).await;
+    }
+}
+
+// ============================================================================
+// Update check
+// ============================================================================
+
+const RELEASES_API: &str = "https://api.github.com/repos/Hankanman/Meetily-Local/releases/latest";
+
+#[derive(Deserialize)]
+struct ReleaseResponse {
+    tag_name: String,
+    html_url: String,
+}
+
+/// Compare `latest_tag` (a GitHub release tag, e.g. `"v1.2.3"`) against
+/// `current` (`env!("CARGO_PKG_VERSION")`, unprefixed) using semver
+/// ordering. Pure, unit-tested; a malformed version on either side is a
+/// friendly `Err` rather than a panic.
+fn is_newer(current: &str, latest_tag: &str) -> Result<bool, String> {
+    let latest = latest_tag.strip_prefix('v').unwrap_or(latest_tag);
+    let current_v = semver::Version::parse(current)
+        .map_err(|e| format!("couldn't parse the current version ({current}): {e}"))?;
+    let latest_v = semver::Version::parse(latest)
+        .map_err(|e| format!("couldn't parse the latest release version ({latest}): {e}"))?;
+    Ok(latest_v > current_v)
+}
+
+/// Check GitHub for the latest release and show a notification: "Parley
+/// X.Y.Z is available", "You're up to date", or a friendly error. Dead in
+/// the Tauri app (the "Check for updates" tray item dispatches a JS event
+/// nothing listens to) — this is the real implementation. No auto-install.
+pub fn check_for_updates(cx: &mut App) {
+    let io = AppServices::global(cx).io.clone();
+    io.spawn(async move {
+        let current = env!("CARGO_PKG_VERSION");
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(8))
+            .user_agent("meetily-gpui-update-check")
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("update check: failed to build http client: {}", e);
+                show("Parley", "Couldn't check for updates right now.".to_string()).await;
+                return;
+            }
+        };
+
+        let response = match client.get(RELEASES_API).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("update check: request failed: {}", e);
+                show("Parley", "Couldn't check for updates right now.".to_string()).await;
+                return;
+            }
+        };
+
+        let release: ReleaseResponse = match response.json().await {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("update check: bad response: {}", e);
+                show("Parley", "Couldn't check for updates right now.".to_string()).await;
+                return;
+            }
+        };
+
+        match is_newer(current, &release.tag_name) {
+            Ok(true) => {
+                show(
+                    "Parley",
+                    format!(
+                        "Parley {} is available — {}",
+                        release.tag_name.trim_start_matches('v'),
+                        release.html_url
+                    ),
+                )
+                .await;
+            }
+            Ok(false) => {
+                show("Parley", "You're up to date.".to_string()).await;
+            }
+            Err(e) => {
+                log::warn!("update check: version compare failed: {}", e);
+                show("Parley", "Couldn't check for updates right now.".to_string()).await;
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_all_on() -> SettingsMini {
+        SettingsMini {
+            consent_given: true,
+            system_permission_granted: true,
+            manual_dnd_mode: false,
+            notification_preferences: PreferencesMini {
+                show_recording_started: true,
+                show_recording_stopped: true,
+                show_recording_paused: true,
+                show_recording_resumed: true,
+                show_transcription_complete: true,
+                show_meeting_reminders: true,
+                show_system_errors: true,
+                meeting_reminder_minutes: vec![15, 5],
+            },
+        }
+    }
+
+    #[test]
+    fn no_consent_blocks_everything_except_test() {
+        let mut settings = settings_all_on();
+        settings.consent_given = false;
+        assert!(!should_notify(&settings, &Kind::Started));
+        assert!(should_notify(&settings, &Kind::Test));
+    }
+
+    #[test]
+    fn no_system_permission_blocks_everything_except_test() {
+        let mut settings = settings_all_on();
+        settings.system_permission_granted = false;
+        assert!(!should_notify(&settings, &Kind::Stopped));
+        assert!(should_notify(&settings, &Kind::Test));
+    }
+
+    #[test]
+    fn manual_dnd_blocks_everything_except_test() {
+        let mut settings = settings_all_on();
+        settings.manual_dnd_mode = true;
+        assert!(!should_notify(&settings, &Kind::SystemError("boom".into())));
+        assert!(should_notify(&settings, &Kind::Test));
+    }
+
+    #[test]
+    fn per_kind_toggle_gates_that_kind_only() {
+        let mut settings = settings_all_on();
+        settings.notification_preferences.show_recording_paused = false;
+        assert!(!should_notify(&settings, &Kind::Paused));
+        assert!(should_notify(&settings, &Kind::Resumed));
+        assert!(should_notify(&settings, &Kind::Started));
+    }
+
+    #[test]
+    fn defaults_match_the_tauri_shell_defaults() {
+        let settings = SettingsMini::default();
+        let p = &settings.notification_preferences;
+        assert!(!p.show_recording_started);
+        assert!(!p.show_recording_stopped);
+        assert!(p.show_recording_paused);
+        assert!(p.show_recording_resumed);
+        assert!(p.show_transcription_complete);
+        assert!(p.show_meeting_reminders);
+        assert!(p.show_system_errors);
+        assert_eq!(p.meeting_reminder_minutes, vec![15, 5]);
+    }
+
+    fn event(id: &str, minutes_from_now: i64, title: Option<&str>, now: DateTime<Utc>) -> UpcomingEvent {
+        UpcomingEvent {
+            id: id.to_string(),
+            title: title.map(|s| s.to_string()),
+            start_at: now + chrono::Duration::minutes(minutes_from_now),
+        }
+    }
+
+    #[test]
+    fn due_reminders_fires_the_largest_reached_threshold() {
+        let now = Utc::now();
+        let events = vec![event("e1", 12, Some("Standup"), now)];
+        let due = due_reminders(&events, now, &[15, 5], &HashSet::new());
+        assert_eq!(due, vec![("e1".to_string(), 15, Some("Standup".to_string()))]);
+    }
+
+    #[test]
+    fn due_reminders_skips_events_that_already_started() {
+        let now = Utc::now();
+        let events = vec![event("e1", -1, None, now)];
+        let due = due_reminders(&events, now, &[15, 5], &HashSet::new());
+        assert!(due.is_empty());
+    }
+
+    #[test]
+    fn due_reminders_skips_events_outside_every_threshold() {
+        let now = Utc::now();
+        let events = vec![event("e1", 30, None, now)];
+        let due = due_reminders(&events, now, &[15, 5], &HashSet::new());
+        assert!(due.is_empty());
+    }
+
+    #[test]
+    fn due_reminders_dedupes_per_event_id() {
+        let now = Utc::now();
+        let events = vec![event("e1", 3, None, now)];
+        let mut already = HashSet::new();
+        already.insert("e1".to_string());
+        let due = due_reminders(&events, now, &[15, 5], &already);
+        assert!(due.is_empty());
+    }
+
+    #[test]
+    fn is_newer_detects_a_newer_release() {
+        assert_eq!(is_newer("1.2.3", "v1.3.0"), Ok(true));
+    }
+
+    #[test]
+    fn is_newer_false_when_up_to_date() {
+        assert_eq!(is_newer("1.2.3", "v1.2.3"), Ok(false));
+    }
+
+    #[test]
+    fn is_newer_false_when_current_is_ahead_of_a_stale_release() {
+        assert_eq!(is_newer("2.0.0", "v1.9.9"), Ok(false));
+    }
+
+    #[test]
+    fn is_newer_handles_an_unprefixed_tag() {
+        assert_eq!(is_newer("1.0.0", "1.0.1"), Ok(true));
+    }
+
+    #[test]
+    fn is_newer_errors_on_malformed_versions() {
+        assert!(is_newer("1.0.0", "not-a-version").is_err());
     }
 }

--- a/meetily-gpui/src/recovery.rs
+++ b/meetily-gpui/src/recovery.rs
@@ -293,6 +293,7 @@ mod tests {
             speaker: None,
             voice_profile_id: None,
             source: None,
+            confidence: None,
         }
     }
 

--- a/meetily-gpui/src/tray.rs
+++ b/meetily-gpui/src/tray.rs
@@ -20,10 +20,20 @@ use meetily_core::audio::recording_service::{self, RecordingArgs, StartRequest};
 use crate::app_state::AppServices;
 use crate::core_events::CoreEvent;
 use crate::notifications;
+use crate::shell::{navigate, Route};
 
 actions!(
     parley_tray,
-    [TrayStartRecording, TrayStopRecording, TrayOpenParley, TrayQuit]
+    [
+        TrayStartRecording,
+        TrayStopRecording,
+        TrayPauseRecording,
+        TrayResumeRecording,
+        TrayOpenParley,
+        TraySettings,
+        TrayCheckForUpdates,
+        TrayQuit,
+    ]
 );
 
 /// The main window, stashed here so the tray's "Open Parley" action can
@@ -93,6 +103,8 @@ fn build_menu(cx: &mut App) -> Vec<MenuItem> {
 
     let can_start = matches!(phase, Idle);
     let can_stop = matches!(phase, Recording | Paused);
+    let can_pause = matches!(phase, Recording);
+    let can_resume = matches!(phase, Paused);
 
     vec![
         disabled(MenuItem::action(status_label, NoAction), true),
@@ -102,11 +114,22 @@ fn build_menu(cx: &mut App) -> Vec<MenuItem> {
             !can_start,
         ),
         disabled(
+            MenuItem::action("Pause recording", TrayPauseRecording),
+            !can_pause,
+        ),
+        disabled(
+            MenuItem::action("Resume recording", TrayResumeRecording),
+            !can_resume,
+        ),
+        disabled(
             MenuItem::action("Stop recording", TrayStopRecording),
             !can_stop,
         ),
         MenuItem::separator(),
         MenuItem::action("Open Parley", TrayOpenParley),
+        MenuItem::action("Settings", TraySettings),
+        MenuItem::action("Check for updates", TrayCheckForUpdates),
+        MenuItem::separator(),
         MenuItem::action("Quit", TrayQuit),
     ]
 }
@@ -147,6 +170,35 @@ fn start_recording_from_tray(cx: &mut App) {
     });
 }
 
+fn pause_recording_from_tray(cx: &mut App) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let ctx = services.recording_context();
+    io.spawn(async move {
+        if let Err(e) = recording_service::pause_recording(&ctx).await {
+            log::error!("tray: failed to pause recording: {}", e);
+        }
+    });
+}
+
+fn resume_recording_from_tray(cx: &mut App) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let ctx = services.recording_context();
+    io.spawn(async move {
+        if let Err(e) = recording_service::resume_recording(&ctx).await {
+            log::error!("tray: failed to resume recording: {}", e);
+        }
+    });
+}
+
+/// Show + focus the main window, then navigate to Settings — used by both
+/// the tray's "Settings" item.
+fn open_settings(cx: &mut App) {
+    open_parley(cx);
+    navigate(Route::Settings, cx);
+}
+
 fn stop_recording_from_tray(cx: &mut App) {
     let services = AppServices::global(cx);
     let ctx = services.recording_context();
@@ -180,9 +232,25 @@ pub fn install(cx: &mut App) -> gpui_tray::Result<()> {
         log::info!("tray: stop recording");
         stop_recording_from_tray(cx);
     });
+    cx.on_action(|_: &TrayPauseRecording, cx: &mut App| {
+        log::info!("tray: pause recording");
+        pause_recording_from_tray(cx);
+    });
+    cx.on_action(|_: &TrayResumeRecording, cx: &mut App| {
+        log::info!("tray: resume recording");
+        resume_recording_from_tray(cx);
+    });
     cx.on_action(|_: &TrayOpenParley, cx: &mut App| {
         log::info!("tray: open Parley");
         open_parley(cx);
+    });
+    cx.on_action(|_: &TraySettings, cx: &mut App| {
+        log::info!("tray: settings");
+        open_settings(cx);
+    });
+    cx.on_action(|_: &TrayCheckForUpdates, cx: &mut App| {
+        log::info!("tray: check for updates");
+        notifications::check_for_updates(cx);
     });
     cx.on_action(|_: &TrayQuit, cx: &mut App| {
         log::info!("tray: quit");
@@ -208,11 +276,38 @@ pub fn install(cx: &mut App) -> gpui_tray::Result<()> {
                 else {
                     return;
                 };
+                let previous = cx.try_global::<TrayPhase>().copied().unwrap_or_default().0;
+                // Pause/resume have no dedicated `recording-*` event (unlike
+                // start/stop) — the Tauri shell doesn't notify on them
+                // either (see `notifications.rs`'s module doc). Detect the
+                // transition here, off the canonical phase machine.
+                if previous == RecordingPhase::Recording && snapshot.phase == RecordingPhase::Paused {
+                    notifications::maybe_notify(cx, notifications::Kind::Paused);
+                } else if previous == RecordingPhase::Paused && snapshot.phase == RecordingPhase::Recording {
+                    notifications::maybe_notify(cx, notifications::Kind::Resumed);
+                }
                 cx.set_global(TrayPhase(snapshot.phase));
                 refresh(cx);
             }
             "recording-started" => notifications::maybe_notify(cx, notifications::Kind::Started),
             "recording-stopped" => notifications::maybe_notify(cx, notifications::Kind::Stopped),
+            "meeting-refined" => {
+                notifications::maybe_notify(cx, notifications::Kind::TranscriptionComplete)
+            }
+            "recording-error" => {
+                if let Some(message) = event.decode::<String>() {
+                    notifications::maybe_notify(cx, notifications::Kind::SystemError(message));
+                }
+            }
+            "transcription-error" => {
+                let message = event
+                    .payload
+                    .get("userMessage")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "Transcription error".to_string());
+                notifications::maybe_notify(cx, notifications::Kind::SystemError(message));
+            }
             _ => {}
         }
     })

--- a/meetily-gpui/src/ui.rs
+++ b/meetily-gpui/src/ui.rs
@@ -1,0 +1,21 @@
+//! Small UI helpers shared across views.
+
+use gpui_kit::{AnyWindowHandle, App, Window};
+
+/// Run `f` against the main window from a context that only has `&mut App`
+/// (a core-event subscription callback, or an async task after an `.await`)
+/// — via the `tray::MainWindow` global stashed at startup. No-op before the
+/// window exists.
+///
+/// Goes through the *untyped* handle on purpose: `WindowHandle<Root>::update`
+/// leases the `Root` entity for the closure, and gpui-kit's window helpers
+/// (`push_notification`, `open_dialog`, `close_dialog`, …) update `Root`
+/// themselves, which then panics with "cannot update Root while it is
+/// already being updated". `AnyWindowHandle::update` only enters the window.
+pub fn with_main_window(cx: &mut App, f: impl FnOnce(&mut Window, &mut App)) {
+    let Some(handle) = cx.try_global::<crate::tray::MainWindow>().map(|main| main.0) else {
+        return;
+    };
+    let handle: AnyWindowHandle = handle.into();
+    let _ = handle.update(cx, |_, window, cx| f(window, cx));
+}

--- a/meetily-gpui/src/views/import/mod.rs
+++ b/meetily-gpui/src/views/import/mod.rs
@@ -13,7 +13,7 @@ mod logic;
 use std::path::PathBuf;
 
 use gpui_kit::component::{
-    ActiveTheme, Disableable as _, IndexPath, Root, StyledExt as _, WindowExt as _, h_flex,
+    ActiveTheme, Disableable as _, IndexPath, StyledExt as _, WindowExt as _, h_flex,
     v_flex,
     button::{Button, ButtonVariants as _},
     dialog::Dialog,
@@ -230,7 +230,7 @@ impl ImportState {
     fn finish(&mut self, result: ImportResult, cx: &mut Context<Self>) {
         self.status = Status::Idle;
         self.progress = None;
-        with_main_window(cx, |_, window, cx| window.close_dialog(cx));
+        with_main_window(cx, |window, cx| window.close_dialog(cx));
         shell::refresh_meetings(cx);
         shell::navigate(Route::Meeting(result.meeting_id), cx);
     }
@@ -354,15 +354,12 @@ fn warning_message(warning: ImportWarning) -> String {
 /// Push a toast on the main window from a context that only has `&mut App`
 /// (a core-event subscription has no `Window`) — the same
 /// `tray::MainWindow` global the tray menu uses to reach the window.
-fn with_main_window(cx: &mut App, f: impl FnOnce(&mut Root, &mut Window, &mut Context<Root>)) {
-    let Some(handle) = cx.try_global::<crate::tray::MainWindow>().map(|m| m.0) else {
-        return;
-    };
-    let _ = handle.update(cx, f);
+fn with_main_window(cx: &mut App, f: impl FnOnce(&mut Window, &mut App)) {
+    crate::ui::with_main_window(cx, f);
 }
 
 fn toast(cx: &mut App, kind: NotificationType, message: String) {
-    with_main_window(cx, move |_, window, cx| {
+    with_main_window(cx, move |window, cx| {
         window.push_notification(Notification::new().message(message).with_type(kind), cx);
     });
 }

--- a/meetily-gpui/src/views/meeting/format.rs
+++ b/meetily-gpui/src/views/meeting/format.rs
@@ -106,6 +106,90 @@ pub fn has_unsaved_summary_edits(editing: bool, editor_text: &str, saved_markdow
     editing && editor_text != saved_markdown
 }
 
+// ---- Confidence indicator -------------------------------------------------
+// Mirrors `frontend/src/components/ConfidenceIndicator.tsx`'s thresholds and
+// labels exactly (including its `>= 0.4` "Medium" cutoff, despite the
+// component's own comment claiming "below 50%").
+
+/// One of the four confidence bands `ConfidenceIndicator.tsx` renders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfidenceLevel {
+    High,
+    Good,
+    Medium,
+    Low,
+}
+
+impl ConfidenceLevel {
+    /// `conf` is the raw 0.0-1.0 Whisper confidence score.
+    pub fn for_confidence(conf: f32) -> Self {
+        if conf >= 0.8 {
+            ConfidenceLevel::High
+        } else if conf >= 0.7 {
+            ConfidenceLevel::Good
+        } else if conf >= 0.4 {
+            ConfidenceLevel::Medium
+        } else {
+            ConfidenceLevel::Low
+        }
+    }
+
+    /// Mirrors `getConfidenceLabel`.
+    pub fn label(self) -> &'static str {
+        match self {
+            ConfidenceLevel::High => "High confidence",
+            ConfidenceLevel::Good => "Good confidence",
+            ConfidenceLevel::Medium => "Medium confidence",
+            ConfidenceLevel::Low => "Low confidence",
+        }
+    }
+}
+
+/// Tooltip text, e.g. "87% confidence - High confidence" — mirrors the
+/// `title` attribute `ConfidenceIndicator.tsx` sets on its dot.
+pub fn confidence_tooltip(conf: f32) -> String {
+    let percent = (conf * 100.0).round() as i64;
+    format!("{percent}% confidence - {}", ConfidenceLevel::for_confidence(conf).label())
+}
+
+// ---- Meeting notes ---------------------------------------------------------
+// Mirrors `MeetingNotesPanel.tsx`'s `formatNoteTime`.
+
+/// "Sep 11, 2:30 PM"-style note timestamp, or `""` for an unparseable
+/// timestamp (matches the React component's `Number.isNaN` guard).
+pub fn format_note_time(created_at: &str) -> String {
+    match DateTime::parse_from_rfc3339(created_at) {
+        Ok(dt) => dt.with_timezone(&chrono::Local).format("%b %-d, %-I:%M %p").to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+// ---- Summary typewriter reveal ---------------------------------------------
+// There's no existing React "typewriter" for `summary-stream` specifically
+// (see `useSummaryStream.ts`, which appends deltas as-is) — this adapts the
+// pacing algorithm `useTranscriptStreaming.ts` uses for live transcript
+// segments (50ms tick, `max(2, ceil(remaining / ticks))` chars per tick)
+// into a delta-buffering model, since the summary case streams over an
+// unbounded duration rather than one fixed-length segment.
+
+/// Reveal tick interval, matching `useTranscriptStreaming.ts`'s `INTERVAL_MS`.
+pub const SUMMARY_REVEAL_INTERVAL_MS: u64 = 50;
+
+/// How many characters to reveal per tick for a buffer of `pending_len`
+/// characters not yet shown. Always reveals at least 1 char/tick so a small
+/// trailing buffer still drains instead of stalling.
+pub fn summary_reveal_chars_per_tick(pending_len: usize) -> usize {
+    if pending_len == 0 {
+        return 0;
+    }
+    // Same shape as useTranscriptStreaming's `Math.max(2, Math.ceil(remaining / totalTicks))`,
+    // sized against one tick's worth of the *current* pending buffer so a
+    // burst of deltas (e.g. after a network stall) catches up within a
+    // handful of ticks instead of trickling out at a fixed rate forever.
+    const TARGET_TICKS: usize = 8;
+    (pending_len.div_ceil(TARGET_TICKS)).max(2).min(pending_len)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,6 +218,7 @@ mod tests {
             speaker: None,
             voice_profile_id: None,
             source: None,
+            confidence: None,
         }
     }
 
@@ -213,5 +298,51 @@ mod tests {
     #[test]
     fn unsaved_edits_when_editing_and_text_differs() {
         assert!(has_unsaved_summary_edits(true, "changed", "original"));
+    }
+
+    #[test]
+    fn confidence_level_thresholds_match_react() {
+        assert_eq!(ConfidenceLevel::for_confidence(1.0), ConfidenceLevel::High);
+        assert_eq!(ConfidenceLevel::for_confidence(0.8), ConfidenceLevel::High);
+        assert_eq!(ConfidenceLevel::for_confidence(0.79), ConfidenceLevel::Good);
+        assert_eq!(ConfidenceLevel::for_confidence(0.7), ConfidenceLevel::Good);
+        assert_eq!(ConfidenceLevel::for_confidence(0.69), ConfidenceLevel::Medium);
+        assert_eq!(ConfidenceLevel::for_confidence(0.4), ConfidenceLevel::Medium);
+        assert_eq!(ConfidenceLevel::for_confidence(0.39), ConfidenceLevel::Low);
+        assert_eq!(ConfidenceLevel::for_confidence(0.0), ConfidenceLevel::Low);
+    }
+
+    #[test]
+    fn confidence_tooltip_matches_react_format() {
+        assert_eq!(confidence_tooltip(0.873), "87% confidence - High confidence");
+        assert_eq!(confidence_tooltip(0.35), "35% confidence - Low confidence");
+    }
+
+    #[test]
+    fn format_note_time_renders_valid_rfc3339() {
+        let formatted = format_note_time("2026-09-11T14:30:00Z");
+        // Exact wall-clock text depends on the local timezone offset, but it
+        // must parse to something non-empty in the expected shape.
+        assert!(!formatted.is_empty());
+    }
+
+    #[test]
+    fn format_note_time_is_empty_for_unparseable_input() {
+        assert_eq!(format_note_time("not-a-date"), "");
+    }
+
+    #[test]
+    fn summary_reveal_chars_per_tick_drains_small_buffers_fully() {
+        assert_eq!(summary_reveal_chars_per_tick(0), 0);
+        assert_eq!(summary_reveal_chars_per_tick(1), 1);
+        assert_eq!(summary_reveal_chars_per_tick(2), 2);
+    }
+
+    #[test]
+    fn summary_reveal_chars_per_tick_scales_with_backlog() {
+        // 80 pending chars / 8 target ticks = 10 chars/tick.
+        assert_eq!(summary_reveal_chars_per_tick(80), 10);
+        // Never reveals more than what's pending.
+        assert_eq!(summary_reveal_chars_per_tick(3), 3);
     }
 }

--- a/meetily-gpui/src/views/meeting/format.rs
+++ b/meetily-gpui/src/views/meeting/format.rs
@@ -342,7 +342,8 @@ mod tests {
     fn summary_reveal_chars_per_tick_scales_with_backlog() {
         // 80 pending chars / 8 target ticks = 10 chars/tick.
         assert_eq!(summary_reveal_chars_per_tick(80), 10);
-        // Never reveals more than what's pending.
-        assert_eq!(summary_reveal_chars_per_tick(3), 3);
+        // Below the floor of 2 chars/tick, still never exceeds what's pending.
+        assert_eq!(summary_reveal_chars_per_tick(3), 2);
+        assert_eq!(summary_reveal_chars_per_tick(1), 1);
     }
 }

--- a/meetily-gpui/src/views/meeting/mod.rs
+++ b/meetily-gpui/src/views/meeting/mod.rs
@@ -1410,12 +1410,7 @@ impl MeetingView {
 /// a `Window` (an async task after an `.await`, or a core-event
 /// subscription callback) — via the `MainWindow` global stashed at startup.
 fn notify(cx: &mut App, notification: Notification) {
-    if let Some(main_window) = cx.try_global::<crate::tray::MainWindow>() {
-        let handle = main_window.0;
-        let _ = handle.update(cx, |_, window, cx| {
-            window.push_notification(notification, cx);
-        });
-    }
+    crate::ui::with_main_window(cx, |window, cx| window.push_notification(notification, cx));
 }
 
 /// The floating speaker-edit popover, rendered from the page root (outside

--- a/meetily-gpui/src/views/meeting/mod.rs
+++ b/meetily-gpui/src/views/meeting/mod.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use gpui_kit::component::{
     ActiveTheme, Disableable as _, IconName, WindowExt as _,
     button::{Button, ButtonVariants as _},
+    checkbox::Checkbox,
     h_flex,
     input::{Input, InputState},
     notification::Notification,
@@ -32,9 +33,13 @@ use gpui_kit::*;
 use meetily_core::calendar::models::CalendarEvent;
 use meetily_core::calendar::repository::CalendarRepository;
 use meetily_core::calendar::service::link_meeting_with_snapshot;
-use meetily_core::database::models::{MeetingDetails, MeetingTranscript, VoiceProfile};
+use meetily_core::database::models::{ActionItem, MeetingDetails, MeetingNote, MeetingTranscript, VoiceProfile};
+use meetily_core::database::repositories::action_item::{
+    ActionItemsRepository, NewActionItem, SOURCE_MANUAL as ACTION_ITEM_SOURCE_MANUAL, STATUS_DONE, STATUS_OPEN,
+};
 use meetily_core::database::repositories::meeting::MeetingsRepository;
-use meetily_core::database::repositories::setting::SettingsRepository;
+use meetily_core::database::repositories::meeting_note::{MeetingNotesRepository, SOURCE_MANUAL as NOTE_SOURCE_MANUAL};
+use meetily_core::database::repositories::setting::{SettingsRepository, KEY_UI_CONFIG};
 use meetily_core::database::repositories::summary::SummaryProcessesRepository;
 use meetily_core::database::repositories::voice_profile::VoiceProfilesRepository;
 use meetily_core::speaker_diarization::service::{merge_cluster_into_profile_core, promote_speaker_to_profile_core};
@@ -172,6 +177,37 @@ pub struct MeetingView {
     /// actually starting), if any.
     loading_segment: Option<String>,
 
+    // -- Confidence indicator ---------------------------------------------
+    /// `ui_config.showConfidenceIndicator`, read once per `load()` — mirrors
+    /// `ConfidenceIndicator.tsx`'s `showIndicator` gate.
+    show_confidence: bool,
+
+    // -- Meeting notes ------------------------------------------------------
+    // Mirrors `MeetingNotesPanel.tsx`: append-only (no edit; delete+re-add).
+    notes: Vec<MeetingNote>,
+    notes_composing: bool,
+    notes_draft: Entity<InputState>,
+    notes_saving: bool,
+
+    // -- Per-meeting action items --------------------------------------------
+    // Mirrors `ActionItemsPanel.tsx`.
+    action_items: Vec<ActionItem>,
+    action_items_loading: bool,
+    /// Item currently shown with an editable text field, if any.
+    ai_editing_id: Option<String>,
+    ai_edit_input: Entity<InputState>,
+    ai_adding: bool,
+    ai_add_input: Entity<InputState>,
+    ai_extracting: bool,
+
+    // -- Summary typewriter reveal --------------------------------------------
+    // `on_summary_stream` buffers incoming deltas here instead of pushing
+    // them straight to `summary_state`; `_summary_reveal_task` drains the
+    // buffer at `format::SUMMARY_REVEAL_INTERVAL_MS`, mirroring
+    // `useTranscriptStreaming.ts`'s pacing (see `format.rs`).
+    summary_reveal_pending: String,
+    _summary_reveal_task: Option<Task<()>>,
+
     _subscriptions: Vec<Subscription>,
 }
 
@@ -194,6 +230,7 @@ impl MeetingView {
                 "retranscription-progress" => this.on_retranscription_progress(event, cx),
                 "retranscription-complete" => this.on_retranscription_complete(event, cx),
                 "retranscription-error" => this.on_retranscription_error(event, cx),
+                "action-items-extracted" => this.on_action_items_extracted(event, cx),
                 meetily_core::audio::playback::PLAYBACK_ENDED_EVENT => this.on_segment_playback_ended(cx),
                 _ => {}
             }
@@ -206,6 +243,9 @@ impl MeetingView {
             cx.new(|cx| InputState::new(window, cx).placeholder("Custom instructions (optional)…"));
         let calendar_picker_query =
             cx.new(|cx| InputState::new(window, cx).placeholder("Search events…"));
+        let notes_draft = cx.new(|cx| InputState::new(window, cx).placeholder("Add a note…"));
+        let ai_edit_input = cx.new(|cx| InputState::new(window, cx).placeholder("Action item text"));
+        let ai_add_input = cx.new(|cx| InputState::new(window, cx).placeholder("Add an action item…"));
 
         let view = Self {
             meeting_id: None,
@@ -249,6 +289,20 @@ impl MeetingView {
             speaker_edit: None,
             playing_segment: None,
             loading_segment: None,
+            show_confidence: false,
+            notes: Vec::new(),
+            notes_composing: false,
+            notes_draft,
+            notes_saving: false,
+            action_items: Vec::new(),
+            action_items_loading: false,
+            ai_editing_id: None,
+            ai_edit_input,
+            ai_adding: false,
+            ai_add_input,
+            ai_extracting: false,
+            summary_reveal_pending: String::new(),
+            _summary_reveal_task: None,
             _subscriptions: subscriptions,
         };
         view.load_default_template(cx);
@@ -323,6 +377,16 @@ impl MeetingView {
         self.speaker_edit = None;
         self.playing_segment = None;
         self.loading_segment = None;
+        self.notes = Vec::new();
+        self.notes_composing = false;
+        self.notes_saving = false;
+        self.action_items = Vec::new();
+        self.action_items_loading = true;
+        self.ai_editing_id = None;
+        self.ai_adding = false;
+        self.ai_extracting = false;
+        self.summary_reveal_pending.clear();
+        self._summary_reveal_task = None;
         self.summary_state.update(cx, |state, cx| state.set_text("", cx));
         cx.notify();
 
@@ -371,6 +435,9 @@ impl MeetingView {
         // in flight (e.g. started from the Tauri UI).
         self.refresh_summary(generation, cx);
         self.load_calendar_event(generation, cx);
+        self.load_notes(generation, cx);
+        self.load_action_items(generation, cx);
+        self.load_confidence_setting(generation, cx);
 
         // A clip from the previous meeting shouldn't keep playing once we've
         // navigated away from its transcript.
@@ -602,6 +669,12 @@ impl MeetingView {
         self._poll_task = Some(task);
     }
 
+    /// Buffers the incoming delta instead of pushing it straight to
+    /// `summary_state` — [`Self::start_summary_reveal_task`] drains the
+    /// buffer at a typewriter pace (see `format::summary_reveal_chars_per_tick`).
+    /// `summary_markdown` (the source-of-truth for save/copy/export) still
+    /// gets the delta immediately: only the *rendered* `summary_state` text
+    /// lags behind.
     fn on_summary_stream(&mut self, event: &crate::core_events::CoreEvent, cx: &mut Context<Self>) {
         #[derive(serde::Deserialize)]
         struct Delta {
@@ -619,7 +692,63 @@ impl MeetingView {
         }
         self.summary_has_content = true;
         self.summary_markdown.push_str(&payload.delta);
-        self.summary_state.update(cx, |state, cx| state.push_str(&payload.delta, cx));
+
+        if cx.reduce_motion() {
+            // Mirrors `useTranscriptStreaming.ts`'s reduced-motion path:
+            // skip the reveal animation and show text immediately.
+            self.summary_state.update(cx, |state, cx| state.push_str(&payload.delta, cx));
+            return;
+        }
+
+        self.summary_reveal_pending.push_str(&payload.delta);
+        if self._summary_reveal_task.is_none() {
+            self.start_summary_reveal_task(cx);
+        }
+    }
+
+    /// Drains `summary_reveal_pending` into `summary_state` a few characters
+    /// at a time on a repeating timer, mirroring `useTranscriptStreaming.ts`'s
+    /// pacing. Stops itself once the buffer empties (a later delta restarts
+    /// it via `on_summary_stream`), so at most one timer runs at a time.
+    fn start_summary_reveal_task(&mut self, cx: &mut Context<Self>) {
+        let generation = self.generation;
+        let task = cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(format::SUMMARY_REVEAL_INTERVAL_MS))
+                    .await;
+                let done = this
+                    .update(cx, |this, cx| {
+                        if this.generation != generation || this.summary_reveal_pending.is_empty() {
+                            return true;
+                        }
+                        let n = format::summary_reveal_chars_per_tick(this.summary_reveal_pending.len())
+                            .min(this.summary_reveal_pending.len());
+                        // Drain on a char boundary — `n` counts bytes of a
+                        // UTF-8 buffer, which may land mid-codepoint.
+                        let mut boundary = n;
+                        while boundary < this.summary_reveal_pending.len()
+                            && !this.summary_reveal_pending.is_char_boundary(boundary)
+                        {
+                            boundary += 1;
+                        }
+                        let chunk: String = this.summary_reveal_pending.drain(..boundary).collect();
+                        this.summary_state.update(cx, |state, cx| state.push_str(&chunk, cx));
+                        this.summary_reveal_pending.is_empty()
+                    })
+                    .unwrap_or(true);
+                if done {
+                    break;
+                }
+            }
+            let _ = this.update(cx, |this, cx| {
+                if this.generation == generation {
+                    this._summary_reveal_task = None;
+                    cx.notify();
+                }
+            });
+        });
+        self._summary_reveal_task = Some(task);
     }
 
     // ---- Summary editing (zorite) ----------------------------------------
@@ -1404,6 +1533,424 @@ impl MeetingView {
         self.loading_segment = None;
         cx.notify();
     }
+
+    // ---- Confidence indicator ---------------------------------------------
+
+    /// Read `ui_config.showConfidenceIndicator` (default `true`, matching
+    /// `ConfigContext.tsx`'s `readStoredBool(.., true)`) once per `load()`.
+    /// Read directly via `SettingsRepository` rather than `SettingsCache`
+    /// (the Settings page's own global) — this view doesn't depend on the
+    /// Settings page being visited first.
+    fn load_confidence_setting(&mut self, generation: u64, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let io = Io::global(cx);
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { SettingsRepository::get_setting_json(&pool, KEY_UI_CONFIG).await }).await;
+            let show = match result {
+                Ok(Ok(Some(json))) => serde_json::from_str::<serde_json::Value>(&json)
+                    .ok()
+                    .and_then(|v| v.get("showConfidenceIndicator").and_then(|v| v.as_bool()))
+                    .unwrap_or(true),
+                _ => true,
+            };
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                this.show_confidence = show;
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    // ---- Meeting notes ------------------------------------------------------
+    // Mirrors `MeetingNotesPanel.tsx`: load silently (no loading/error UI),
+    // oldest-first, append-only (delete + re-add instead of editing).
+
+    fn load_notes(&mut self, generation: u64, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let Some(id) = self.meeting_id.clone() else {
+            return;
+        };
+        let io = Io::global(cx);
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { MeetingNotesRepository::list_by_meeting(&pool, &id).await }).await;
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                if let Ok(Ok(notes)) = result {
+                    this.notes = notes;
+                }
+                // Silent on error, matching the React panel (console.error only).
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn open_note_composer(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.notes_composing = true;
+        self.notes_draft.update(cx, |s, cx| s.set_value("", window, cx));
+        cx.notify();
+    }
+
+    fn cancel_note_composer(&mut self, cx: &mut Context<Self>) {
+        self.notes_composing = false;
+        cx.notify();
+    }
+
+    fn save_note(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let Some(id) = self.meeting_id.clone() else {
+            return;
+        };
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let body = self.notes_draft.read(cx).value().trim().to_string();
+        if body.is_empty() || self.notes_saving {
+            return;
+        }
+        self.notes_saving = true;
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let result = io
+                .spawn(async move { MeetingNotesRepository::create(&pool, &id, &body, NOTE_SOURCE_MANUAL).await })
+                .await;
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.notes_saving = false;
+                if this.generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(Ok(note)) => {
+                        this.notes.push(note);
+                        this.notes_composing = false;
+                        this.notes_draft.update(cx, |s, cx| s.set_value("", window, cx));
+                    }
+                    Ok(Err(e)) => notify(cx, Notification::error(format!("Failed to add note: {e}"))),
+                    Err(e) => notify(cx, Notification::error(format!("Failed to add note: {e}"))),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    /// Optimistic removal, mirroring `MeetingNotesPanel.tsx`'s
+    /// `handleDelete`: removed from view immediately, re-inserted
+    /// (sorted back into place) on failure.
+    fn delete_note(&mut self, id: String, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let removed = self.notes.iter().position(|n| n.id == id).map(|ix| self.notes.remove(ix));
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { MeetingNotesRepository::delete(&pool, &id).await }).await;
+            let ok = matches!(result, Ok(Ok(true)));
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                if !ok {
+                    if let Some(note) = removed {
+                        this.notes.push(note);
+                        this.notes.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+                    }
+                    notify(cx, Notification::error("Failed to delete note"));
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    // ---- Per-meeting action items -------------------------------------------
+    // Mirrors `ActionItemsPanel.tsx`: `list_by_meeting`'s order (open first,
+    // oldest-first within each group) is used as-is, no client-side re-sort.
+
+    fn load_action_items(&mut self, generation: u64, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            self.action_items_loading = false;
+            return;
+        };
+        let Some(id) = self.meeting_id.clone() else {
+            self.action_items_loading = false;
+            return;
+        };
+        let io = Io::global(cx);
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { ActionItemsRepository::list_by_meeting(&pool, &id).await }).await;
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                this.action_items_loading = false;
+                if let Ok(Ok(items)) = result {
+                    this.action_items = items;
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn on_action_items_extracted(&mut self, event: &crate::core_events::CoreEvent, cx: &mut Context<Self>) {
+        #[derive(serde::Deserialize)]
+        struct Payload {
+            meeting_id: String,
+        }
+        let Some(payload) = event.decode::<Payload>() else {
+            return;
+        };
+        if self.meeting_id.as_deref() != Some(payload.meeting_id.as_str()) {
+            return;
+        }
+        self.ai_extracting = false;
+        self.load_action_items(self.generation, cx);
+    }
+
+    fn toggle_action_item_status(&mut self, id: String, currently_done: bool, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let next = if currently_done { STATUS_OPEN } else { STATUS_DONE };
+        if let Some(item) = self.action_items.iter_mut().find(|i| i.id == id) {
+            item.status = next.to_string();
+        }
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        let id_for_task = id.clone();
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { ActionItemsRepository::set_status(&pool, &id_for_task, next).await }).await;
+            if !matches!(result, Ok(Ok(Some(_)))) {
+                let _ = this.update(cx, |this, cx| {
+                    if this.generation == generation {
+                        this.load_action_items(generation, cx);
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
+    fn start_action_item_edit(&mut self, item_id: String, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(item) = self.action_items.iter().find(|i| i.id == item_id) else {
+            return;
+        };
+        let text = item.text.clone();
+        self.ai_editing_id = Some(item_id);
+        self.ai_edit_input.update(cx, |s, cx| s.set_value(text, window, cx));
+        cx.notify();
+    }
+
+    fn cancel_action_item_edit(&mut self, cx: &mut Context<Self>) {
+        self.ai_editing_id = None;
+        cx.notify();
+    }
+
+    fn save_action_item_edit(&mut self, cx: &mut Context<Self>) {
+        let Some(id) = self.ai_editing_id.take() else {
+            return;
+        };
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let text = self.ai_edit_input.read(cx).value().trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        if let Some(item) = self.action_items.iter_mut().find(|i| i.id == id) {
+            item.text = text.clone();
+        }
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { ActionItemsRepository::update(&pool, &id, Some(&text), None, None).await }).await;
+            if !matches!(result, Ok(Ok(Some(_)))) {
+                let _ = this.update(cx, |this, cx| {
+                    if this.generation == generation {
+                        this.load_action_items(generation, cx);
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
+    fn delete_action_item(&mut self, id: String, cx: &mut Context<Self>) {
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        self.action_items.retain(|i| i.id != id);
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let result = io.spawn(async move { ActionItemsRepository::delete(&pool, &id).await }).await;
+            if !matches!(result, Ok(Ok(true))) {
+                let _ = this.update(cx, |this, cx| {
+                    if this.generation == generation {
+                        this.load_action_items(generation, cx);
+                    }
+                });
+            }
+        })
+        .detach();
+    }
+
+    fn open_action_item_composer(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.ai_adding = true;
+        self.ai_add_input.update(cx, |s, cx| s.set_value("", window, cx));
+        cx.notify();
+    }
+
+    fn cancel_action_item_composer(&mut self, cx: &mut Context<Self>) {
+        self.ai_adding = false;
+        cx.notify();
+    }
+
+    fn save_new_action_item(&mut self, cx: &mut Context<Self>) {
+        let Some(id) = self.meeting_id.clone() else {
+            return;
+        };
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        let text = self.ai_add_input.read(cx).value().trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        self.ai_adding = false;
+        cx.notify();
+
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let item = NewActionItem { text, ..Default::default() };
+            let result =
+                io.spawn(async move { ActionItemsRepository::create(&pool, &id, &item, ACTION_ITEM_SOURCE_MANUAL).await }).await;
+            let _ = this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(Ok(_)) => this.load_action_items(generation, cx),
+                    Ok(Err(e)) => notify(cx, Notification::error(format!("Failed to add action item: {e}"))),
+                    Err(e) => notify(cx, Notification::error(format!("Failed to add action item: {e}"))),
+                }
+            });
+        })
+        .detach();
+    }
+
+    /// "Extract from summary" / "Re-extract" — mirrors the Tauri
+    /// `extract_action_items` command: try the transcript-grounded
+    /// extractor first, falling back to the summary-markdown extractor if
+    /// it errors (e.g. no transcript rows to window over).
+    fn extract_action_items(&mut self, cx: &mut Context<Self>) {
+        let Some(id) = self.meeting_id.clone() else {
+            return;
+        };
+        let Some(pool) = AppServices::global(cx).pool() else {
+            return;
+        };
+        if self.ai_extracting {
+            return;
+        }
+        self.ai_extracting = true;
+        cx.notify();
+
+        let sink = AppServices::global(cx).sink.clone();
+        let summary_markdown = self.summary_markdown.clone();
+        let io = Io::global(cx);
+        let generation = self.generation;
+        cx.spawn(async move |this, cx| {
+            let pool_for_config = pool.clone();
+            let config = io.spawn(async move { SettingsRepository::get_model_config(&pool_for_config).await }).await;
+            let Ok(Ok(Some(config))) = config else {
+                let _ = this.update(cx, |this, cx| {
+                    this.ai_extracting = false;
+                    if this.generation == generation {
+                        notify(cx, Notification::error("No model configured — set one up in Settings first."));
+                    }
+                    cx.notify();
+                });
+                return;
+            };
+
+            let provider = config.provider;
+            let model = config.model;
+            let pool_for_transcript = pool.clone();
+            let sink_for_transcript = sink.clone();
+            let id_for_transcript = id.clone();
+            let provider_for_transcript = provider.clone();
+            let model_for_transcript = model.clone();
+            let transcript_result = io
+                .spawn(async move {
+                    meetily_core::summary::transcript_action_items::extract_from_transcript(
+                        sink_for_transcript.as_ref(),
+                        &pool_for_transcript,
+                        &id_for_transcript,
+                        &provider_for_transcript,
+                        &model_for_transcript,
+                    )
+                    .await
+                })
+                .await;
+
+            let outcome = match transcript_result {
+                Ok(Ok(count)) => Ok(count),
+                _ => {
+                    // Fall back to extracting from the stored summary markdown.
+                    let id_for_summary = id.clone();
+                    io.spawn(async move {
+                        meetily_core::summary::action_extraction::extract_for_meeting(
+                            sink.as_ref(),
+                            &pool,
+                            &id_for_summary,
+                            &summary_markdown,
+                            &provider,
+                            &model,
+                        )
+                        .await
+                    })
+                    .await
+                    .unwrap_or_else(|e| Err(format!("Task panicked: {e}")))
+                }
+            };
+
+            let _ = this.update(cx, |this, cx| {
+                this.ai_extracting = false;
+                if this.generation != generation {
+                    return;
+                }
+                match outcome {
+                    Ok(_) => this.load_action_items(generation, cx),
+                    Err(e) => notify(cx, Notification::error(format!("Extraction failed: {e}"))),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
 }
 
 /// Show a notification on the main window from a context that doesn't carry
@@ -2120,6 +2667,7 @@ impl MeetingView {
         let speaker_edit = self.speaker_edit.clone();
         let playing_segment = self.playing_segment.clone();
         let loading_segment = self.loading_segment.clone();
+        let show_confidence = self.show_confidence;
 
         v_flex()
             .size_full()
@@ -2197,6 +2745,25 @@ impl MeetingView {
                                 header_row = header_row.child(speaker.clone());
                             }
                             header_row = header_row.child(time);
+
+                            if show_confidence {
+                                if let Some(conf) = t.confidence {
+                                    let color = match format::ConfidenceLevel::for_confidence(conf) {
+                                        format::ConfidenceLevel::High => cx.theme().success,
+                                        format::ConfidenceLevel::Good | format::ConfidenceLevel::Medium => {
+                                            cx.theme().warning
+                                        }
+                                        format::ConfidenceLevel::Low => cx.theme().danger,
+                                    };
+                                    header_row = header_row.child(
+                                        Button::new(SharedString::from(format!("confidence-{}", t.id)))
+                                            .ghost()
+                                            .xsmall()
+                                            .tooltip(format::confidence_tooltip(conf))
+                                            .child(div().size(px(8.)).rounded_full().bg(color)),
+                                    );
+                                }
+                            }
 
                             let row = v_flex()
                                 .w_full()
@@ -2358,10 +2925,325 @@ impl MeetingView {
                     .min_h_0()
                     .overflow_y_scroll()
                     .p_4()
-                    .when(!self.editing_summary, |this| {
-                        this.child(TextView::new(&self.summary_state).selectable(true))
-                    })
-                    .when(self.editing_summary, |this| this.child(self.summary_editor.clone())),
+                    .child(
+                        v_flex()
+                            .w_full()
+                            .gap_4()
+                            .when(!self.editing_summary, |this| {
+                                this.child(TextView::new(&self.summary_state).selectable(true))
+                            })
+                            .when(self.editing_summary, |this| this.child(self.summary_editor.clone()))
+                            .child(self.render_action_items_panel(cx))
+                            .child(self.render_notes_panel(cx)),
+                    ),
             )
+    }
+
+    // ---- Per-meeting action items panel -------------------------------------
+    // Mirrors `ActionItemsPanel.tsx`'s card layout: header (icon, title, open
+    // count / "All done"), an "Extract from summary"/"Re-extract" button
+    // (only once there's a summary), the item list, then an add row.
+
+    fn render_action_items_panel(&self, cx: &mut Context<Self>) -> AnyElement {
+        let open_count = self.action_items.iter().filter(|i| i.status != STATUS_DONE).count();
+        let is_empty = self.action_items.is_empty();
+        let has_summary = self.summary_has_content;
+
+        let mut card = v_flex()
+            .w_full()
+            .gap_2()
+            .p_3()
+            .rounded_md()
+            .bg(cx.theme().muted.opacity(0.3))
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .child(Lucide::ListChecks.view(cx))
+                            .child(div().text_sm().font_semibold().child("Action Items"))
+                            .when(open_count > 0, |this| {
+                                this.child(
+                                    div()
+                                        .text_xs()
+                                        .px_2()
+                                        .rounded_full()
+                                        .bg(cx.theme().primary.opacity(0.15))
+                                        .text_color(cx.theme().primary)
+                                        .child(open_count.to_string()),
+                                )
+                            })
+                            .when(!is_empty && open_count == 0, |this| {
+                                this.child(
+                                    div().text_xs().text_color(cx.theme().muted_foreground).child("All done"),
+                                )
+                            }),
+                    )
+                    .when(has_summary, |this| {
+                        let label = if is_empty { "Extract from summary" } else { "Re-extract" };
+                        this.child(
+                            Button::new("extract-action-items")
+                                .ghost()
+                                .xsmall()
+                                .icon(Lucide::Sparkles)
+                                .label(label)
+                                .loading(self.ai_extracting)
+                                .disabled(self.ai_extracting)
+                                .on_click(cx.listener(|this, _, _, cx| this.extract_action_items(cx))),
+                        )
+                    }),
+            );
+
+        if is_empty {
+            let empty_text = if has_summary {
+                "No action items yet. Extract them from the summary, or add one below."
+            } else {
+                "No action items yet. Add one below."
+            };
+            card = card.child(div().text_xs().text_color(cx.theme().muted_foreground).child(empty_text));
+        } else {
+            for item in &self.action_items {
+                card = card.child(self.render_action_item_row(item, cx));
+            }
+        }
+
+        card = card.child(self.render_action_item_composer(cx));
+        card.into_any_element()
+    }
+
+    fn render_action_item_row(&self, item: &ActionItem, cx: &mut Context<Self>) -> AnyElement {
+        let is_done = item.status == STATUS_DONE;
+        let id = item.id.clone();
+
+        if self.ai_editing_id.as_deref() == Some(item.id.as_str()) {
+            return h_flex()
+                .w_full()
+                .items_center()
+                .gap_2()
+                .child(div().flex_1().min_w_0().child(Input::new(&self.ai_edit_input)))
+                .child(
+                    Button::new(SharedString::from(format!("save-ai-{id}")))
+                        .primary()
+                        .xsmall()
+                        .label("Save")
+                        .on_click(cx.listener(|this, _, _, cx| this.save_action_item_edit(cx))),
+                )
+                .child(
+                    Button::new(SharedString::from(format!("cancel-ai-{id}")))
+                        .ghost()
+                        .xsmall()
+                        .label("Cancel")
+                        .on_click(cx.listener(|this, _, _, cx| this.cancel_action_item_edit(cx))),
+                )
+                .into_any_element();
+        }
+
+        let id_for_toggle = id.clone();
+        let id_for_edit = id.clone();
+        let id_for_delete = id.clone();
+
+        h_flex()
+            .w_full()
+            .items_start()
+            .gap_2()
+            .child(
+                Checkbox::new(SharedString::from(format!("ai-done-{id}"))).checked(is_done).on_click(cx.listener(
+                    move |this, _, _, cx| this.toggle_action_item_status(id_for_toggle.clone(), is_done, cx),
+                )),
+            )
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .gap_1()
+                    .child(
+                        div()
+                            .text_sm()
+                            .when(is_done, |this| this.line_through().text_color(cx.theme().muted_foreground))
+                            .child(item.text.clone()),
+                    )
+                    .when(item.assignee.is_some() || item.due_hint.is_some(), |this| {
+                        this.child(
+                            h_flex()
+                                .gap_2()
+                                .text_xs()
+                                .text_color(cx.theme().muted_foreground)
+                                .when_some(item.assignee.clone(), |this, a| this.child(a))
+                                .when_some(item.due_hint.clone(), |this, d| this.child(d)),
+                        )
+                    }),
+            )
+            .child(
+                Button::new(SharedString::from(format!("edit-ai-{id}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(Lucide::Pencil)
+                    .tooltip("Edit")
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.start_action_item_edit(id_for_edit.clone(), window, cx);
+                    })),
+            )
+            .child(
+                Button::new(SharedString::from(format!("delete-ai-{id}")))
+                    .ghost()
+                    .xsmall()
+                    .icon(IconName::Delete)
+                    .tooltip("Delete")
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.delete_action_item(id_for_delete.clone(), cx);
+                    })),
+            )
+            .into_any_element()
+    }
+
+    fn render_action_item_composer(&self, cx: &mut Context<Self>) -> AnyElement {
+        if self.ai_adding {
+            return h_flex()
+                .w_full()
+                .items_center()
+                .gap_2()
+                .child(div().flex_1().min_w_0().child(Input::new(&self.ai_add_input)))
+                .child(
+                    Button::new("save-add-ai")
+                        .primary()
+                        .xsmall()
+                        .label("Add")
+                        .on_click(cx.listener(|this, _, _, cx| this.save_new_action_item(cx))),
+                )
+                .child(
+                    Button::new("cancel-add-ai")
+                        .ghost()
+                        .xsmall()
+                        .label("Cancel")
+                        .on_click(cx.listener(|this, _, _, cx| this.cancel_action_item_composer(cx))),
+                )
+                .into_any_element();
+        }
+
+        Button::new("open-add-ai")
+            .ghost()
+            .xsmall()
+            .icon(IconName::Plus)
+            .label("Add item")
+            .on_click(cx.listener(|this, _, window, cx| this.open_action_item_composer(window, cx)))
+            .into_any_element()
+    }
+
+    // ---- Meeting notes panel -------------------------------------------------
+    // Mirrors `MeetingNotesPanel.tsx`'s card layout: header (icon, title,
+    // count badge, "Add note" button), a list of notes, no empty-state text.
+
+    fn render_notes_panel(&self, cx: &mut Context<Self>) -> AnyElement {
+        let count = self.notes.len();
+
+        let mut card = v_flex()
+            .w_full()
+            .gap_2()
+            .p_3()
+            .rounded_md()
+            .bg(cx.theme().muted.opacity(0.3))
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .child(Lucide::NotebookPen.view(cx))
+                            .child(div().text_sm().font_semibold().child("Notes"))
+                            .when(count > 0, |this| {
+                                this.child(
+                                    div()
+                                        .text_xs()
+                                        .px_2()
+                                        .rounded_full()
+                                        .bg(cx.theme().primary.opacity(0.15))
+                                        .text_color(cx.theme().primary)
+                                        .child(count.to_string()),
+                                )
+                            }),
+                    )
+                    .when(!self.notes_composing, |this| {
+                        this.child(
+                            Button::new("open-note-composer")
+                                .ghost()
+                                .xsmall()
+                                .icon(IconName::Plus)
+                                .label("Add note")
+                                .on_click(cx.listener(|this, _, window, cx| this.open_note_composer(window, cx))),
+                        )
+                    }),
+            );
+
+        for note in &self.notes {
+            let id = note.id.clone();
+            let time = format::format_note_time(&note.created_at);
+            let suffix = if note.source == "agent" { " · added by an agent" } else { "" };
+            card = card.child(
+                v_flex()
+                    .w_full()
+                    .gap_1()
+                    .child(div().text_sm().child(note.body.clone()))
+                    .child(
+                        h_flex()
+                            .items_center()
+                            .justify_between()
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(format!("{time}{suffix}")),
+                            )
+                            .child(
+                                Button::new(SharedString::from(format!("delete-note-{id}")))
+                                    .ghost()
+                                    .xsmall()
+                                    .icon(IconName::Delete)
+                                    .tooltip("Delete note")
+                                    .on_click(cx.listener(move |this, _, _, cx| this.delete_note(id.clone(), cx))),
+                            ),
+                    ),
+            );
+        }
+
+        if self.notes_composing {
+            card = card.child(
+                v_flex()
+                    .w_full()
+                    .gap_2()
+                    .child(div().w_full().child(Input::new(&self.notes_draft)))
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .child(
+                                Button::new("save-note")
+                                    .primary()
+                                    .xsmall()
+                                    .label(if self.notes_saving { "Saving…" } else { "Save" })
+                                    .loading(self.notes_saving)
+                                    .disabled(self.notes_saving)
+                                    .on_click(cx.listener(|this, _, window, cx| this.save_note(window, cx))),
+                            )
+                            .child(
+                                Button::new("cancel-note")
+                                    .ghost()
+                                    .xsmall()
+                                    .label("Cancel")
+                                    .disabled(self.notes_saving)
+                                    .on_click(cx.listener(|this, _, _, cx| this.cancel_note_composer(cx))),
+                            ),
+                    ),
+            );
+        }
+
+        card.into_any_element()
     }
 }

--- a/meetily-gpui/src/views/recording/view.rs
+++ b/meetily-gpui/src/views/recording/view.rs
@@ -26,6 +26,11 @@ use meetily_core::audio::recording_preferences::{self, RecordingPreferences};
 use meetily_core::audio::recording_service::{self, RecordingArgs, StartRequest};
 use meetily_core::audio::simple_level_monitor;
 use meetily_core::audio::transcription::TranscriptUpdate;
+use meetily_core::calendar::repository::CalendarRepository;
+use meetily_core::database::repositories::setting::{
+    SettingsRepository, KEY_BETA_FEATURES,
+};
+use meetily_core::summary::live_action_items;
 
 use crate::app_state::AppServices;
 use crate::core_events::CoreEvent;
@@ -79,6 +84,51 @@ struct RecordingStoppedPayload {
     folder_path: Option<String>,
 }
 
+/// Wire shape of a `live-action-items` event's `items` entries (the
+/// private `LiveItem` in `meetily_core::summary::live_action_items`,
+/// mirrored the same way `PartialUpdatePayload` mirrors `partial_worker`'s).
+#[derive(Debug, Clone, Deserialize)]
+struct LiveActionItemPayload {
+    text: String,
+    #[allow(dead_code)]
+    assignee: Option<String>,
+    #[allow(dead_code)]
+    due_hint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LiveActionItemsEvent {
+    items: Vec<LiveActionItemPayload>,
+}
+
+/// Only the one beta flag this view needs, read straight from
+/// `KEY_BETA_FEATURES` — mirrors `frontend/src/types/betaFeatures.ts`'s
+/// `BetaFeatures.liveActionItems` default (`false`). Deliberately not
+/// reusing `views::settings::state::BetaFeatures`: that module is private
+/// to the settings page (see its own doc comment on why a local mirror
+/// beats a shared type), the same pattern `notifications.rs`'s
+/// `SettingsMini` uses for the notification-settings row.
+#[derive(Debug, Deserialize, Default)]
+struct BetaFeaturesMini {
+    #[serde(default)]
+    live_action_items: bool,
+}
+
+/// Case/whitespace-insensitive dedupe key, mirroring
+/// `useLiveActionItems.ts`'s `key()`.
+fn action_item_key(text: &str) -> String {
+    text.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim_end_matches(['.', ' '])
+        .to_string()
+}
+
+fn is_active_phase(phase: RecordingPhase) -> bool {
+    matches!(phase, RecordingPhase::Recording | RecordingPhase::Paused)
+}
+
 /// Tracks the server-reported active recording duration so the header can
 /// tick locally between `recording-state` events instead of only updating
 /// on phase transitions. Re-based on every snapshot.
@@ -120,6 +170,14 @@ pub struct RecordingView {
     levels: Levels,
     refining: bool,
     pending_toasts: Vec<(NotificationType, String)>,
+    /// Provisional action items from the beta live extractor — see
+    /// `restart_live_action_items`/`stop_live_action_items`.
+    live_action_items: Vec<String>,
+    /// Calendar event matched at the moment recording started, stashed so
+    /// `stop`'s `recording-stopped` payload (which carries the fresh
+    /// `meeting_id`) can link the two. Mirrors
+    /// `frontend/src/lib/recordingCalendarLink.ts`'s sessionStorage handoff.
+    pending_calendar_event_id: Option<String>,
 }
 
 impl RecordingView {
@@ -166,6 +224,8 @@ impl RecordingView {
             levels: Levels::default(),
             refining: false,
             pending_toasts: Vec::new(),
+            live_action_items: Vec::new(),
+            pending_calendar_event_id: None,
         };
 
         this.sync_initial_state(window, cx);
@@ -379,6 +439,28 @@ impl RecordingView {
                     cx.notify();
                 }
             }
+            "live-action-items" => {
+                if let Some(payload) = event.decode::<LiveActionItemsEvent>() {
+                    let mut seen: std::collections::HashSet<String> = self
+                        .live_action_items
+                        .iter()
+                        .map(|t| action_item_key(t))
+                        .collect();
+                    let mut added = false;
+                    for item in payload.items {
+                        let key = action_item_key(&item.text);
+                        if seen.contains(&key) {
+                            continue;
+                        }
+                        seen.insert(key);
+                        self.live_action_items.push(item.text);
+                        added = true;
+                    }
+                    if added {
+                        cx.notify();
+                    }
+                }
+            }
             "audio-levels" => {
                 if let Some(update) =
                     event.decode::<meetily_core::audio::simple_level_monitor::AudioLevelUpdate>()
@@ -425,6 +507,34 @@ impl RecordingView {
                                 folder_path,
                             ));
                         }
+
+                        // Link to the calendar event matched at start time
+                        // (if any), now that a `meeting_id` exists. Mirrors
+                        // `useRecordingStop.ts`'s `consumePendingCalendarEventId`
+                        // + `linkMeetingToCalendarEvent` call — failure is
+                        // non-fatal, matching React's try/catch.
+                        if let Some(event_id) = self.pending_calendar_event_id.take() {
+                            if let Some(pool) = AppServices::global(cx).pool() {
+                                let meeting_id = meeting_id.clone();
+                                AppServices::global(cx).io.spawn(async move {
+                                    if let Err(e) = meetily_core::calendar::service::link_meeting_with_snapshot(
+                                        &pool,
+                                        &meeting_id,
+                                        Some(&event_id),
+                                    )
+                                    .await
+                                    {
+                                        log::warn!(
+                                            "failed to link meeting {} to calendar event {}: {}",
+                                            meeting_id,
+                                            event_id,
+                                            e
+                                        );
+                                    }
+                                });
+                            }
+                        }
+
                         navigate(Route::Meeting(meeting_id), cx);
                     }
                 }
@@ -451,9 +561,43 @@ impl RecordingView {
         if entering_starting {
             self.clear_transcript(cx);
         }
+
+        let was_active = is_active_phase(self.snapshot.phase);
+        let now_active = is_active_phase(snapshot.phase);
+        if !was_active && now_active {
+            self.live_action_items.clear();
+            self.restart_live_action_items(cx);
+        } else if was_active && !now_active {
+            live_action_items::stop();
+        }
+
         self.elapsed.rebase(&snapshot);
         self.snapshot = snapshot;
         cx.notify();
+    }
+
+    /// Start the beta live action-item extractor, mirroring
+    /// `useLiveActionItems.ts`: only when the Beta flag is on, and
+    /// best-effort (a missing model config just means no live items).
+    fn restart_live_action_items(&mut self, cx: &mut Context<Self>) {
+        let services = AppServices::global(cx);
+        let io = services.io.clone();
+        let sink = services.sink.clone();
+        let Some(pool) = services.pool() else { return };
+        io.spawn(async move {
+            let beta = SettingsRepository::get_setting::<BetaFeaturesMini>(&pool, KEY_BETA_FEATURES)
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            if !beta.live_action_items {
+                return;
+            }
+            let Ok(Some(config)) = SettingsRepository::get_model_config(&pool).await else {
+                return;
+            };
+            live_action_items::start(sink, pool, config.provider, config.model);
+        });
     }
 
     fn clear_transcript(&mut self, cx: &mut Context<Self>) {
@@ -520,17 +664,52 @@ impl RecordingView {
         let services = AppServices::global(cx);
         let io = services.io.clone();
         let ctx = services.recording_context();
-        let meeting_name = self.meeting_name.read(cx).value().to_string();
+        let pool = services.pool();
+        let typed_name = self.meeting_name.read(cx).value().to_string();
         let mic = self.mic_selection(cx);
         let system = self.system_selection(cx);
 
-        let req = StartRequest {
-            mic_device_name: Some(mic),
-            system_device_name: Some(system),
-            meeting_name: Some(meeting_name),
-        };
-
         cx.spawn(async move |this, cx| {
+            // Find the calendar event happening right now (if any), mirroring
+            // `recordingCalendarLink.ts`'s `prepareRecordingMetadata`: its
+            // summary becomes the meeting title, and its id is stashed so
+            // the `recording-stopped` handler can link the two once a
+            // `meeting_id` exists.
+            let matched_event = match &pool {
+                Some(pool) => CalendarRepository::find_event_for_now(pool).await.ok().flatten(),
+                None => None,
+            };
+
+            let (meeting_name, event_id) = match &matched_event {
+                Some(event) => {
+                    let summary = event.summary.clone().unwrap_or_default();
+                    let title = if summary.trim().is_empty() { typed_name } else { summary };
+                    (title, Some(event.id.clone()))
+                }
+                None => (typed_name, None),
+            };
+
+            let _ = this.update_in(cx, |this, window, cx| {
+                this.pending_calendar_event_id = event_id;
+                if let Some(event) = &matched_event {
+                    this.meeting_name.update(cx, |state, cx| {
+                        state.set_value(meeting_name.clone(), window, cx);
+                    });
+                    this.toast(
+                        NotificationType::Info,
+                        format!(
+                            "Linked to \"{}\" from your calendar",
+                            event.summary.clone().unwrap_or_else(|| meeting_name.clone())
+                        ),
+                    );
+                }
+            });
+
+            let req = StartRequest {
+                mic_device_name: Some(mic),
+                system_device_name: Some(system),
+                meeting_name: Some(meeting_name),
+            };
             let handle = io.spawn(async move {
                 let hooks = recording_service::default_start_hooks(ctx.pool.clone());
                 recording_service::start(ctx, hooks, req).await
@@ -793,6 +972,26 @@ impl Render for RecordingView {
                             .child(div().text_sm().italic().text_color(cx.theme().muted_foreground).child(text))
                     },
                 )))
+            })
+            .when(!self.live_action_items.is_empty(), |parent| {
+                parent.child(
+                    v_flex()
+                        .gap_1()
+                        .p_3()
+                        .rounded(cx.theme().radius)
+                        .border_1()
+                        .border_color(cx.theme().border)
+                        .child(
+                            div()
+                                .text_xs()
+                                .font_semibold()
+                                .text_color(cx.theme().muted_foreground)
+                                .child("Action items (live, beta)"),
+                        )
+                        .children(self.live_action_items.iter().map(|text| {
+                            div().text_sm().child(format!("• {}", text))
+                        })),
+                )
             })
     }
 }

--- a/meetily-gpui/src/views/settings/integrations.rs
+++ b/meetily-gpui/src/views/settings/integrations.rs
@@ -3,6 +3,7 @@
 //! against the same Tauri-free core (`meetily_core::mcp_config`).
 
 use gpui_kit::component::{
+    button::Button,
     clipboard::Clipboard,
     h_flex, v_flex,
     label::Label,
@@ -52,6 +53,7 @@ fn info_item(view: &Entity<SettingsView>) -> SettingItem {
             Some(path) => format!("Binary not found at last known path: {}", path),
             None => "Binary not found — build meetily-mcp or set $MEETILY_MCP_BIN".to_string(),
         };
+        let reveal_path = info.binary_path.clone().filter(|_| info.binary_found);
 
         let bin_display = info
             .binary_path
@@ -66,11 +68,28 @@ fn info_item(view: &Entity<SettingsView>) -> SettingItem {
             .gap_3()
             .child(Label::new(format!("{}{}", db_line, db_exists)).text_color(cx.theme().muted_foreground))
             .child(
-                Label::new(binary_line).text_color(if info.binary_found {
-                    cx.theme().success
-                } else {
-                    cx.theme().danger
-                }),
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .child(
+                        Label::new(binary_line).text_color(if info.binary_found {
+                            cx.theme().success
+                        } else {
+                            cx.theme().danger
+                        }),
+                    )
+                    .children(reveal_path.map(|path| {
+                        Button::new("mcp-reveal-binary")
+                            .outline()
+                            .label("Show in file manager")
+                            .on_click(move |_, _, _cx| {
+                                if let Err(e) = meetily_core::mcp_config::reveal_mcp_binary(path.clone()) {
+                                    log::warn!("settings: failed to reveal MCP binary: {}", e);
+                                }
+                            })
+                    })),
             )
             .child(snippet_block(cx, "Claude Code", &claude_code_snippet))
             .child(snippet_block(cx, "Claude Desktop / other MCP JSON config", &json_snippet))

--- a/meetily-gpui/src/views/settings/mod.rs
+++ b/meetily-gpui/src/views/settings/mod.rs
@@ -10,6 +10,7 @@ mod appearance;
 mod beta;
 mod calendar;
 mod integrations;
+mod model_utils;
 mod notifications;
 mod recording;
 mod state;
@@ -68,6 +69,57 @@ impl SettingsView {
                         cx.notify();
                     }
                 }
+                // Ollama model manager (Settings → Summary, Ollama section):
+                // same three-event shape as the Whisper events above, just a
+                // different event-name prefix.
+                "ollama-model-download-progress" => {
+                    if let Some(payload) = event.decode::<DownloadProgress>() {
+                        cx.update_global::<state::SettingsCache, _>(|cache, _| {
+                            cache
+                                .ollama_pull_progress
+                                .insert(payload.model_name, payload.progress);
+                        });
+                        cx.notify();
+                    }
+                }
+                "ollama-model-download-complete" => {
+                    if let Some(payload) = event.decode::<DownloadComplete>() {
+                        cx.update_global::<state::SettingsCache, _>(|cache, _| {
+                            cache.ollama_pull_progress.remove(&payload.model_name);
+                        });
+                        state::refresh_ollama_models(cx.entity(), cx);
+                    }
+                }
+                "ollama-model-download-error" => {
+                    if let Some(payload) = event.decode::<DownloadError>() {
+                        cx.update_global::<state::SettingsCache, _>(|cache, _| {
+                            cache.ollama_pull_progress.remove(&payload.model_name);
+                            cache.ollama_error = Some(payload.error);
+                        });
+                        cx.notify();
+                    }
+                }
+                // Built-in AI model manager (Settings → Summary,
+                // "Built-in AI" section).
+                "builtin-ai-download-progress" => {
+                    if let Some(payload) = event.decode::<BuiltinDownloadProgress>() {
+                        let done = matches!(payload.status.as_str(), "completed" | "cancelled" | "error");
+                        cx.update_global::<state::SettingsCache, _>(|cache, _| {
+                            if done {
+                                cache.builtin_download_progress.remove(&payload.model);
+                            } else {
+                                cache
+                                    .builtin_download_progress
+                                    .insert(payload.model.clone(), payload.progress);
+                            }
+                        });
+                        if done {
+                            state::refresh_builtin_models(cx.entity(), cx);
+                        } else {
+                            cx.notify();
+                        }
+                    }
+                }
                 _ => {}
             }
         })
@@ -95,6 +147,13 @@ struct DownloadError {
     #[serde(rename = "modelName")]
     model_name: String,
     error: String,
+}
+
+#[derive(serde::Deserialize)]
+struct BuiltinDownloadProgress {
+    model: String,
+    progress: u8,
+    status: String,
 }
 
 impl Render for SettingsView {

--- a/meetily-gpui/src/views/settings/model_utils.rs
+++ b/meetily-gpui/src/views/settings/model_utils.rs
@@ -1,0 +1,128 @@
+//! Pure, side-effect-free helpers backing the Settings → Summary model
+//! pickers: merging a live-fetched model list with a static fallback list
+//! (mirrors `ModelSettingsModal`'s `modelOptions` memo — fallback only when
+//! nothing was fetched), filtering a list by a search query, and formatting
+//! a size in MB the same way across the Ollama/Whisper/built-in-AI model
+//! managers. Kept free of `gpui`/`tokio` so it's plainly unit-testable.
+
+/// Fallback model ids shown when OpenAI's `get_openai_models` fails or no
+/// API key is configured yet — mirrors
+/// `frontend/src/components/ModelSettings/constants.ts`'s
+/// `OPENAI_FALLBACK_MODELS`.
+pub const OPENAI_FALLBACK_MODELS: &[&str] = &[
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4-turbo",
+    "gpt-4",
+    "gpt-3.5-turbo",
+    "o1",
+    "o1-mini",
+    "o3",
+    "o3-mini",
+];
+
+/// Mirrors `CLAUDE_FALLBACK_MODELS`.
+pub const CLAUDE_FALLBACK_MODELS: &[&str] = &[
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-5-20251101",
+    "claude-3-5-sonnet-latest",
+];
+
+/// Mirrors `GROQ_FALLBACK_MODELS`.
+pub const GROQ_FALLBACK_MODELS: &[&str] = &[
+    "llama-3.3-70b-versatile",
+    "llama-3.1-70b-versatile",
+    "mixtral-8x7b-32768",
+    "gemma2-9b-it",
+];
+
+/// The static fallback list for `provider`, or `None` for providers that
+/// have no fallback (Ollama/OpenRouter — an empty fetch there just means
+/// "no models yet", not "use a canned list").
+pub fn fallback_for_provider(provider: &str) -> Option<&'static [&'static str]> {
+    match provider {
+        "openai" => Some(OPENAI_FALLBACK_MODELS),
+        "claude" => Some(CLAUDE_FALLBACK_MODELS),
+        "groq" => Some(GROQ_FALLBACK_MODELS),
+        _ => None,
+    }
+}
+
+/// Merge a live-fetched model list with `provider`'s static fallback: the
+/// fetch wins whenever it returned anything, otherwise fall back. Mirrors
+/// `ModelSettingsModal`'s `modelOptions` memo.
+pub fn merge_with_fallback(provider: &str, fetched: &[String]) -> Vec<String> {
+    if !fetched.is_empty() {
+        return fetched.to_vec();
+    }
+    fallback_for_provider(provider)
+        .map(|fallback| fallback.iter().map(|s| s.to_string()).collect())
+        .unwrap_or_default()
+}
+
+/// Case-insensitive substring filter over `models`, matching
+/// `OllamaModelsList`'s search box. An empty query returns everything.
+pub fn filter_models<'a>(models: &'a [String], query: &str) -> Vec<&'a String> {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return models.iter().collect();
+    }
+    models
+        .iter()
+        .filter(|m| m.to_lowercase().contains(&query))
+        .collect()
+}
+
+/// Format a size in megabytes as "NNN MB" below 1 GB, else "N.N GB" —
+/// shared by the Ollama/built-in-AI model manager rows.
+pub fn format_size_mb(size_mb: u64) -> String {
+    if size_mb >= 1024 {
+        format!("{:.1} GB", size_mb as f64 / 1024.0)
+    } else {
+        format!("{} MB", size_mb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_models, format_size_mb, merge_with_fallback};
+
+    #[test]
+    fn merge_with_fallback_prefers_a_nonempty_fetch() {
+        let fetched = vec!["gpt-5".to_string(), "gpt-5-mini".to_string()];
+        assert_eq!(merge_with_fallback("openai", &fetched), fetched);
+    }
+
+    #[test]
+    fn merge_with_fallback_falls_back_when_fetch_is_empty() {
+        let result = merge_with_fallback("openai", &[]);
+        assert_eq!(result, super::OPENAI_FALLBACK_MODELS.to_vec());
+    }
+
+    #[test]
+    fn merge_with_fallback_is_empty_for_providers_without_a_fallback_list() {
+        assert!(merge_with_fallback("ollama", &[]).is_empty());
+        assert!(merge_with_fallback("openrouter", &[]).is_empty());
+    }
+
+    #[test]
+    fn filter_models_is_case_insensitive_substring_match() {
+        let models = vec!["Llama3:8b".to_string(), "gemma3:1b".to_string()];
+        let matches = filter_models(&models, "LLAMA");
+        assert_eq!(matches, vec![&models[0]]);
+    }
+
+    #[test]
+    fn filter_models_returns_everything_for_a_blank_query() {
+        let models = vec!["a".to_string(), "b".to_string()];
+        assert_eq!(filter_models(&models, "   ").len(), 2);
+    }
+
+    #[test]
+    fn format_size_mb_switches_units_at_one_gigabyte() {
+        assert_eq!(format_size_mb(512), "512 MB");
+        assert_eq!(format_size_mb(1024), "1.0 GB");
+        assert_eq!(format_size_mb(2560), "2.5 GB");
+    }
+}

--- a/meetily-gpui/src/views/settings/notifications.rs
+++ b/meetily-gpui/src/views/settings/notifications.rs
@@ -10,6 +10,7 @@
 //! must keep the JSON field names identical.
 
 use gpui_kit::component::{
+    button::Button,
     setting::{SettingField, SettingGroup, SettingItem, SettingPage},
     IconName,
 };
@@ -17,6 +18,7 @@ use gpui_kit::*;
 
 use super::state::{NotificationPreferences, NotificationSettings, SettingsCache};
 use super::SettingsView;
+use crate::notifications;
 
 pub fn page(view: &Entity<SettingsView>, cx: &mut Context<SettingsView>) -> SettingPage {
     let _ = cx;
@@ -115,6 +117,17 @@ pub fn page(view: &Entity<SettingsView>, cx: &mut Context<SettingsView>) -> Sett
                     |p, v| p.show_system_errors = v,
                 ),
             ]),
+        )
+        .group(
+            SettingGroup::new().title("Test").items(vec![SettingItem::render(
+                |_options, _window, _cx| {
+                    Button::new("send-test-notification")
+                        .outline()
+                        .label("Send test notification")
+                        .on_click(|_, _, cx| notifications::send_test_notification(cx))
+                        .into_any_element()
+                },
+            )]),
         )
 }
 

--- a/meetily-gpui/src/views/settings/state.rs
+++ b/meetily-gpui/src/views/settings/state.rs
@@ -178,6 +178,30 @@ pub struct SettingsCache {
 
     /// "light" | "dark" | "system".
     pub theme_pref: String,
+
+    /// Live-fetched summary model lists, keyed by provider id
+    /// ("openai"/"claude"/"groq"/"openrouter"/"ollama") — populated
+    /// on-demand by `fetch_provider_models` (mirrors `ModelSettingsModal`'s
+    /// per-provider `models`/`openaiModels`/... state).
+    pub provider_models: HashMap<String, Vec<String>>,
+    pub provider_models_loading: HashMap<String, bool>,
+    pub provider_models_error: HashMap<String, String>,
+
+    /// Ollama model manager (Settings → Summary, Ollama section): models
+    /// currently installed on the configured endpoint, mirroring
+    /// `OllamaModelsList`. `ollama_pull_progress` is modelName -> percent
+    /// for a pull currently in progress.
+    pub ollama_installed: Vec<meetily_core::ollama::OllamaModel>,
+    pub ollama_installed_loading: bool,
+    pub ollama_pull_progress: HashMap<String, u8>,
+    pub ollama_error: Option<String>,
+
+    /// Built-in AI model manager (Settings → Summary, "Built-in AI"
+    /// section): live status of the local llama.cpp models, mirroring
+    /// `BuiltInModelManager`. `builtin_download_progress` is modelName ->
+    /// percent for a download currently in progress.
+    pub builtin_models: Vec<meetily_core::summary::summary_engine::ModelInfo>,
+    pub builtin_download_progress: HashMap<String, u8>,
 }
 
 impl Global for SettingsCache {}
@@ -756,6 +780,280 @@ pub fn calendar_refresh(cx: &mut App, view: Entity<SettingsView>, source_id: Str
             });
             let _ = view.update(cx, |_, cx| cx.notify());
         }
+    })
+    .detach();
+}
+
+/// Fetch the live model list for `provider` (Settings → Summary's model
+/// picker) and cache it in `provider_models`. Mirrors
+/// `ModelSettingsModal`'s `fetchOllamaModels`/`loadOpenAIModels`/etc: keys
+/// (openai/claude/groq) are read from SQLite server-side rather than kept in
+/// the in-memory cache, since `SettingsCache` deliberately never holds
+/// plaintext API keys once saved (see its doc comment).
+pub fn fetch_provider_models(cx: &mut App, view: Entity<SettingsView>, provider: String) {
+    {
+        let cache = cx.global_mut::<SettingsCache>();
+        cache.provider_models_loading.insert(provider.clone(), true);
+        cache.provider_models_error.remove(&provider);
+    }
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let pool = services.pool();
+    let ollama_endpoint = SettingsCache::global(cx).summary.ollama_endpoint.clone();
+
+    let provider_for_task = provider.clone();
+    cx.spawn(async move |cx| {
+        let result: Result<Vec<String>, String> = io
+            .spawn(async move {
+                match provider_for_task.as_str() {
+                    "ollama" => {
+                        let endpoint = if ollama_endpoint.is_empty() { None } else { Some(ollama_endpoint) };
+                        meetily_core::ollama::get_ollama_models(endpoint)
+                            .await
+                            .map(|models| models.into_iter().map(|m| m.name).collect())
+                    }
+                    "openrouter" => meetily_core::openrouter::get_openrouter_models()
+                        .await
+                        .map(|models| models.into_iter().map(|m| m.id).collect()),
+                    "openai" | "claude" | "groq" => {
+                        let key = match &pool {
+                            Some(pool) => SettingsRepository::get_api_key(pool, &provider_for_task)
+                                .await
+                                .ok()
+                                .flatten(),
+                            None => None,
+                        };
+                        match provider_for_task.as_str() {
+                            "openai" => meetily_core::openai::openai::get_openai_models(key)
+                                .await
+                                .map(|models| models.into_iter().map(|m| m.id).collect()),
+                            "claude" => meetily_core::anthropic::anthropic::get_anthropic_models(key)
+                                .await
+                                .map(|models| models.into_iter().map(|m| m.id).collect()),
+                            "groq" => meetily_core::groq::groq::get_groq_models(key)
+                                .await
+                                .map(|models| models.into_iter().map(|m| m.id).collect()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    _ => Ok(Vec::new()),
+                }
+            })
+            .await
+            .unwrap_or_else(|_| Err("model list fetch task panicked".to_string()));
+
+        let _ = cx.update(|cx| {
+            cx.update_global::<SettingsCache, _>(|cache, _| {
+                cache.provider_models_loading.insert(provider.clone(), false);
+                match result {
+                    Ok(models) => {
+                        cache.provider_models.insert(provider.clone(), models);
+                        cache.provider_models_error.remove(&provider);
+                    }
+                    Err(e) => {
+                        log::warn!("settings: failed to fetch {} models: {}", provider, e);
+                        cache.provider_models_error.insert(provider, e);
+                    }
+                }
+            });
+        });
+        let _ = view.update(cx, |_, cx| cx.notify());
+    })
+    .detach();
+}
+
+/// Refresh the Ollama-installed model list (Settings → Summary, Ollama
+/// model manager) against the configured endpoint. Mirrors
+/// `fetchOllamaModels`.
+pub fn refresh_ollama_models(view: Entity<SettingsView>, cx: &mut App) {
+    cx.global_mut::<SettingsCache>().ollama_installed_loading = true;
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let ollama_endpoint = SettingsCache::global(cx).summary.ollama_endpoint.clone();
+
+    cx.spawn(async move |cx| {
+        let endpoint = if ollama_endpoint.is_empty() { None } else { Some(ollama_endpoint) };
+        let result = io.spawn(meetily_core::ollama::get_ollama_models(endpoint)).await;
+
+        let _ = cx.update(|cx| {
+            cx.update_global::<SettingsCache, _>(|cache, _| {
+                cache.ollama_installed_loading = false;
+                match result {
+                    Ok(Ok(models)) => {
+                        cache.ollama_installed = models;
+                        cache.ollama_error = None;
+                    }
+                    Ok(Err(e)) => {
+                        cache.ollama_installed = Vec::new();
+                        cache.ollama_error = Some(e);
+                    }
+                    Err(_) => {
+                        cache.ollama_error = Some("model list refresh task panicked".to_string());
+                    }
+                }
+            });
+        });
+        let _ = view.update(cx, |_, cx| cx.notify());
+    })
+    .detach();
+}
+
+/// Pull an Ollama model by name (Settings → Summary, Ollama model manager's
+/// "Download" button). Progress arrives via the `ollama-model-download-*`
+/// core events, mirrored into `ollama_pull_progress` by `SettingsView`.
+pub fn pull_ollama_model(cx: &mut App, view: &Entity<SettingsView>, model_name: String) {
+    let services = AppServices::global(cx);
+    let sink = services.sink.clone();
+    let io = services.io.clone();
+    let ollama_endpoint = SettingsCache::global(cx).summary.ollama_endpoint.clone();
+
+    {
+        let cache = cx.global_mut::<SettingsCache>();
+        cache.ollama_pull_progress.insert(model_name.clone(), 0);
+        cache.ollama_error = None;
+    }
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    io.spawn(async move {
+        let endpoint = if ollama_endpoint.is_empty() { None } else { Some(ollama_endpoint) };
+        if let Err(e) = meetily_core::ollama::pull_ollama_model_with_progress(sink, model_name.clone(), endpoint)
+            .await
+        {
+            log::warn!("settings: failed to pull Ollama model '{}': {}", model_name, e);
+        }
+    });
+}
+
+/// Delete an installed Ollama model, then refresh the installed list.
+pub fn delete_ollama_model(cx: &mut App, view: Entity<SettingsView>, model_name: String) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let ollama_endpoint = SettingsCache::global(cx).summary.ollama_endpoint.clone();
+
+    cx.spawn(async move |cx| {
+        let endpoint = if ollama_endpoint.is_empty() { None } else { Some(ollama_endpoint) };
+        let result = io
+            .spawn(meetily_core::ollama::delete_ollama_model(model_name.clone(), endpoint))
+            .await;
+
+        if let Ok(Err(e)) = &result {
+            log::warn!("settings: failed to delete Ollama model '{}': {}", model_name, e);
+        }
+        let _ = cx.update(|cx| {
+            refresh_ollama_models(view.clone(), cx);
+        });
+    })
+    .detach();
+}
+
+/// List the built-in AI models with live status (Settings → Summary,
+/// "Built-in AI" section). Mirrors `BuiltInModelManager.fetchModels`.
+pub fn refresh_builtin_models(view: Entity<SettingsView>, cx: &mut App) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let manager_slot = services.builtin_manager_slot();
+
+    cx.spawn(async move |cx| {
+        let result = io
+            .spawn(async move {
+                let manager = meetily_core::summary::summary_engine::service::ensure_manager(&manager_slot)
+                    .await?;
+                Ok::<_, String>(manager.list_models().await)
+            })
+            .await;
+
+        if let Ok(Ok(models)) = result {
+            let _ = cx.update(|cx| {
+                cx.update_global::<SettingsCache, _>(|cache, _| {
+                    cache.builtin_models = models;
+                });
+            });
+            let _ = view.update(cx, |_, cx| cx.notify());
+        } else if let Ok(Err(e)) = result {
+            log::warn!("settings: failed to list built-in AI models: {}", e);
+        }
+    })
+    .detach();
+}
+
+/// Download a built-in AI model. Progress arrives via
+/// `builtin-ai-download-progress`, mirrored by `SettingsView`, which also
+/// calls `refresh_builtin_models` once the download settles.
+pub fn download_builtin_model(cx: &mut App, view: &Entity<SettingsView>, model_name: String) {
+    let services = AppServices::global(cx);
+    let sink = services.sink.clone();
+    let io = services.io.clone();
+    let manager_slot = services.builtin_manager_slot();
+
+    cx.global_mut::<SettingsCache>()
+        .builtin_download_progress
+        .insert(model_name.clone(), 0);
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    io.spawn(async move {
+        match meetily_core::summary::summary_engine::service::ensure_manager(&manager_slot).await {
+            Ok(manager) => {
+                if let Err(e) = meetily_core::summary::summary_engine::service::download_builtin_ai_model(
+                    manager,
+                    model_name.clone(),
+                    sink,
+                )
+                .await
+                {
+                    log::warn!("settings: failed to download built-in AI model '{}': {}", model_name, e);
+                }
+            }
+            Err(e) => log::warn!("settings: built-in AI model manager unavailable: {}", e),
+        }
+    });
+}
+
+/// Cancel an in-progress built-in AI model download.
+pub fn cancel_builtin_download(cx: &mut App, view: Entity<SettingsView>, model_name: String) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let manager_slot = services.builtin_manager_slot();
+
+    cx.global_mut::<SettingsCache>()
+        .builtin_download_progress
+        .remove(&model_name);
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    io.spawn(async move {
+        if let Ok(manager) = meetily_core::summary::summary_engine::service::ensure_manager(&manager_slot).await {
+            if let Err(e) = manager.cancel_download(&model_name).await {
+                log::warn!("settings: failed to cancel built-in AI download '{}': {}", model_name, e);
+            }
+        }
+    });
+}
+
+/// Delete a downloaded (or corrupted) built-in AI model, then refresh the
+/// list.
+pub fn delete_builtin_model(view: Entity<SettingsView>, cx: &mut App, model_name: String) {
+    let services = AppServices::global(cx);
+    let io = services.io.clone();
+    let manager_slot = services.builtin_manager_slot();
+
+    cx.spawn(async move |cx| {
+        let result = io
+            .spawn(async move {
+                let manager = meetily_core::summary::summary_engine::service::ensure_manager(&manager_slot)
+                    .await?;
+                manager.delete_model(&model_name).await.map_err(|e| e.to_string())
+            })
+            .await;
+
+        if let Ok(Err(e)) = result {
+            log::warn!("settings: failed to delete built-in AI model: {}", e);
+        }
+        let _ = cx.update(|cx| {
+            refresh_builtin_models(view.clone(), cx);
+        });
     })
     .detach();
 }

--- a/meetily-gpui/src/views/settings/summary.rs
+++ b/meetily-gpui/src/views/settings/summary.rs
@@ -27,17 +27,22 @@
 //!   writes (`primaryLanguage`/`showConfidenceIndicator`/`isAutoSummary`).
 
 use gpui_kit::component::{
+    button::Button,
+    combobox::{Combobox, ComboboxEvent, ComboboxState},
     h_flex,
     input::{Input, InputContentType, InputEvent, InputState},
     label::Label,
+    searchable_list::SearchableVec,
     setting::{SettingField, SettingGroup, SettingItem, SettingPage},
-    ActiveTheme, Icon, Sizable as _,
+    v_flex,
+    ActiveTheme, Disableable, Icon, IndexPath, Sizable as _,
 };
 use gpui_kit::*;
 
-use meetily_core::summary::summary_engine::models::get_available_models;
+use meetily_core::summary::summary_engine::{model_manager::ModelStatus as BuiltinModelStatus, models::get_available_models};
 use meetily_core::summary::CustomOpenAIConfig;
 
+use super::model_utils::{format_size_mb, merge_with_fallback};
 use super::state::SettingsCache;
 use super::SettingsView;
 
@@ -107,38 +112,48 @@ pub fn page(view: &Entity<SettingsView>, cx: &mut Context<SettingsView>) -> Sett
             ]),
         );
 
+    let is_ollama = provider == "ollama";
+
     if is_custom_openai {
         page = page.group(custom_openai_group(&view));
-    } else {
+    } else if is_builtin {
+        // No plain Model field for built-in AI — selection happens by
+        // clicking a row in the manager list below (mirrors
+        // `ModelSettingsModal` swapping the Model field for
+        // `<BuiltInModelManager>` on this provider).
+        let _ = model_options;
+    } else if is_ollama {
         page = page.group(
-            SettingGroup::new().title("Model").items(vec![
+            SettingGroup::new().title("Model").item(
                 SettingItem::new(
                     "Model",
-                    if is_builtin {
-                        SettingField::dropdown(
-                            model_options,
-                            |cx: &App| SharedString::from(SettingsCache::global(cx).summary.model.clone()),
-                            {
-                                let view = view.clone();
-                                move |val: SharedString, cx: &mut App| {
-                                    set_summary(cx, &view, |cfg| cfg.model = val.to_string());
-                                }
-                            },
-                        )
-                    } else {
-                        SettingField::input(
-                            |cx: &App| SharedString::from(SettingsCache::global(cx).summary.model.clone()),
-                            {
-                                let view = view.clone();
-                                move |val: SharedString, cx: &mut App| {
-                                    set_summary(cx, &view, |cfg| cfg.model = val.to_string());
-                                }
-                            },
-                        )
-                    },
+                    SettingField::dropdown(
+                        SettingsCache::global(cx)
+                            .ollama_installed
+                            .iter()
+                            .map(|m| (SharedString::from(m.name.clone()), SharedString::from(m.name.clone())))
+                            .collect(),
+                        |cx: &App| SharedString::from(SettingsCache::global(cx).summary.model.clone()),
+                        {
+                            let view = view.clone();
+                            move |val: SharedString, cx: &mut App| {
+                                set_summary(cx, &view, |cfg| cfg.model = val.to_string());
+                            }
+                        },
+                    ),
                 )
-                .description("Built-in AI runs entirely on-device; other providers send transcripts out."),
-            ]),
+                .description("Installed on the Ollama endpoint below. Manage models in the section further down."),
+            ),
+        );
+    } else {
+        // Cloud provider (openai/claude/groq/openrouter): a searchable
+        // picker populated live from that provider's model-list API,
+        // falling back to a static list when unfetched or the fetch fails
+        // — mirrors `ModelSettingsModal`'s `ProviderModelPicker`.
+        page = page.group(
+            SettingGroup::new()
+                .title("Model")
+                .item(cloud_model_picker_item(&view, provider.clone())),
         );
     }
 
@@ -160,6 +175,14 @@ pub fn page(view: &Entity<SettingsView>, cx: &mut Context<SettingsView>) -> Sett
             .description("Used only when the provider above is set to Ollama."),
         ),
     );
+
+    if is_ollama {
+        page = page.group(ollama_manager_group(&view));
+    }
+
+    if is_builtin {
+        page = page.group(builtin_manager_group(&view));
+    }
 
     let mut key_items = Vec::new();
     for (id, label) in API_KEY_PROVIDERS {
@@ -412,4 +435,381 @@ fn custom_openai_group(view: &Entity<SettingsView>) -> SettingGroup {
             )
             .description("Optional — leave blank if the server doesn't require one."),
         ])
+}
+
+/// Searchable model picker for a cloud provider (openai/claude/groq/
+/// openrouter), backed by that provider's live model list
+/// (`SettingsCache::provider_models`) with a static fallback — mirrors
+/// `ProviderModelPicker`. Triggers the fetch itself the first time it's
+/// rendered for `provider` (React's "auto-fetch on initial load only").
+fn cloud_model_picker_item(view: &Entity<SettingsView>, provider: String) -> SettingItem {
+    let view = view.clone();
+    SettingItem::new(
+        "Model",
+        SettingField::render(move |_options, window, cx| {
+            let cache = SettingsCache::global(cx);
+            let fetched = cache.provider_models.get(&provider).cloned().unwrap_or_default();
+            let loading = cache.provider_models_loading.get(&provider).copied().unwrap_or(false);
+            let error = cache.provider_models_error.get(&provider).cloned();
+            let current_model = cache.summary.model.clone();
+
+            // Trigger the live fetch exactly once per provider (not on
+            // every render) — a `use_keyed_state` marker entity whose init
+            // closure only runs the first time this key is seen.
+            struct FetchTrigger;
+            let _ = window.use_keyed_state(
+                SharedString::from(format!("summary-cloud-model-fetch-{}", provider)),
+                cx,
+                {
+                    let view = view.clone();
+                    let provider = provider.clone();
+                    move |_window, cx: &mut Context<FetchTrigger>| {
+                        super::state::fetch_provider_models(cx, view.clone(), provider.clone());
+                        FetchTrigger
+                    }
+                },
+            );
+
+            let options = merge_with_fallback(&provider, &fetched);
+
+            struct ModelComboState {
+                combo: Entity<ComboboxState<SearchableVec<String>>>,
+                _subscription: Subscription,
+            }
+
+            // Re-key on the *fetched* count (not the merged list, which
+            // already shows the static fallback at a stable length) so a
+            // fresh combobox — with the live results as its options — is
+            // built exactly once the fetch resolves.
+            let combo_key = SharedString::from(format!(
+                "summary-cloud-model-combobox-{}-{}",
+                provider,
+                fetched.len()
+            ));
+            let state = window.use_keyed_state(combo_key, cx, {
+                let view = view.clone();
+                let options = options.clone();
+                let current_model = current_model.clone();
+                move |window, cx| {
+                    let selected = options
+                        .iter()
+                        .position(|m| *m == current_model)
+                        .map(|ix| vec![IndexPath::default().row(ix)])
+                        .unwrap_or_default();
+                    let delegate = SearchableVec::new(options.clone());
+                    let combo =
+                        cx.new(|cx| ComboboxState::new(delegate, selected, window, cx).searchable(true));
+                    let subscription = cx.subscribe(&combo, {
+                        let view = view.clone();
+                        move |_, _, event: &ComboboxEvent<SearchableVec<String>>, cx| {
+                            if let ComboboxEvent::Confirm(values) = event {
+                                if let Some(model) = values.first() {
+                                    let model = model.clone();
+                                    set_summary(cx, &view, |cfg| cfg.model = model);
+                                }
+                            }
+                        }
+                    });
+                    ModelComboState { combo, _subscription: subscription }
+                }
+            });
+            let combo_entity = state.read(cx).combo.clone();
+
+            v_flex()
+                .w_full()
+                .gap_1()
+                .child(
+                    Combobox::new(&combo_entity)
+                        .placeholder("Select a model")
+                        .search_placeholder("Search models…")
+                        .cleanable(false),
+                )
+                .children(loading.then(|| {
+                    Label::new("Loading models…").text_xs().text_color(cx.theme().muted_foreground)
+                }))
+                .children(error.map(|e| {
+                    Label::new(format!("Couldn't fetch live models — showing a fallback list ({e}).",))
+                        .text_xs()
+                        .text_color(cx.theme().danger)
+                }))
+                .into_any_element()
+        }),
+    )
+}
+
+/// Ollama model manager (mirrors `OllamaModelsList` + the pull/delete
+/// actions from `ModelSettingsModal`): pull a model by name (progress via
+/// `ollama-model-download-*` events), and list/delete what's installed on
+/// the configured endpoint.
+fn ollama_manager_group(view: &Entity<SettingsView>) -> SettingGroup {
+    let view = view.clone();
+
+    SettingGroup::new()
+        .title("Ollama models")
+        .description("Models installed on the endpoint above.")
+        .item(SettingItem::render({
+            let view = view.clone();
+            move |_options, window, cx| {
+                struct FetchTrigger;
+                let _ = window.use_keyed_state(
+                    SharedString::from("summary-ollama-models-fetch"),
+                    cx,
+                    {
+                        let view = view.clone();
+                        move |_window, cx: &mut Context<FetchTrigger>| {
+                            super::state::refresh_ollama_models(view.clone(), cx);
+                            FetchTrigger
+                        }
+                    },
+                );
+
+                let cache = SettingsCache::global(cx);
+                let loading = cache.ollama_installed_loading;
+                let error = cache.ollama_error.clone();
+                let installed = cache.ollama_installed.clone();
+                let pull_progress = cache.ollama_pull_progress.clone();
+                let selected_model = cache.summary.model.clone();
+
+                struct PullInputState {
+                    input: Entity<InputState>,
+                    _subscription: Subscription,
+                }
+                let pull_state = window.use_keyed_state(SharedString::from("summary-ollama-pull-input"), cx, {
+                    move |window, cx| {
+                        let input = cx.new(|cx| InputState::new(window, cx).placeholder("Model name, e.g. gemma3:1b"));
+                        let subscription = cx.subscribe(&input, |_, _, _: &InputEvent, _| {});
+                        PullInputState { input, _subscription: subscription }
+                    }
+                });
+                let pull_input = pull_state.read(cx).input.clone();
+                let pull_value = pull_input.read(cx).value().to_string();
+
+                struct SearchInputState {
+                    input: Entity<InputState>,
+                    _subscription: Subscription,
+                }
+                let search_state = window.use_keyed_state(SharedString::from("summary-ollama-search-input"), cx, {
+                    move |window, cx| {
+                        let input = cx.new(|cx| InputState::new(window, cx).placeholder("Search installed models…"));
+                        let subscription = cx.subscribe(&input, |_, _, _: &InputEvent, _| {});
+                        SearchInputState { input, _subscription: subscription }
+                    }
+                });
+                let search_input = search_state.read(cx).input.clone();
+                let search_value = search_input.read(cx).value().to_string();
+                let installed_names: Vec<String> = installed.iter().map(|m| m.name.clone()).collect();
+                let visible_names = super::model_utils::filter_models(&installed_names, &search_value);
+
+                let mut column = v_flex().w_full().gap_3();
+
+                column = column.child(
+                    h_flex()
+                        .w_full()
+                        .gap_2()
+                        .items_center()
+                        .child(Input::new(&pull_input).small().flex_1())
+                        .child(Button::new("ollama-pull").outline().label("Pull model").disabled(pull_value.trim().is_empty()).on_click({
+                            let view = view.clone();
+                            move |_, _, cx| {
+                                let name = pull_value.trim().to_string();
+                                if !name.is_empty() {
+                                    super::state::pull_ollama_model(cx, &view, name);
+                                }
+                            }
+                        })),
+                );
+
+                if !installed.is_empty() {
+                    column = column.child(Input::new(&search_input).small());
+                }
+
+                if let Some(e) = &error {
+                    column = column.child(Label::new(e.clone()).text_xs().text_color(cx.theme().danger));
+                }
+
+                if loading && installed.is_empty() {
+                    column = column.child(Label::new("Loading installed models…").text_xs().text_color(cx.theme().muted_foreground));
+                } else if installed.is_empty() {
+                    column = column.child(Label::new("No models installed yet.").text_xs().text_color(cx.theme().muted_foreground));
+                } else if visible_names.is_empty() {
+                    column = column.child(Label::new("No installed models match your search.").text_xs().text_color(cx.theme().muted_foreground));
+                } else {
+                    for model in installed.iter().filter(|m| visible_names.iter().any(|n| **n == m.name)) {
+                        let name = model.name.clone();
+                        let progress = pull_progress.get(&name).copied();
+                        let is_selected = selected_model == name;
+                        let delete_view = view.clone();
+                        let delete_name = name.clone();
+
+                        let mut row = h_flex()
+                            .w_full()
+                            .justify_between()
+                            .items_center()
+                            .gap_3()
+                            .child(
+                                v_flex()
+                                    .gap_1()
+                                    .child(Label::new(name.clone()).text_sm())
+                                    .child(
+                                        Label::new(if let Some(pct) = progress {
+                                            format!("{} · downloading… {}%", model.size, pct)
+                                        } else if is_selected {
+                                            format!("{} · selected", model.size)
+                                        } else {
+                                            model.size.clone()
+                                        })
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground),
+                                    ),
+                            );
+                        row = row.child(
+                            Button::new(SharedString::from(format!("ollama-delete-{}", name)))
+                                .outline()
+                                .label("Delete")
+                                .disabled(progress.is_some())
+                                .on_click(move |_, _, cx| {
+                                    super::state::delete_ollama_model(cx, delete_view.clone(), delete_name.clone());
+                                }),
+                        );
+                        column = column.child(row);
+                    }
+                }
+
+                column.into_any_element()
+            }
+        }))
+}
+
+/// Built-in AI model manager (mirrors `BuiltInModelManager`): live status
+/// of the local llama.cpp models, with download/cancel/delete.
+fn builtin_manager_group(view: &Entity<SettingsView>) -> SettingGroup {
+    let view = view.clone();
+
+    SettingGroup::new()
+        .title("Built-in AI models")
+        .description("Runs entirely on-device; nothing leaves your machine.")
+        .item(SettingItem::render({
+            let view = view.clone();
+            move |_options, window, cx| {
+                struct FetchTrigger;
+                let _ = window.use_keyed_state(SharedString::from("summary-builtin-models-fetch"), cx, {
+                    let view = view.clone();
+                    move |_window, cx: &mut Context<FetchTrigger>| {
+                        super::state::refresh_builtin_models(view.clone(), cx);
+                        FetchTrigger
+                    }
+                });
+
+                let cache = SettingsCache::global(cx);
+                let models = cache.builtin_models.clone();
+                let progress = cache.builtin_download_progress.clone();
+                let selected_model = cache.summary.model.clone();
+
+                if models.is_empty() {
+                    return Label::new("Loading built-in AI models…")
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .into_any_element();
+                }
+
+                let mut column = v_flex().w_full().gap_3();
+                for model in &models {
+                    let name = model.name.clone();
+                    let is_available = matches!(model.status, BuiltinModelStatus::Available);
+                    let is_downloading = progress.contains_key(&name)
+                        || matches!(model.status, BuiltinModelStatus::Downloading { .. });
+                    let pct = progress.get(&name).copied();
+                    let is_selected = selected_model == name;
+
+                    let status_text = match (&model.status, pct) {
+                        (_, Some(p)) => format!("Downloading… {}%", p),
+                        (BuiltinModelStatus::Available, _) => {
+                            if is_selected { "Ready · selected".to_string() } else { "Ready".to_string() }
+                        }
+                        (BuiltinModelStatus::NotDownloaded, _) => "Not downloaded".to_string(),
+                        (BuiltinModelStatus::Downloading { progress }, _) => format!("Downloading… {}%", progress),
+                        (BuiltinModelStatus::Corrupted { .. }, _) => "Corrupted — re-download".to_string(),
+                        (BuiltinModelStatus::Error(e), _) => format!("Error: {}", e),
+                    };
+
+                    let mut row = h_flex()
+                        .w_full()
+                        .justify_between()
+                        .items_center()
+                        .gap_3()
+                        .child(
+                            v_flex()
+                                .gap_1()
+                                .child(Label::new(model.display_name.clone()).text_sm())
+                                .child(
+                                    Label::new(format!("{} · {}", format_size_mb(model.size_mb), status_text))
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground),
+                                ),
+                        );
+
+                    let mut actions = h_flex().gap_2();
+                    if is_available && !is_downloading {
+                        if !is_selected {
+                            let select_view = view.clone();
+                            let select_name = name.clone();
+                            actions = actions.child(
+                                Button::new(SharedString::from(format!("builtin-select-{}", name)))
+                                    .outline()
+                                    .label("Select")
+                                    .on_click(move |_, _, cx| {
+                                        set_summary(
+                                            cx,
+                                            &select_view,
+                                            |cfg| cfg.model = select_name.clone(),
+                                        );
+                                    }),
+                            );
+                        }
+                        let delete_view = view.clone();
+                        let delete_name = name.clone();
+                        actions = actions.child(
+                            Button::new(SharedString::from(format!("builtin-delete-{}", name)))
+                                .outline()
+                                .label("Delete")
+                                .on_click(move |_, _, cx| {
+                                    super::state::delete_builtin_model(delete_view.clone(), cx, delete_name.clone());
+                                }),
+                        );
+                    } else if is_downloading {
+                        let cancel_view = view.clone();
+                        let cancel_name = name.clone();
+                        actions = actions.child(
+                            Button::new(SharedString::from(format!("builtin-cancel-{}", name)))
+                                .outline()
+                                .label("Cancel")
+                                .on_click(move |_, _, cx| {
+                                    super::state::cancel_builtin_download(cx, cancel_view.clone(), cancel_name.clone());
+                                }),
+                        );
+                    } else {
+                        let download_view = view.clone();
+                        let download_name = name.clone();
+                        let label = if matches!(model.status, BuiltinModelStatus::Corrupted { .. }) {
+                            "Re-download"
+                        } else {
+                            "Download"
+                        };
+                        actions = actions.child(
+                            Button::new(SharedString::from(format!("builtin-download-{}", name)))
+                                .outline()
+                                .label(label)
+                                .on_click(move |_, _, cx| {
+                                    super::state::download_builtin_model(cx, &download_view, download_name.clone());
+                                }),
+                        );
+                    }
+
+                    row = row.child(actions);
+                    column = column.child(row);
+                }
+
+                column.into_any_element()
+            }
+        }))
 }

--- a/meetily-gpui/src/views/settings/transcription.rs
+++ b/meetily-gpui/src/views/settings/transcription.rs
@@ -95,10 +95,50 @@ fn model_row(view: &Entity<SettingsView>, model: meetily_core::whisper_engine::M
         };
 
         let is_downloading = matches!(status, ModelStatus::Downloading { .. }) || progress.is_some();
-        let can_download = !matches!(status, ModelStatus::Available) && !is_downloading;
+        let is_corrupted = matches!(status, ModelStatus::Corrupted { .. });
+        let is_available = matches!(status, ModelStatus::Available);
+        let can_download = !is_available && !is_downloading;
 
         let download_name = name.clone();
         let download_view = view.clone();
+
+        let mut actions = h_flex().gap_2();
+
+        if is_downloading {
+            let cancel_name = name.clone();
+            let cancel_view = view.clone();
+            actions = actions.child(
+                Button::new(SharedString::from(format!("cancel-{}", name)))
+                    .outline()
+                    .label("Cancel")
+                    .on_click(move |_, _, cx| {
+                        cancel_download(cx, &cancel_view, cancel_name.clone());
+                    }),
+            );
+        } else {
+            actions = actions.child(
+                Button::new(SharedString::from(format!("download-{}", name)))
+                    .outline()
+                    .label(if is_corrupted { "Re-download" } else { "Download" })
+                    .disabled(!can_download)
+                    .on_click(move |_, _, cx| {
+                        start_download(cx, &download_view, download_name.clone());
+                    }),
+            );
+        }
+
+        if (is_available || is_corrupted) && !is_downloading {
+            let delete_name = name.clone();
+            let delete_view = view.clone();
+            actions = actions.child(
+                Button::new(SharedString::from(format!("delete-{}", name)))
+                    .outline()
+                    .label("Delete")
+                    .on_click(move |_, _, cx| {
+                        delete_model(cx, &delete_view, delete_name.clone());
+                    }),
+            );
+        }
 
         h_flex()
             .w_full()
@@ -115,15 +155,7 @@ fn model_row(view: &Entity<SettingsView>, model: meetily_core::whisper_engine::M
                             .text_color(cx.theme().muted_foreground),
                     ),
             )
-            .child(
-                Button::new(SharedString::from(format!("download-{}", name)))
-                    .outline()
-                    .label(if is_downloading { "Downloading…" } else { "Download" })
-                    .disabled(!can_download)
-                    .on_click(move |_, _, cx| {
-                        start_download(cx, &download_view, download_name.clone());
-                    }),
-            )
+            .child(actions)
             .into_any_element()
     })
 }
@@ -148,4 +180,44 @@ fn start_download(cx: &mut App, view: &Entity<SettingsView>, model_name: String)
             log::warn!("settings: failed to download model '{}': {}", model_name, e);
         }
     });
+}
+
+/// Cancel an in-progress Whisper model download.
+fn cancel_download(cx: &mut App, view: &Entity<SettingsView>, model_name: String) {
+    let services = crate::app_state::AppServices::global(cx);
+    let io = services.io.clone();
+
+    {
+        let cache = cx.global_mut::<SettingsCache>();
+        cache.download_progress.remove(&model_name);
+    }
+    let _ = view.update(cx, |_, cx| cx.notify());
+
+    io.spawn(async move {
+        if let Err(e) = meetily_core::whisper_engine::whisper_cancel_download(model_name.clone()).await {
+            log::warn!("settings: failed to cancel model download '{}': {}", model_name, e);
+        }
+    });
+}
+
+/// Delete a downloaded (or corrupted) Whisper model, then re-scan the
+/// catalog so its status flips back to Missing.
+fn delete_model(cx: &mut App, view: &Entity<SettingsView>, model_name: String) {
+    let services = crate::app_state::AppServices::global(cx);
+    let io = services.io.clone();
+    let view = view.clone();
+
+    cx.spawn(async move |cx| {
+        let result = io
+            .spawn(meetily_core::whisper_engine::whisper_delete_corrupted_model(model_name.clone()))
+            .await;
+
+        if let Ok(Err(e)) = result {
+            log::warn!("settings: failed to delete model '{}': {}", model_name, e);
+        }
+        let _ = cx.update(|cx| {
+            super::state::load(view.clone(), cx);
+        });
+    })
+    .detach();
 }


### PR DESCRIPTION
## Description

Closes the remaining feature gaps between the React/Tauri app and the GPUI app (`meetily-gpui`), and fixes two serious bugs found while testing a real recording.

### Two bug fixes (one is data loss, and affected the Tauri app too)

**Auto-refine could wipe a meeting's transcript.** After a recording stopped, the post-meeting refine re-ran speech detection over the saved audio, found nothing usable, and replaced the live transcript with zero segments — in the database *and* `transcripts.json`.

- **Cause:** sherpa's VAD updates its speech/silence state once per `accept_waveform` call (the OR of every 512-sample window in that call), so the size of the call decides segment granularity. The batch path passed the whole recording in one call (< 60 s) or 10 s slices (longer).
- **Measured on a real 22 s recording:** whole-buffer → 1 bogus 0.3 s segment at the very end; 1 s calls → the two utterances merged; 10 s calls → first utterance lost; 512-sample calls → both utterances, correct.
- **Fix:** `vad.rs` feeds sherpa exactly one silero window per call, so results no longer depend on slicing. This affects retranscription, auto-refine, import and voice enrollment; live capture (800-sample calls) gets finer boundaries too.
- **Guard:** `retranscription.rs` now refuses to replace an existing transcript with an empty result.

**GPUI crash when retranscription finished** (and the same bug on import): a toast raised from a core-event callback went through `WindowHandle<Root>::update`, which leases `Root` while gpui-kit's `push_notification` / `close_dialog` update `Root` again — "cannot update Root while it is already being updated". New `ui::with_main_window` uses the untyped window handle.

### Parity work

- **Meeting page**: notes panel; that meeting's action items (check off/edit/add/delete, plus extract-from-summary); confidence indicator on transcript segments (gated by the existing `showConfidenceIndicator` setting); typewriter reveal for streamed summaries (respects reduced-motion).
- **Recording**: live action-item extraction during a recording (beta-gated as in React); auto-links the calendar event happening now and prefills the meeting title.
- **Tray**: pause/resume, Settings shortcut, and a working "Check for updates" (GitHub releases + semver compare). The Tauri tray's version was dead code — it dispatched a JS event nothing listened for.
- **Notifications**: full parity with the Tauri set (started/stopped/paused/resumed, transcription complete, system error), each gated by the same stored `NotificationPreferences`; calendar meeting reminders (also dead code in Tauri — `show_meeting_reminder` was never called); "Send test notification" button.
- **Settings**: live model lists for OpenAI/Claude/Groq/OpenRouter/Ollama via searchable pickers (falling back to static lists on error); Ollama pull/delete manager; built-in AI model download/cancel/delete; Whisper cancel-download and delete; "Show MCP binary in file manager".

### Schema

New migration `20260911000000_add_confidence_to_transcripts.sql` adds a **nullable** `confidence REAL` column so the live Whisper confidence survives a save (React only had it in memory). Older rows stay NULL and render no indicator, matching the React behaviour. Both apps run on the migrated database.

## Type of Change
- [x] Bug fix (transcript data loss; GPUI crash)
- [x] New feature (parity items above)

## Testing
- [x] All tests pass: meetily-core 304 (+3 ignored), meetily-gpui 134, Tauri shell 3, 1 doctest. `cargo tree -p meetily-core | grep -i tauri` empty.
- [x] Manual: the VAD fix was verified against a real recording (see numbers above). Both apps were run against the real data dir after the migration — the Tauri app lists all 81 meetings; the GPUI app starts clean with tray and sidebar.
- [ ] Not exercised by hand: most new UI paths (automated runs never click the UI, use the mic, or spend API credits).

## Additional Notes
- `./dev.sh gpui` on CUDA was broken (the sidecar was built without `CMAKE_POSITION_INDEPENDENT_CODE=ON`, so rust-lld rejected llama.cpp's non-PIC CUDA objects). It now builds the helper in release with the same flags `build.sh` uses and passes it via `MEETILY_LLAMA_HELPER`; the core's dev-mode sidecar lookup no longer assumes the app crate sits two levels below the workspace root.
- The AppImage no longer bundles the NVIDIA driver libraries (`libcuda`, `libnvidia-*`), which must come from the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTLuKqNphAxzHZRVqUArf3
