### PR TITLE
Window behaviour: tray re-open, one close policy, system decorations

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -49,9 +49,17 @@ setup_common_env() {
     #   - zbus / tracing / wgpu / naga at warn → D-Bus (tray, portals) and
     #                          GPU-backend chatter the GPUI shell would
     #                          otherwise log at INFO on every tray poll
+    #   - wgpu_hal::vulkan::instance at error → the Vulkan loader warns once
+    #                          per incompatible ICD it skips (e.g. Mesa's
+    #                          dzn/D3D12 shim on a normal Linux box), which
+    #                          is expected and not actionable
+    #   - gpui_component::theme::mono_font at error → gpui-kit warns when its
+    #                          hard-coded default mono font is missing, from
+    #                          inside its own init; we replace the family with
+    #                          the desktop's a moment later (see fonts.rs)
     #   - everything else at info
     # Override by exporting RUST_LOG before invoking dev.sh.
-    export RUST_LOG="${RUST_LOG:-info,whisper_rs=warn,zbus=warn,tracing=warn,wgpu_hal=warn,wgpu_core=warn,naga=warn}"
+    export RUST_LOG="${RUST_LOG:-info,whisper_rs=warn,zbus=warn,tracing=warn,wgpu_hal=warn,wgpu_core=warn,naga=warn,wgpu_hal::vulkan::instance=error,gpui_component::theme::mono_font=error}"
 
     if command -v sccache >/dev/null 2>&1; then
         export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"

--- a/meetily-gpui/src/fonts.rs
+++ b/meetily-gpui/src/fonts.rs
@@ -1,0 +1,119 @@
+//! Match the desktop's monospace font.
+//!
+//! gpui-kit's Linux default is "DejaVu Sans Mono"; when that isn't installed
+//! it probes for a stand-in and logs a warning. Rather than let it guess, ask
+//! the desktop what monospace font the user actually chose, so code blocks
+//! and transcripts match the rest of their system.
+//!
+//! Only applied when the family is really installed: GPUI panics on the first
+//! line laid out in a family it can't find, so a stale setting must never
+//! reach the theme.
+
+use gpui_kit::App;
+use gpui_kit::component::Theme;
+
+/// Apply the desktop's configured monospace family to the theme, if we can
+/// find one that's installed. No-op otherwise, leaving gpui-kit's own
+/// fallback probe in charge.
+pub fn apply_system_mono_font(cx: &mut App) {
+    let Some(family) = system_mono_family() else {
+        return;
+    };
+
+    // GPUI panics laying out text in a family it can't load, so only take the
+    // desktop's answer if the font system actually knows it.
+    let installed = cx
+        .text_system()
+        .all_font_names()
+        .iter()
+        .any(|name| name == &family);
+    if !installed {
+        log::debug!("System monospace font {family:?} isn't installed; keeping the default");
+        return;
+    }
+
+    log::info!("Using the desktop's monospace font: {family}");
+    cx.global_mut::<Theme>().mono_font_family = family.into();
+}
+
+/// The desktop's monospace family: the GNOME/GTK setting where present,
+/// otherwise fontconfig's `monospace` alias. `None` if neither answers.
+fn system_mono_family() -> Option<String> {
+    gsettings_mono_family().or_else(fontconfig_mono_family)
+}
+
+/// `org.gnome.desktop.interface monospace-font-name` — a Pango description
+/// like `'Adwaita Mono 11'`, i.e. quoted, with a trailing size to strip.
+fn gsettings_mono_family() -> Option<String> {
+    let out = std::process::Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.interface", "monospace-font-name"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(out.stdout).ok()?;
+    strip_pango_size(value.trim().trim_matches('\''))
+}
+
+/// `fc-match monospace family` — the portable answer for non-GNOME desktops.
+fn fontconfig_mono_family() -> Option<String> {
+    let out = std::process::Command::new("fc-match")
+        .args(["monospace", "family"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(out.stdout).ok()?;
+    // fc-match can return a comma-separated alias list ("Noto Sans Mono,Noto Sans Mono Regular").
+    let family = value.trim().split(',').next()?.trim().to_string();
+    (!family.is_empty()).then_some(family)
+}
+
+/// Drop a Pango trailing size ("Adwaita Mono 11" -> "Adwaita Mono"), keeping
+/// families that merely end in a digit ("M+ 1m", "Go Mono 2").
+fn strip_pango_size(desc: &str) -> Option<String> {
+    let desc = desc.trim();
+    if desc.is_empty() {
+        return None;
+    }
+    let family = match desc.rsplit_once(' ') {
+        // Only a bare integer is a size; "M+ 1m" keeps its last word.
+        Some((head, tail)) if !head.is_empty() && tail.parse::<u32>().is_ok() => head.trim(),
+        _ => desc,
+    };
+    (!family.is_empty()).then(|| family.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_pango_size;
+
+    #[test]
+    fn strips_a_trailing_point_size() {
+        // Quotes are stripped by the caller, so this only sees bare
+        // descriptions.
+        assert_eq!(strip_pango_size("Adwaita Mono 11").as_deref(), Some("Adwaita Mono"));
+        assert_eq!(
+            strip_pango_size("Source Code Pro 10").as_deref(),
+            Some("Source Code Pro")
+        );
+    }
+
+    #[test]
+    fn keeps_families_without_a_size() {
+        assert_eq!(strip_pango_size("Hack").as_deref(), Some("Hack"));
+        assert_eq!(strip_pango_size("JetBrains Mono").as_deref(), Some("JetBrains Mono"));
+    }
+
+    #[test]
+    fn keeps_a_family_whose_last_word_only_contains_a_digit() {
+        assert_eq!(strip_pango_size("M+ 1m").as_deref(), Some("M+ 1m"));
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert_eq!(strip_pango_size("   "), None);
+    }
+}

--- a/meetily-gpui/src/main.rs
+++ b/meetily-gpui/src/main.rs
@@ -4,6 +4,7 @@
 
 mod app_state;
 mod core_events;
+mod fonts;
 mod notifications;
 mod recovery;
 mod root;
@@ -32,7 +33,8 @@ static QUIT_STARTED: AtomicBool = AtomicBool::new(false);
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(
-        "info,whisper_rs=warn,zbus=warn,tracing=warn,wgpu_hal=warn,wgpu_core=warn,naga=warn",
+        "info,whisper_rs=warn,zbus=warn,tracing=warn,wgpu_hal=warn,wgpu_core=warn,naga=warn,\
+         wgpu_hal::vulkan::instance=error,gpui_component::theme::mono_font=error",
     ))
     .init();
 
@@ -84,6 +86,9 @@ fn main() {
     app.run(move |cx| {
         gpui_kit::init(cx);
         zorite_editor::bind_keys(cx);
+        // After `gpui_kit::init` (which sets the Theme global), before any
+        // text is laid out.
+        fonts::apply_system_mono_font(cx);
 
         let core_events = cx.new(|cx| CoreEvents::new(events_rx, cx));
         cx.set_global(io.clone());

--- a/meetily-gpui/src/main.rs
+++ b/meetily-gpui/src/main.rs
@@ -11,12 +11,12 @@ mod runtime;
 mod shell;
 mod tray;
 mod ui;
+mod window;
 mod views;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
-use gpui_kit::component::{Root, TitleBar};
 use gpui_kit::*;
 use meetily_core::bootstrap;
 use meetily_core::database::setup::StartupOutcome;
@@ -24,7 +24,6 @@ use meetily_core::events::SharedEventSink;
 
 use app_state::AppServices;
 use core_events::CoreEvents;
-use root::RootView;
 use runtime::Io;
 
 /// Set once a close/quit request has started finishing the recording, so a
@@ -96,28 +95,14 @@ fn main() {
             builtin_manager,
         });
 
-        let mut window_options = TitleBar::window_options();
-        window_options.window_bounds = Some(WindowBounds::centered(size(px(1100.), px(720.)), cx));
-        window_options.window_decorations = Some(WindowDecorations::Client);
-
         cx.spawn(async move |cx| {
-            let window = cx
-                .open_window(window_options, |window, cx| {
-                    let view = cx.new(|cx| RootView::new(window, cx));
-                    cx.new(|cx| Root::new(view, window, cx))
-                })
-                .expect("failed to open window");
+            let _ = cx.update(|cx| {
+                // Opens the window and registers its theme + close handler;
+                // also stores the `MainWindow` handle the tray reaches for.
+                if let Err(e) = window::open_main_window(cx) {
+                    log::error!("Failed to open the main window: {}", e);
+                }
 
-            let _ = window.update(cx, |_, window, cx| {
-                views::settings::init_theme(window, cx);
-                window.on_window_should_close(cx, |_, cx| {
-                    request_quit(cx);
-                    false
-                });
-            });
-
-            cx.update(|cx| {
-                cx.set_global(tray::MainWindow(window));
                 if let Err(e) = tray::install(cx) {
                     log::warn!(
                         "Tray unavailable (no StatusNotifierItem host?), continuing without one: {}",

--- a/meetily-gpui/src/shell/mod.rs
+++ b/meetily-gpui/src/shell/mod.rs
@@ -14,6 +14,7 @@ use gpui_kit::component::{
     input::{Input, InputEvent, InputState},
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarMenu, SidebarMenuItem},
 };
+use gpui_kit::prelude::FluentBuilder as _;
 use gpui_kit::*;
 use meetily_core::database::models::MeetingModel;
 use meetily_core::database::repositories::meeting::MeetingsRepository;
@@ -396,7 +397,7 @@ fn meeting_row(model: MeetingModel) -> MeetingRow {
 }
 
 impl Render for AppShell {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let page: AnyView = match &self.route {
             Route::Recording => self.recording.clone().into(),
             Route::Meeting(_) => self.meeting.clone().into(),
@@ -472,18 +473,28 @@ impl Render for AppShell {
                     import::open_with_file(window, cx, path.clone());
                 }
             })
-            // Without `on_close_window`, gpui-kit's X calls
-            // `window.remove_window()` directly — bypassing
-            // `on_window_should_close` entirely. Route it through the same
-            // policy so both close paths behave identically.
-            .child(
-                TitleBar::new()
-                    .on_close_window(|_, window, cx| {
-                        if crate::window::close_to_tray_or_quit(cx) {
-                            window.remove_window();
-                        }
-                    })
-                    .child("Parley"),
+            // Our title bar is only for when the app has to draw its own
+            // window frame. When the compositor draws one (server-side
+            // decorations), this strip holds nothing the system bar doesn't
+            // already show, so skip it rather than stack two title bars.
+            //
+            // In the client-side case, `on_close_window` matters: without it
+            // gpui-kit's X calls `window.remove_window()` directly, bypassing
+            // `on_window_should_close`. Routing it through the same policy
+            // keeps both close paths identical.
+            .when(
+                matches!(window.window_decorations(), Decorations::Client { .. }),
+                |this| {
+                    this.child(
+                        TitleBar::new()
+                            .on_close_window(|_, window, cx| {
+                                if crate::window::close_to_tray_or_quit(cx) {
+                                    window.remove_window();
+                                }
+                            })
+                            .child("Parley"),
+                    )
+                },
             )
             .child(
                 h_flex()

--- a/meetily-gpui/src/shell/mod.rs
+++ b/meetily-gpui/src/shell/mod.rs
@@ -472,7 +472,19 @@ impl Render for AppShell {
                     import::open_with_file(window, cx, path.clone());
                 }
             })
-            .child(TitleBar::new().child("Parley"))
+            // Without `on_close_window`, gpui-kit's X calls
+            // `window.remove_window()` directly — bypassing
+            // `on_window_should_close` entirely. Route it through the same
+            // policy so both close paths behave identically.
+            .child(
+                TitleBar::new()
+                    .on_close_window(|_, window, cx| {
+                        if crate::window::close_to_tray_or_quit(cx) {
+                            window.remove_window();
+                        }
+                    })
+                    .child("Parley"),
+            )
             .child(
                 h_flex()
                     .flex_1()

--- a/meetily-gpui/src/tray.rs
+++ b/meetily-gpui/src/tray.rs
@@ -63,6 +63,12 @@ struct AppTray {
 
 impl Global for AppTray {}
 
+/// Whether a tray icon is actually registered. Closing the window is only
+/// safe to treat as "close to tray" when there's a tray to get back from.
+pub fn is_installed(cx: &App) -> bool {
+    cx.has_global::<AppTray>()
+}
+
 /// A simple filled circle, red while idle/stopped-ish, matching the
 /// spike's icon. `gpui-tray::Tray::set_icon` could recolor this live; out
 /// of scope for phase 1.

--- a/meetily-gpui/src/tray.rs
+++ b/meetily-gpui/src/tray.rs
@@ -134,15 +134,14 @@ fn build_menu(cx: &mut App) -> Vec<MenuItem> {
     ]
 }
 
-/// Focus/raise the main window. Best-effort: logs if the window has already
-/// been closed (shouldn't happen — the window only closes via
-/// `request_quit`, which also tears the tray down).
+/// Bring the main window back: re-opens it if it has been closed (the app
+/// keeps running without a window under `QuitMode::Explicit`), then asks the
+/// compositor to focus it. Wayland compositors commonly refuse an
+/// unsolicited raise, so the re-open is what actually gets the UI back.
 fn open_parley(cx: &mut App) {
-    let Some(main_window) = cx.try_global::<MainWindow>() else {
-        log::warn!("tray: Open Parley clicked before the main window was registered");
+    let Some(handle) = crate::window::ensure_main_window(cx) else {
         return;
     };
-    let handle = main_window.0;
     if let Err(e) = handle.update(cx, |_, window, _cx| window.activate_window()) {
         log::warn!("tray: failed to activate the main window: {}", e);
     }

--- a/meetily-gpui/src/window.rs
+++ b/meetily-gpui/src/window.rs
@@ -28,19 +28,13 @@ pub fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>> {
         cx.new(|cx| Root::new(view, window, cx))
     })?;
 
-    // Registering the close handler is not optional: it's what turns a close
-    // request into "finish the active recording, then quit" instead of the
-    // Wayland default of destroying the window (which leaves the app running
-    // with only a tray). Loud on failure — silence here is what hid exactly
-    // that bug.
+    // Registering the close handler is not optional: it's what puts a close
+    // request under [`close_to_tray_or_quit`] instead of the Wayland default
+    // of destroying the window regardless. Loud on failure — silence here is
+    // exactly what hid that bug.
     if let Err(e) = window.update(cx, |_, window, cx| {
         crate::views::settings::init_theme(window, cx);
-        window.on_window_should_close(cx, |_, cx| {
-            crate::request_quit(cx);
-            // Never let the compositor destroy the window: `request_quit`
-            // finishes any recording and then quits the whole app.
-            false
-        });
+        window.on_window_should_close(cx, |_, cx| close_to_tray_or_quit(cx));
     }) {
         log::error!(
             "Failed to register main-window handlers ({e}); closing the window \
@@ -50,6 +44,24 @@ pub fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>> {
 
     cx.set_global(crate::tray::MainWindow(window));
     Ok(window)
+}
+
+/// What a close request should do, for both close paths (the compositor's
+/// close button and gpui-kit's own title-bar X). With a tray registered the
+/// window closes and the app keeps running — an active recording continues,
+/// and the tray's "Open Parley" brings the UI back. Without a tray there'd
+/// be no way back, so a close means quit: [`crate::request_quit`] finishes
+/// any recording first.
+///
+/// Returns whether the window may actually close.
+pub fn close_to_tray_or_quit(cx: &mut App) -> bool {
+    if crate::tray::is_installed(cx) {
+        log::info!("Main window closed to tray; the app keeps running");
+        true
+    } else {
+        crate::request_quit(cx);
+        false
+    }
 }
 
 /// The live main window, re-opening it if it has gone away. `None` only if

--- a/meetily-gpui/src/window.rs
+++ b/meetily-gpui/src/window.rs
@@ -21,7 +21,13 @@ use crate::root::RootView;
 pub fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>> {
     let mut options = TitleBar::window_options();
     options.window_bounds = Some(WindowBounds::centered(size(px(1100.), px(720.)), cx));
-    options.window_decorations = Some(WindowDecorations::Client);
+    // Prefer the system's own title bar and borders. GPUI asks the
+    // compositor for server-side decorations and silently falls back to
+    // client-side when it can't provide them (GNOME/Wayland, notably) —
+    // gpui-kit's `TitleBar` then draws our own controls, and skips them
+    // when the compositor is drawing its own, so there's never a double
+    // title bar either way.
+    options.window_decorations = Some(WindowDecorations::Server);
 
     let window = cx.open_window(options, |window, cx| {
         let view = cx.new(|cx| RootView::new(window, cx));
@@ -41,6 +47,19 @@ pub fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>> {
              would skip finishing an active recording"
         );
     }
+
+    // Report what we actually got, so "is this using system decorations /
+    // the system theme?" is answerable from the log.
+    let _ = window.update(cx, |_, window, cx| {
+        let decorations = match window.window_decorations() {
+            Decorations::Server => "server-side (system)",
+            Decorations::Client { .. } => "client-side (drawn by the app)",
+        };
+        log::info!(
+            "Main window: {decorations} decorations, system appearance {:?}",
+            cx.window_appearance()
+        );
+    });
 
     cx.set_global(crate::tray::MainWindow(window));
     Ok(window)

--- a/meetily-gpui/src/window.rs
+++ b/meetily-gpui/src/window.rs
@@ -1,0 +1,74 @@
+//! Opening (and re-opening) the main window.
+//!
+//! Startup and the tray's "Open Parley" both go through [`open_main_window`]
+//! so the window is always set up identically: saved theme applied, the
+//! close handler registered, and the [`crate::tray::MainWindow`] global
+//! pointed at the live handle.
+//!
+//! Re-opening matters because the window can genuinely go away while the app
+//! keeps running: the app uses `QuitMode::Explicit`, so closing the last
+//! window doesn't quit, and GPUI's Wayland backend closes a window outright
+//! when no `should_close` callback is registered. Without a way back, the
+//! app becomes a tray-only zombie ("window not found" from Open Parley).
+
+use gpui_kit::component::{Root, TitleBar};
+use gpui_kit::*;
+
+use crate::root::RootView;
+
+/// Open the main window, register its handlers, and store the handle in the
+/// `MainWindow` global. Returns the new handle.
+pub fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>> {
+    let mut options = TitleBar::window_options();
+    options.window_bounds = Some(WindowBounds::centered(size(px(1100.), px(720.)), cx));
+    options.window_decorations = Some(WindowDecorations::Client);
+
+    let window = cx.open_window(options, |window, cx| {
+        let view = cx.new(|cx| RootView::new(window, cx));
+        cx.new(|cx| Root::new(view, window, cx))
+    })?;
+
+    // Registering the close handler is not optional: it's what turns a close
+    // request into "finish the active recording, then quit" instead of the
+    // Wayland default of destroying the window (which leaves the app running
+    // with only a tray). Loud on failure — silence here is what hid exactly
+    // that bug.
+    if let Err(e) = window.update(cx, |_, window, cx| {
+        crate::views::settings::init_theme(window, cx);
+        window.on_window_should_close(cx, |_, cx| {
+            crate::request_quit(cx);
+            // Never let the compositor destroy the window: `request_quit`
+            // finishes any recording and then quits the whole app.
+            false
+        });
+    }) {
+        log::error!(
+            "Failed to register main-window handlers ({e}); closing the window \
+             would skip finishing an active recording"
+        );
+    }
+
+    cx.set_global(crate::tray::MainWindow(window));
+    Ok(window)
+}
+
+/// The live main window, re-opening it if it has gone away. `None` only if
+/// opening a window failed outright.
+pub fn ensure_main_window(cx: &mut App) -> Option<WindowHandle<Root>> {
+    if let Some(handle) = cx.try_global::<crate::tray::MainWindow>().map(|main| main.0) {
+        // `is_window_active` is just a cheap liveness probe here: it errors
+        // when the handle's window is no longer in the app's window map.
+        if handle.update(cx, |_, _, _| ()).is_ok() {
+            return Some(handle);
+        }
+        log::info!("Main window was closed; re-opening it");
+    }
+
+    match open_main_window(cx) {
+        Ok(handle) => Some(handle),
+        Err(e) => {
+            log::error!("Failed to open the main window: {}", e);
+            None
+        }
+    }
+}


### PR DESCRIPTION
## Description

Three related window fixes, found while actually using the app.

### 1. Tray "Open Parley" left the app window-less

```
[WARN meetily_gpui::tray] tray: failed to activate the main window: window not found
```

`main.rs` registered `on_window_should_close` but discarded the result (`let _ = …`). GPUI's Wayland backend closes a window outright when no callback is registered, and the app runs `QuitMode::Explicit`, so the last window closing doesn't quit — a tray-only zombie with no way back.

New `meetily-gpui/src/window.rs` owns opening the main window (theme, close handler, `MainWindow` handle) so startup and the tray share one path, and logs loudly if registration ever fails again. The tray now **re-opens** the window when it's gone instead of only logging.

### 2. The two close paths disagreed

gpui-kit's title bar draws its own X, which calls `window.remove_window()` directly unless given an `on_close_window` callback — bypassing `on_window_should_close` entirely. So the X destroyed the window regardless of the handler, while the compositor's close would have done nothing visible.

Both now go through `window::close_to_tray_or_quit`:
- **Tray registered** → close to tray: the window closes, the app keeps running, an active recording continues, and tray → Open Parley brings the UI back.
- **No tray** → close quits via `request_quit`, which finishes any recording first (otherwise there'd be no way back).

This also fixes a data-loss risk: with no close handler, closing mid-recording skipped "finish the recording before quitting".

### 3. System decorations and theme

Requests server-side (system) decorations instead of hard-coding client-side; GPUI falls back to client-side automatically where the compositor can't provide them. gpui-kit skips its own window *controls* under SSD but still drew the bar, stacking an empty "Parley" strip under the real system title bar — the shell now renders its title bar only when the app must draw its own frame.

Startup logs the decorations actually granted and the detected system appearance. The theme already follows the system (no stored preference ⇒ "system"); this makes it verifiable.

## Type of Change
- [x] Bug fix
- [x] New feature (system decorations)

## Testing
- [x] 134 GPUI tests, 304 core, workspace check clean.
- [x] Startup on GNOME/Wayland: `Main window: server-side (system) decorations, system appearance Dark`, tray registered, 81 meetings loaded, no errors.
- [ ] Needs a human: close via the X (expect "closed to tray" and no error flood), tray → Open Parley, and closing mid-recording while the tray keeps recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTLuKqNphAxzHZRVqUArf3